### PR TITLE
Use the correct Cargo.toml in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./cat-launcher/src-tauri/Cargo.toml"
+    ]
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Configure VS Code to use the correct Cargo.toml for rust-analyzer by linking cat-launcher/src-tauri/Cargo.toml. This fixes incorrect indexing and ensures accurate diagnostics, navigation, and autocomplete in the Tauri project.

<!-- End of auto-generated description by cubic. -->

