### PR TITLE
Make GameVariant non-exhaustive with a default value

### DIFF
--- a/cat-launcher/src-tauri/src/variants/game_variant.rs
+++ b/cat-launcher/src-tauri/src/variants/game_variant.rs
@@ -3,9 +3,22 @@ use strum_macros::{EnumIter, IntoStaticStr};
 use ts_rs::TS;
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Deserialize, Serialize, IntoStaticStr, TS,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    IntoStaticStr,
+    TS,
+    Default,
 )]
+#[non_exhaustive]
 pub enum GameVariant {
+    #[default]
     DarkDaysAhead,
     BrightNights,
     TheLastGeneration,


### PR DESCRIPTION
### **User description**
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Marked GameVariant as non-exhaustive and derived Default, with DarkDaysAhead as the default. This future-proofs the enum for adding new variants and gives callers a safe fallback value; external matches must include a wildcard arm.

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added `#[non_exhaustive]` attribute to `GameVariant` enum

- Derived `Default` trait with `DarkDaysAhead` as default

- Reformatted derive attributes for better readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GameVariant enum"] --> B["Add #[non_exhaustive]"]
  A --> C["Derive Default trait"]
  C --> D["DarkDaysAhead as default"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>game_variant.rs</strong><dd><code>Make enum non-exhaustive with default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/variants/game_variant.rs

<ul><li>Added <code>#[non_exhaustive]</code> attribute to prevent exhaustive matching<br> <li> Derived <code>Default</code> trait with <code>DarkDaysAhead</code> as the default variant<br> <li> Reformatted derive macro attributes across multiple lines</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/15/files#diff-82ce342a47e2e3378def91e338ced601fbb1f88f5444c5f1f8893f80a83f695f">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

