### PR TITLE
Separate release selection from writing cache

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -2,6 +2,7 @@ use super::error::FetchReleasesError;
 use super::game_release::{GameRelease, ReleaseType};
 use super::github_fetch::{fetch_github_releases, GithubRelease};
 use super::utils::{get_cached_releases, merge_releases, write_cached_releases};
+use crate::fetch_releases::utils::select_releases_for_cache;
 use crate::infra::http_client::HTTP_CLIENT;
 use crate::infra::utils::get_github_repo_for_variant;
 use crate::variants::GameVariant;
@@ -15,9 +16,10 @@ impl GameVariant {
         let cached_releases: Vec<GithubRelease> = get_cached_releases(&self);
 
         let all_releases = merge_releases(fetched_releases, cached_releases);
-        write_cached_releases(&self, &all_releases);
+        let to_cache = select_releases_for_cache(&all_releases);
+        write_cached_releases(&self, &to_cache);
 
-        let game_releases = all_releases
+        let game_releases = to_cache
             .into_iter()
             .map(|r| GameRelease {
                 variant: self.clone(),


### PR DESCRIPTION
### **User description**
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Separated release selection from cache writing. We now pick releases once and use them for both the cache and the returned list (max 100 stable + 10 newest prereleases).

- **Refactors**
  - Added select_releases_for_cache (sorts prereleases by created_at desc; takes 100 stable + 10 prereleases).
  - write_cached_releases now only writes to disk.
  - fetch_releases uses the selected list for caching and GameRelease output.

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Separated release selection logic from cache writing

- Added `select_releases_for_cache` function for consistent filtering

- Improved prerelease sorting by creation date

- Ensured same releases used for both caching and output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fetch_releases"] --> B["select_releases_for_cache"]
  B --> C["write_cached_releases"]
  B --> D["GameRelease output"]
  B --> E["100 stable + 10 newest prereleases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetch_releases.rs</strong><dd><code>Updated fetch_releases to use selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs

<ul><li>Added import for <code>select_releases_for_cache</code> function<br> <li> Modified <code>fetch_releases</code> to use selected releases for both caching and <br>output<br> <li> Replaced direct <code>all_releases</code> usage with <code>to_cache</code> variable</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/18/files#diff-19283ad499418d43a7d777b1f92ca8a791b38df4d5639d5abc0a4f27db3b37ae">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Added release selection and refactored caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/utils.rs

<ul><li>Added <code>select_releases_for_cache</code> function with proper filtering logic<br> <li> Simplified <code>write_cached_releases</code> to only handle file writing<br> <li> Improved prerelease sorting using <code>Reverse</code> for descending order<br> <li> Used functional programming approach with <code>partition</code> and <code>chain</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/18/files#diff-119eef27e04fbf03c964f89066867f12f0152b9c1a8cc05acb2df48bc0fdd721">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

