### PR TITLE
Accept slices instead of owned types as parameters where possible

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -15,7 +15,7 @@ impl GameVariant {
             fetch_github_releases(&HTTP_CLIENT, repo).await?;
         let cached_releases: Vec<GithubRelease> = get_cached_releases(&self);
 
-        let all_releases = merge_releases(fetched_releases, cached_releases);
+        let all_releases = merge_releases(&fetched_releases, &cached_releases);
         let to_cache = select_releases_for_cache(&all_releases);
         write_cached_releases(&self, &to_cache);
 

--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -23,7 +23,7 @@ pub fn get_cached_releases(variant: &GameVariant) -> Vec<GithubRelease> {
     }
 }
 
-pub fn write_cached_releases(variant: &GameVariant, releases: &Vec<GithubRelease>) -> () {
+pub fn write_cached_releases(variant: &GameVariant, releases: &[GithubRelease]) -> () {
     let repo = get_github_repo_for_variant(variant);
     let cache_path = get_cache_path_for_repo(repo);
 
@@ -34,7 +34,7 @@ pub fn write_cached_releases(variant: &GameVariant, releases: &Vec<GithubRelease
     let _ = write_to_file(&cache_path, &releases);
 }
 
-pub fn select_releases_for_cache(releases: &Vec<GithubRelease>) -> Vec<GithubRelease> {
+pub fn select_releases_for_cache(releases: &[GithubRelease]) -> Vec<GithubRelease> {
     let (non_prereleases, mut prereleases): (Vec<&GithubRelease>, Vec<&GithubRelease>) =
         releases.iter().partition(|r| !r.prerelease);
 
@@ -55,19 +55,12 @@ pub fn get_cache_path_for_repo(repo: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-pub fn merge_releases(
-    fetched: Vec<GithubRelease>,
-    cached: Vec<GithubRelease>,
-) -> Vec<GithubRelease> {
-    let mut map: HashMap<u64, GithubRelease> = HashMap::new();
+pub fn merge_releases(fetched: &[GithubRelease], cached: &[GithubRelease]) -> Vec<GithubRelease> {
+    let map: HashMap<u64, GithubRelease> = cached
+        .iter()
+        .chain(fetched.iter())
+        .map(|r| (r.id, r.clone()))
+        .collect();
 
-    for r in cached {
-        map.insert(r.id, r);
-    }
-
-    for r in fetched {
-        map.insert(r.id, r);
-    }
-
-    map.values().cloned().collect()
+    map.into_values().collect()
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched release utils to accept slices instead of owned Vecs. This reduces allocations and moves at call sites with no behavior changes.

- **Refactors**
  - write_cached_releases and select_releases_for_cache now take &[GithubRelease].
  - merge_releases now takes slices and returns a Vec after de-duping by id; call site updated to pass references.
  - Internally clones items when building the map to keep owned values.

<!-- End of auto-generated description by cubic. -->

