### PR TITLE
Make cache path platform independent

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -50,9 +50,11 @@ pub fn select_releases_for_cache(releases: &[GithubRelease]) -> Vec<GithubReleas
 
 pub fn get_cache_path_for_repo(repo: &str) -> PathBuf {
     let safe = get_safe_filename(repo);
-    let path = format!("CatLauncherCache/Releases/{}.json", safe);
+    let mut path = PathBuf::from("CatLauncherCache");
+    path.push("Releases");
+    path.push(format!("{}.json", safe));
 
-    PathBuf::from(path)
+    path
 }
 
 pub fn merge_releases(fetched: &[GithubRelease], cached: &[GithubRelease]) -> Vec<GithubRelease> {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make the cache file path platform-independent by constructing it with PathBuf components. This avoids hardcoded separators and fixes path issues on Windows.

<!-- End of auto-generated description by cubic. -->

