### PR TITLE
add-ability-to-download-releases

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -423,8 +423,8 @@ dependencies = [
 name = "cat-launcher"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
+ "downloader",
  "reqwest",
  "serde",
  "serde_json",
@@ -434,6 +434,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "thiserror 2.0.16",
+ "tokio",
  "ts-rs",
 ]
 
@@ -805,6 +806,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "git+https://github.com/abhi-kr-2100/downloader.git?branch=main#197d47343aae450a442bb1f1f7b7e7d5f4aab3a2"
+dependencies = [
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,12 +1066,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1126,6 +1155,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -4259,7 +4289,19 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.16"
 reqwest = { version = "0.12.23", features = ["json"] }
-async-trait = "0.1.89"
 ts-rs = "11.0"
 chrono = { version = "0.4.42", features = ["serde"] }
-downloader = "0.2.8"
+downloader = { git = "https://github.com/abhi-kr-2100/downloader.git", branch = "main" }

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -5,6 +5,7 @@ use ts_rs::TS;
 
 use crate::fetch_releases::utils::get_assets;
 use crate::game_release::error::GameReleaseError;
+use crate::infra::github::asset::GitHubAsset;
 use crate::variants::GameVariant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, TS)]
@@ -22,7 +23,7 @@ pub struct GameRelease {
 }
 
 impl GameRelease {
-    pub fn get_asset_download_url(&self) -> Result<String, GameReleaseError> {
+    pub fn get_asset(&self) -> Result<GitHubAsset, GameReleaseError> {
         let assets = get_assets(self);
 
         let asset = match (self.variant, OS) {
@@ -40,7 +41,7 @@ impl GameRelease {
         .and_then(|substring| assets.iter().find(|a| a.name.contains(substring)));
 
         asset
-            .map(|a| a.browser_download_url.clone())
+            .map(|a| a.clone())
             .ok_or(GameReleaseError::NoCompatibleAssetFound)
     }
 }

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use tauri::command;
+
+use crate::game_release::game_release::GameRelease;
+use crate::install_release::error::InstallReleaseError;
+
+#[command]
+pub async fn install_release(release: GameRelease) -> Result<PathBuf, InstallReleaseError> {
+    release.install_release().await
+}

--- a/cat-launcher/src-tauri/src/install_release/error.rs
+++ b/cat-launcher/src-tauri/src/install_release/error.rs
@@ -1,0 +1,45 @@
+use std::io::Error as IoError;
+
+use downloader::Error as DownloaderError;
+use serde::ser::{SerializeStruct, Serializer};
+use serde::Serialize;
+use strum_macros::IntoStaticStr;
+use thiserror::Error as ThisError;
+
+use crate::game_release::error::GameReleaseError;
+use crate::infra::github::error::GitHubError;
+
+#[derive(Debug, ThisError, IntoStaticStr)]
+pub enum InstallReleaseError {
+    #[error("Failed to set up asset download directory: {0}")]
+    AssetDownloadDir(#[from] IoError),
+
+    #[error("Failed to set up downloader: {0}")]
+    Downloader(#[from] DownloaderError),
+
+    #[error("No compatible asset found for the game release")]
+    NoCompatibleAssetFound(#[from] GameReleaseError),
+
+    #[error("Failed to download asset: {0}")]
+    Download(#[from] GitHubError),
+
+    #[error("Unknown error")]
+    Unknown,
+}
+
+impl Serialize for InstallReleaseError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut st = serializer.serialize_struct("InstallReleaseError", 2)?;
+
+        let err_type: &'static str = self.into();
+        st.serialize_field("type", &err_type)?;
+
+        let msg = self.to_string();
+        st.serialize_field("message", &msg)?;
+
+        st.end()
+    }
+}

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use downloader::Downloader;
+
+use crate::game_release::game_release::GameRelease;
+use crate::install_release::error::InstallReleaseError;
+use crate::install_release::utils::get_asset_download_dir;
+
+impl GameRelease {
+    pub async fn install_release(&self) -> Result<PathBuf, InstallReleaseError> {
+        let download_dir = get_asset_download_dir(&self.variant)?;
+        let mut downloader = Downloader::builder()
+            .download_folder(&download_dir)
+            .parallel_requests(4)
+            .user_agent("cat-launcher")
+            .build()?;
+
+        let asset = self.get_asset()?;
+
+        Ok(asset.download(&mut downloader).await?)
+    }
+}

--- a/cat-launcher/src-tauri/src/install_release/mod.rs
+++ b/cat-launcher/src-tauri/src/install_release/mod.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod install_release;
+
+mod error;
+mod utils;

--- a/cat-launcher/src-tauri/src/install_release/utils.rs
+++ b/cat-launcher/src-tauri/src/install_release/utils.rs
@@ -1,0 +1,19 @@
+use std::fs::create_dir_all;
+use std::io::Error as IoError;
+use std::path::PathBuf;
+
+use crate::infra::utils::get_safe_filename;
+use crate::variants::GameVariant;
+
+pub(crate) fn get_asset_download_dir(variant: &GameVariant) -> Result<PathBuf, IoError> {
+    let safe_variant_name = get_safe_filename(variant.into());
+
+    let dir = PathBuf::from("CatLauncherCache")
+        .join("Releases")
+        .join("Assets")
+        .join(&safe_variant_name);
+
+    create_dir_all(&dir)?;
+
+    Ok(dir)
+}

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -2,10 +2,12 @@ mod basic_info;
 mod fetch_releases;
 mod game_release;
 mod infra;
+mod install_release;
 mod variants;
 
 use crate::basic_info::commands::get_game_variants_info;
 use crate::fetch_releases::commands::fetch_releases_for_variant;
+use crate::install_release::commands::install_release;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -13,7 +15,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             get_game_variants_info,
-            fetch_releases_for_variant
+            fetch_releases_for_variant,
+            install_release,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/cat-launcher/src/components/ui/card.tsx
+++ b/cat-launcher/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -12,7 +12,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -58,7 +58,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -8,12 +8,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export async function fetchReleasesForVariant(variant: GameVariantInfo): Promise<GameRelease[]> {
-    const response = await invoke("fetch_releases_for_variant", { variant: variant.id });
-    return response as GameRelease[];
+export async function fetchReleasesForVariant(
+  variant: GameVariantInfo
+): Promise<GameRelease[]> {
+  const response = await invoke<GameRelease[]>("fetch_releases_for_variant", {
+    variant: variant.id,
+  });
+  return response;
 }
 
 export async function fetchGameVariantsInfo(): Promise<GameVariantInfo[]> {
-    const response = await invoke("get_game_variants_info");
-    return response as GameVariantInfo[];
+  const response = await invoke<GameVariantInfo[]>("get_game_variants_info");
+  return response;
+}
+
+export async function installReleaseForVariant(
+  release: GameRelease
+): Promise<string> {
+  const response = await invoke<string>("install_release", {
+    release,
+  });
+
+  return response;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add the ability to download a selected release from the launcher UI. Adds a Tauri command that downloads the correct asset to a per-variant cache directory and returns the file path.

- **New Features**
  - New Tauri command install_release(release) -> PathBuf, invoked from the UI.
  - GameRelease.install_release uses downloader with parallel requests and a custom user agent.
  - Creates CatLauncherCache/Releases/Assets/<variant> if missing, using safe names.
  - GameRelease.get_asset now returns a GitHubAsset (not just a URL) for direct downloading.
  - UI: Download button with spinner, disabled states, and error-safe handling in GameVariant.

- **Dependencies**
  - Switch downloader to a Git git+https://github.com/abhi-kr-2100/downloader.git (branch main).
  - Add tokio; remove async-trait; lockfile updates include futures and tokio-macros.

<!-- End of auto-generated description by cubic. -->

