### PR TITLE
Add ability to download releases

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -423,8 +423,8 @@ dependencies = [
 name = "cat-launcher"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
+ "downloader",
  "reqwest",
  "serde",
  "serde_json",
@@ -805,6 +805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "git+https://github.com/hunger/downloader.git?rev=197d47343aae450a442bb1f1f7b7e7d5f4aab3a2#197d47343aae450a442bb1f1f7b7e7d5f4aab3a2"
+dependencies = [
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,12 +1065,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1126,6 +1154,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.16"
 reqwest = { version = "0.12.23", features = ["json"] }
-async-trait = "0.1.89"
 ts-rs = "11.0"
 chrono = { version = "0.4.42", features = ["serde"] }
-downloader = "0.2.8"
+downloader = { git = "https://github.com/hunger/downloader.git", rev = "197d47343aae450a442bb1f1f7b7e7d5f4aab3a2" }

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -5,6 +5,7 @@ use ts_rs::TS;
 
 use crate::fetch_releases::utils::get_assets;
 use crate::game_release::error::GameReleaseError;
+use crate::infra::github::asset::GitHubAsset;
 use crate::variants::GameVariant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, TS)]
@@ -22,7 +23,7 @@ pub struct GameRelease {
 }
 
 impl GameRelease {
-    pub fn get_asset_download_url(&self) -> Result<String, GameReleaseError> {
+    pub fn get_asset(&self) -> Result<GitHubAsset, GameReleaseError> {
         let assets = get_assets(self);
 
         let asset = match (self.variant, OS) {
@@ -37,10 +38,8 @@ impl GameRelease {
             (GameVariant::TheLastGeneration, "linux") => Some("linux-tiles-sounds"),
             _ => None,
         }
-        .and_then(|substring| assets.iter().find(|a| a.name.contains(substring)));
+        .and_then(|substring| assets.into_iter().find(|a| a.name.contains(substring)));
 
-        asset
-            .map(|a| a.browser_download_url.clone())
-            .ok_or(GameReleaseError::NoCompatibleAssetFound)
+        asset.ok_or(GameReleaseError::NoCompatibleAssetFound)
     }
 }

--- a/cat-launcher/src-tauri/src/infra/github/asset.rs
+++ b/cat-launcher/src-tauri/src/infra/github/asset.rs
@@ -23,7 +23,7 @@ impl GitHubAsset {
                 Err(e) => Err(e.into()),
             }
         } else {
-            Err(GitHubError::Unknown)
+            Err(GitHubError::Unknown("No download result found".into()))
         }
     }
 }

--- a/cat-launcher/src-tauri/src/infra/github/error.rs
+++ b/cat-launcher/src-tauri/src/infra/github/error.rs
@@ -15,8 +15,8 @@ pub enum GitHubError {
     #[error("Download error: {0}")]
     Download(DownloaderError),
 
-    #[error("Unknown error")]
-    Unknown,
+    #[error("Unknown error: {0}")]
+    Unknown(String),
 }
 
 impl From<ReqwestError> for GitHubError {

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,6 +1,17 @@
+use std::path::Path;
 use std::sync::LazyLock;
 
+use downloader::Downloader;
 use reqwest::Client;
+
+pub fn create_downloader(download_folder: &Path) -> downloader::Result<Downloader> {
+    let mut builder = Downloader::builder();
+    builder
+        .download_folder(download_folder)
+        .parallel_requests(4);
+
+    builder.build_with_client(HTTP_CLIENT.clone())
+}
 
 pub static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use tauri::command;
+
+use crate::game_release::game_release::GameRelease;
+use crate::install_release::error::InstallReleaseError;
+
+#[command]
+pub async fn install_release(release: GameRelease) -> Result<PathBuf, InstallReleaseError> {
+    release.install_release().await
+}

--- a/cat-launcher/src-tauri/src/install_release/error.rs
+++ b/cat-launcher/src-tauri/src/install_release/error.rs
@@ -1,0 +1,45 @@
+use std::io::Error as IoError;
+
+use downloader::Error as DownloaderError;
+use serde::ser::{SerializeStruct, Serializer};
+use serde::Serialize;
+use strum_macros::IntoStaticStr;
+use thiserror::Error as ThisError;
+
+use crate::game_release::error::GameReleaseError;
+use crate::infra::github::error::GitHubError;
+
+#[derive(Debug, ThisError, IntoStaticStr)]
+pub enum InstallReleaseError {
+    #[error("Failed to set up asset download directory: {0}")]
+    AssetDownloadDir(#[from] IoError),
+
+    #[error("Failed to set up downloader: {0}")]
+    Downloader(#[from] DownloaderError),
+
+    #[error("No compatible asset found for the game release")]
+    NoCompatibleAssetFound(#[from] GameReleaseError),
+
+    #[error("Failed to download asset: {0}")]
+    Download(#[from] GitHubError),
+
+    #[error("Unknown error")]
+    Unknown,
+}
+
+impl Serialize for InstallReleaseError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut st = serializer.serialize_struct("InstallReleaseError", 2)?;
+
+        let err_type: &'static str = self.into();
+        st.serialize_field("type", &err_type)?;
+
+        let msg = self.to_string();
+        st.serialize_field("message", &msg)?;
+
+        st.end()
+    }
+}

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+use crate::game_release::game_release::GameRelease;
+use crate::infra::http_client::create_downloader;
+use crate::install_release::error::InstallReleaseError;
+use crate::install_release::utils::get_asset_download_dir;
+
+impl GameRelease {
+    pub async fn install_release(&self) -> Result<PathBuf, InstallReleaseError> {
+        let download_dir = get_asset_download_dir(&self.variant)?;
+        let mut downloader = create_downloader(&download_dir)?;
+
+        let asset = self.get_asset()?;
+
+        Ok(asset.download(&mut downloader).await?)
+    }
+}

--- a/cat-launcher/src-tauri/src/install_release/mod.rs
+++ b/cat-launcher/src-tauri/src/install_release/mod.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod install_release;
+
+mod error;
+mod utils;

--- a/cat-launcher/src-tauri/src/install_release/utils.rs
+++ b/cat-launcher/src-tauri/src/install_release/utils.rs
@@ -1,0 +1,19 @@
+use std::fs::create_dir_all;
+use std::io::Error as IoError;
+use std::path::PathBuf;
+
+use crate::infra::utils::get_safe_filename;
+use crate::variants::GameVariant;
+
+pub(crate) fn get_asset_download_dir(variant: &GameVariant) -> Result<PathBuf, IoError> {
+    let safe_variant_name = get_safe_filename(variant.into());
+
+    let dir = PathBuf::from("CatLauncherCache")
+        .join("Releases")
+        .join("Assets")
+        .join(&safe_variant_name);
+
+    create_dir_all(&dir)?;
+
+    Ok(dir)
+}

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -2,10 +2,12 @@ mod basic_info;
 mod fetch_releases;
 mod game_release;
 mod infra;
+mod install_release;
 mod variants;
 
 use crate::basic_info::commands::get_game_variants_info;
 use crate::fetch_releases::commands::fetch_releases_for_variant;
+use crate::install_release::commands::install_release;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -13,7 +15,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             get_game_variants_info,
-            fetch_releases_for_variant
+            fetch_releases_for_variant,
+            install_release,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/cat-launcher/src/components/ui/card.tsx
+++ b/cat-launcher/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -12,7 +12,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -58,7 +58,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -8,12 +8,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export async function fetchReleasesForVariant(variant: GameVariantInfo): Promise<GameRelease[]> {
-    const response = await invoke("fetch_releases_for_variant", { variant: variant.id });
-    return response as GameRelease[];
+export async function fetchReleasesForVariant(
+  variant: GameVariantInfo
+): Promise<GameRelease[]> {
+  const response = await invoke<GameRelease[]>("fetch_releases_for_variant", {
+    variant: variant.id,
+  });
+  return response;
 }
 
 export async function fetchGameVariantsInfo(): Promise<GameVariantInfo[]> {
-    const response = await invoke("get_game_variants_info");
-    return response as GameVariantInfo[];
+  const response = await invoke<GameVariantInfo[]>("get_game_variants_info");
+  return response;
+}
+
+export async function installReleaseForVariant(
+  release: GameRelease
+): Promise<string> {
+  const response = await invoke<string>("install_release", {
+    release,
+  });
+
+  return response;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the ability to download a selected game release asset directly from the launcher. Includes a new backend command and a Download button in the UI, with cached storage per variant and a returned file path.

- **New Features**
  - Added install_release Tauri command that downloads the compatible GitHub asset for a selected release and returns the local path.
  - Implemented per-variant cache directory at CatLauncherCache/Releases/Assets/<variant>.
  - Added GameRelease.install_release and changed get_asset_download_url to get_asset to work with GitHubAsset.
  - UI: Added a Download button with loading state and disabled controls during download.

- **Dependencies**
  - Switched downloader to the GitHub git source (branch main); removed async-trait.

<!-- End of auto-generated description by cubic. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #28 
- <kbd>&nbsp;2&nbsp;</kbd> #27 
- <kbd>&nbsp;1&nbsp;</kbd> #26 👈 
<!-- GitButler Footer Boundary Bottom -->

