### PR TITLE
chore(vscode): add tasks and launch configs for Tauri dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb-dap",
+      "request": "launch",
+      "name": "Tauri Rust Debug",
+      "program": "${workspaceFolder}/cat-launcher/src-tauri/target/debug/cat-launcher",
+      "args": [],
+      "env": {
+        "RUST_BACKTRACE": "full"
+      },
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "tauri:dev-server"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "tauri:dev-server",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["dev"],
+      "isBackground": true,
+      "problemMatcher": [
+        {
+          "pattern": [
+            {
+              "regexp": ".*",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "cat-launcher",
+            "endsPattern": "ready"
+          }
+        }
+      ],
+      "group": {
+        "kind": "none"
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/cat-launcher"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add a VS Code task to run the Tauri frontend with pnpm in the
cat-launcher workspace and a launch configuration to debug the
Tauri Rust binary with LLDB. The task ("tauri:dev-and-launch") runs
pnpm dev in cat-launcher and is marked as a background task with a
Rust problem matcher. The debugger configuration launches the
cat-launcher Rust executable, enables full RUST_BACKTRACE, and uses
the task as a preLaunchTask.

These files streamline local development and native debugging
setup for the Tauri app.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add VS Code tasks and a launch config to run the Tauri app and debug the Rust binary. The task runs pnpm dev in cat-launcher (background with rustc matcher), and the LLDB config launches the cat-launcher debug binary with RUST_BACKTRACE=full using the task as preLaunchTask.

<!-- End of auto-generated description by cubic. -->

