### PR TITLE
fix: launcher name for TLG

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -144,7 +144,7 @@ pub fn get_release_status(
     }
 
     let extraction_dir = get_asset_extraction_dir(version, &download_dir)?;
-    let executable_path = get_executable_path(os, &extraction_dir)?;
+    let executable_path = get_executable_path(variant, os, &extraction_dir)?;
     if !executable_path.exists() {
         return Ok(GameReleaseStatus::NotInstalled);
     }

--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -1,3 +1,5 @@
+use std::env::consts::OS;
+
 use serde::ser::SerializeStruct;
 use serde::Serializer;
 use strum_macros::IntoStaticStr;
@@ -22,7 +24,7 @@ pub fn launch_game(
 ) -> Result<(), LaunchGameCommandError> {
     let data_dir = app_handle.path().app_local_data_dir()?;
 
-    release.launch_game(&data_dir)?;
+    release.launch_game(OS, &data_dir)?;
 
     Ok(())
 }

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -1,4 +1,3 @@
-use std::env::consts::OS;
 use std::io;
 use std::path::Path;
 use std::process::Command;
@@ -29,11 +28,11 @@ pub enum LaunchGameError {
 }
 
 impl GameRelease {
-    pub fn launch_game(&self, data_dir: &Path) -> Result<(), LaunchGameError> {
+    pub fn launch_game(&self, os: &str, data_dir: &Path) -> Result<(), LaunchGameError> {
         let download_dir = get_asset_download_dir(&self.variant, data_dir)?;
         let game_dir = get_asset_extraction_dir(&self.version, &download_dir)?;
 
-        let executable_path = get_executable_path(OS, &game_dir)?;
+        let executable_path = get_executable_path(&self.variant, os, &game_dir)?;
         let executable_dir = executable_path
             .parent()
             .ok_or(LaunchGameError::ExecutableDir)?;


### PR DESCRIPTION
Add OS and variant-aware launcher resolution and propagate OS
through launch flow so the correct executable filename is found for
each game variant and platform.

- Pass std::env::consts::OS from the command entrypoint into
  GameRelease::launch_game.
- Update launch_game signature to accept an os parameter and use the
  variant when resolving the executable path.
- Change fetch_releases utils to pass variant into get_executable_path.
- Refactor get_executable_path to accept a GameVariant and delegate
  filename selection to a new get_launcher_filename helper.
- Introduce LauncherFilenameError for more precise unsupported-OS
  errors and return it via GetExecutablePathError::UnsupportedOS.
- Add mapping for variant-specific launcher filenames (TLG vs BN/DDA)
  and platforms (linux/macos/windows).

This ensures the launcher resolution picks the correct binary for
each variant and platform instead of always using a single filename.