### PR TITLE
fix(fetch-releases): treat missing executable dir as not installed

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -144,7 +144,12 @@ pub fn get_release_status(
     }
 
     let extraction_dir = get_asset_extraction_dir(version, &download_dir)?;
-    let executable_path = get_executable_path(variant, os, &extraction_dir)?;
+    let executable_path = match get_executable_path(variant, os, &extraction_dir) {
+        Ok(path) => path,
+        Err(GetExecutablePathError::DoesNotExist) => return Ok(GameReleaseStatus::NotInstalled),
+        Err(e) => return Err(GetReleaseStatusError::ExecutableDir(e)),
+    };
+
     if !executable_path.exists() {
         return Ok(GameReleaseStatus::NotInstalled);
     }

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -5,7 +5,7 @@ use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetExecutablePathError {
-    #[error("installation directory does not exist")]
+    #[error("launcher file does not exist")]
     DoesNotExist,
 
     #[error("failed to get executable path: {0}")]


### PR DESCRIPTION
Update release status logic to handle missing executable path more
precisely. Match on get_executable_path result and return NotInstalled
when the executable is absent, and map other errors to
ExecutableDir for clearer error propagation. Also adjust the error
message for GetExecutablePathError::DoesNotExist from "installation
directory does not exist" to "launcher file does not exist" to better
reflect the condition.

This prevents spurious errors when a release is not installed and
ensures callers receive a meaningful status instead of an internal
error.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Treat missing launcher file as “NotInstalled” instead of an error to prevent false failures when checking release status. This makes the status more accurate and error messages clearer.

- **Bug Fixes**
  - In get_release_status, return NotInstalled when get_executable_path returns DoesNotExist; map other errors to ExecutableDir.
  - Update error text to “launcher file does not exist” for clearer messaging.

<!-- End of auto-generated description by cubic. -->

