### PR TITLE
feat(last-played add last-played tracking and Tauri command

### DIFF
--- a/cat-launcher/src-tauri/src/last_played/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played/commands.rs
@@ -1,0 +1,43 @@
+use serde::{ser::SerializeStruct, Serializer};
+use strum_macros::IntoStaticStr;
+use tauri::{command, AppHandle, Manager};
+
+use crate::{last_played::last_played::LastPlayedError, variants::GameVariant};
+
+#[derive(thiserror::Error, Debug, IntoStaticStr)]
+pub enum LastPlayedCommandError {
+    #[error("failed to get last played version: {0}")]
+    GetLastPlayedVersion(#[from] LastPlayedError),
+
+    #[error("failed to get system directory: {0}")]
+    SystemDirectory(#[from] tauri::Error),
+}
+
+#[command]
+pub fn get_last_played_version(
+    app_handle: AppHandle,
+    variant: GameVariant,
+) -> Result<Option<String>, LastPlayedCommandError> {
+    let data_dir = app_handle.path().app_local_data_dir()?;
+
+    let last_played_version = variant.get_last_played_version(&data_dir)?;
+
+    Ok(last_played_version)
+}
+
+impl serde::Serialize for LastPlayedCommandError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut st = serializer.serialize_struct("LastPlayedCommandError", 2)?;
+
+        let err_type: &'static str = self.into();
+        st.serialize_field("type", &err_type)?;
+
+        let msg = self.to_string();
+        st.serialize_field("message", &msg)?;
+
+        st.end()
+    }
+}

--- a/cat-launcher/src-tauri/src/last_played/last_played.rs
+++ b/cat-launcher/src-tauri/src/last_played/last_played.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::infra::utils::{read_from_file, write_to_file, ReadFromFileError, WriteToFileError};
+use crate::last_played::utils::{get_last_played_file_path, LastPlayedFileError};
+use crate::variants::GameVariant;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LastPlayedData {
+    pub versions: HashMap<String, String>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LastPlayedError {
+    #[error("failed to read last played data: {0}")]
+    Read(#[from] ReadFromFileError),
+
+    #[error("failed to write last played data: {0}")]
+    Write(#[from] WriteToFileError),
+
+    #[error("failed to get last played file path: {0}")]
+    GetFilePath(#[from] LastPlayedFileError),
+}
+
+impl GameVariant {
+    pub fn get_last_played_version(
+        &self,
+        data_dir: &Path,
+    ) -> Result<Option<String>, LastPlayedError> {
+        let file_path = get_last_played_file_path(self, data_dir)?;
+
+        if !file_path.exists() {
+            return Ok(None);
+        }
+
+        let mut data: LastPlayedData = read_from_file(&file_path)?;
+        let variant_key: &'static str = self.into();
+
+        Ok(data.versions.remove(variant_key))
+    }
+
+    pub fn set_last_played_version(
+        &self,
+        version: &str,
+        data_dir: &Path,
+    ) -> Result<(), LastPlayedError> {
+        let file_path = get_last_played_file_path(self, data_dir)?;
+
+        let mut data = if file_path.exists() {
+            read_from_file(&file_path)?
+        } else {
+            LastPlayedData {
+                versions: std::collections::HashMap::new(),
+            }
+        };
+
+        let variant_key: &'static str = self.into();
+
+        data.versions
+            .insert(variant_key.into(), version.to_string());
+
+        write_to_file(&file_path, &data)?;
+
+        Ok(())
+    }
+}

--- a/cat-launcher/src-tauri/src/last_played/mod.rs
+++ b/cat-launcher/src-tauri/src/last_played/mod.rs
@@ -1,0 +1,3 @@
+pub mod commands;
+pub mod last_played;
+pub mod utils;

--- a/cat-launcher/src-tauri/src/last_played/utils.rs
+++ b/cat-launcher/src-tauri/src/last_played/utils.rs
@@ -1,0 +1,24 @@
+use std::fs::create_dir_all;
+use std::path::{Path, PathBuf};
+
+use crate::infra::utils::get_safe_filename;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LastPlayedFileError {
+    #[error("failed to create directory: {0}")]
+    CreateDir(#[from] std::io::Error),
+}
+
+pub fn get_last_played_file_path(
+    variant: &GameVariant,
+    data_dir: &Path,
+) -> Result<PathBuf, LastPlayedFileError> {
+    let safe_variant_name = get_safe_filename(variant.into());
+    let directory = data_dir.join("LastPlayed").join(&safe_variant_name);
+    create_dir_all(&directory)?;
+
+    let file_path = directory.join("last_played_versions.json");
+
+    Ok(file_path)
+}

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -41,6 +41,10 @@ impl GameRelease {
             .current_dir(executable_dir)
             .spawn()?;
 
+        let _ = self
+            .variant
+            .set_last_played_version(&self.version, data_dir);
+
         Ok(())
     }
 }

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -3,12 +3,14 @@ mod fetch_releases;
 mod game_release;
 mod infra;
 mod install_release;
+mod last_played;
 mod launch_game;
 mod variants;
 
 use crate::basic_info::commands::get_game_variants_info;
 use crate::fetch_releases::commands::fetch_releases_for_variant;
 use crate::install_release::commands::install_release;
+use crate::last_played::commands::get_last_played_version;
 use crate::launch_game::commands::launch_game;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -20,6 +22,7 @@ pub fn run() {
             fetch_releases_for_variant,
             install_release,
             launch_game,
+            get_last_played_version,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
Implement last-played version tracking for game variants and expose it
to the Tauri frontend.

- Add last_played module (commands, last_played, utils) to encapsulate
  logic for storing and retrieving last-played versions.
- Implement GameVariant::get_last_played_version and
  GameVariant::set_last_played_version backed by a JSON file in the app
  local data directory. Use infra read/write helpers and ensure the data
  directory is created.
- Add get_last_played_file_path util to build a safe path under
  <data>/LastPlayed/<variant>/last_played_versions.json and create
  directories as needed.
- Add a Tauri command get_last_played_version that returns the last
  played version or null, with custom serializable error type for better
  JS interop.
- Wire the new command into the Tauri command list in lib.rs.
- Update launch_game to record the version as last-played when a game
  is launched.

This enables persisting which version of each variant was played last,
so the UI can surface and use that information.