### PR TITLE
fix(game-release): normalize OS string for asset matching

### DIFF
--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -1,7 +1,7 @@
 use crate::variants::GameVariant;
 
 pub fn get_platform_asset_substr(variant: &GameVariant, os: &str) -> Option<&'static str> {
-    match (variant, os) {
+    match (variant, os.to_lowercase().as_str()) {
         (GameVariant::DarkDaysAhead, "windows") => Some("windows-with-graphics-and-sounds"),
         (GameVariant::DarkDaysAhead, "macos") => Some("osx-terminal-only"),
         (GameVariant::DarkDaysAhead, "linux") => Some("linux-with-graphics-and-sounds"),


### PR DESCRIPTION
### **User description**
Convert the incoming OS string to lowercase before pattern matching
so comparisons are case-insensitive. This prevents mismatches when
the caller supplies e.g. "Windows" or "WINDOWS" and ensures the
correct platform asset substring is returned for each GameVariant.


___

### **PR Type**
Bug fix


___

### **Description**
- Normalize OS string to lowercase for case-insensitive matching

- Prevent asset matching failures with different case inputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OS string input"] --> B["Convert to lowercase"] --> C["Pattern matching"] --> D["Return platform asset"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Add case-insensitive OS string normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/game_release/utils.rs

<ul><li>Convert OS string to lowercase before pattern matching<br> <li> Ensures case-insensitive comparison for platform detection</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/47/files#diff-8db7a5d9f2885a42967d2465e356d7aacdc947cef5b2284b66a29dcdec6319e1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

