### PR TITLE
refactor(last_played): module and fix data access

### DIFF
--- a/cat-launcher/src-tauri/src/last_played/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played/commands.rs
@@ -2,7 +2,7 @@ use serde::{ser::SerializeStruct, Serializer};
 use strum_macros::IntoStaticStr;
 use tauri::{command, AppHandle, Manager};
 
-use crate::{last_played::last_played::LastPlayedError, variants::GameVariant};
+use crate::{last_played::state::LastPlayedError, variants::GameVariant};
 
 #[derive(thiserror::Error, Debug, IntoStaticStr)]
 pub enum LastPlayedCommandError {

--- a/cat-launcher/src-tauri/src/last_played/mod.rs
+++ b/cat-launcher/src-tauri/src/last_played/mod.rs
@@ -1,2 +1,2 @@
 pub mod commands;
-pub mod last_played;
+pub mod state;

--- a/cat-launcher/src-tauri/src/last_played/state.rs
+++ b/cat-launcher/src-tauri/src/last_played/state.rs
@@ -35,10 +35,10 @@ impl GameVariant {
             return Ok(None);
         }
 
-        let mut data: LastPlayedData = read_from_file(&file_path)?;
+        let data: LastPlayedData = read_from_file(&file_path)?;
         let variant_key: &'static str = self.into();
 
-        Ok(data.versions.remove(variant_key))
+        Ok(data.versions.get(variant_key).cloned())
     }
 
     pub fn set_last_played_version(

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -6,7 +6,7 @@ use crate::filesystem::paths::{get_game_executable_filepath, AssetDownloadDirErr
     AssetExtractionDirError, GetExecutablePathError,
 };
 use crate::game_release::GameRelease;
-use crate::last_played::last_played::LastPlayedError;
+use crate::last_played::state::LastPlayedError;
 use crate::launch_game::utils::{backup_and_copy_save_files, BackupAndCopyError};
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
### **User description**
Update last_played module layout and adjust usages to improve clarity
and prevent mutation when reading version data- Rename module path from_played::last_played to
  last_played::state and update mod export in last_played/mod.rs.
- Update imports to use crate::last_played::state::LastPlayedError
  previously referenced from last_played::last_played.
- Change read logic in state::get_last_played_version:
  - Avoid creating a mutable binding for deserialized data.
  - Use get(...).cloned() instead of remove(...) so the in-memory
    cached structure is not mutated when only reading a value.

These changes clarify module responsibilities and ensure read-only
access does not modify the stored versions map.


___

### **PR Type**
Enhancement


___

### **Description**
- Rename module from `last_played` to `state`

- Fix data mutation in read operations

- Update import paths across affected files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["last_played::last_played"] -- "rename to" --> B["last_played::state"]
  C["remove() mutation"] -- "fix to" --> D["get().cloned() read-only"]
  B --> E["Updated imports"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Update import path for LastPlayedError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/last_played/commands.rs

<ul><li>Update import path from <code>last_played::last_played::LastPlayedError</code> to <br><code>last_played::state::LastPlayedError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/49/files#diff-b948fdf2c75ff00859704a13246659483d8a96dc6f0aac8b5b5fd675bc88098b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Rename module export to state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/last_played/mod.rs

- Change module export from `last_played` to `state`


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/49/files#diff-a204931a61547cae7dce9f26f19490b8a527928243085055567359353158c96a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>launch_game.rs</strong><dd><code>Update import path for LastPlayedError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/launch_game/launch_game.rs

<ul><li>Update import path from <code>last_played::last_played::LastPlayedError</code> to <br><code>last_played::state::LastPlayedError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/49/files#diff-e0af1e526282c234e69308809193c6c834da1fe02862127f7573e52c1f7d6ec1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>state.rs</strong><dd><code>Fix data mutation in read operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/last_played/state.rs

<ul><li>Remove mutable binding for deserialized data<br> <li> Replace <code>remove()</code> with <code>get().cloned()</code> to prevent mutation during reads</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/49/files#diff-350223412927fddfe00c41c98f9667a1223655965223f9acf0c1ac2ea934a08d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

