### PR TITLE
docs: streamline AGENTS.md and update architecture details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,9 @@
 
 This document provides instructions for AI agents working on the CatLauncher project.
 
-## Project Overview
-
-CatLauncher is an opinionated cross-platform launcher for Cataclysm games with modern social features. It is built with Tauri, using Rust for the backend and a web-based frontend.
-
 ## Architecture
 
-The project's architecture is designed for maintainability and testability, with a clear separation between the backend (Rust) and frontend (React).
+The project's architecture is designed for testability, with a clear separation between the backend (Rust) and frontend (React).
 
 ### Backend Architecture
 
@@ -18,11 +14,9 @@ Within each slice, the principles of **Clean Architecture** are applied:
 - **Framework Agnostic Core:** The core business logic (e.g., in `fetch_releases.rs`) is decoupled from the Tauri framework. It receives dependencies like paths and HTTP clients via arguments (dependency injection), making it easy to test in isolation.
 - **Framework Bridge:** The `commands.rs` file in each module is the only part that interacts directly with Tauri. It acts as a bridge, exposing the core logic to the frontend as Tauri commands.
 
-There is **no database** in this project. Data persistence, such as caching release information or storing the last played version, is handled by writing directly to the local filesystem in platform-appropriate directories provided by Tauri.
-
 ### Frontend Architecture
 
-The frontend is a standard React application and does **not** follow the same vertical slice structure as the backend. It is organized by component features (e.g., `PlayPage`, `components/ui`).
+The frontend is a standard React application and follows a similar vertical slice structure as the backend. It is organized by screens (e.g., `PlayPage`).
 
 ### Frontend-Backend Interaction
 
@@ -33,15 +27,14 @@ The frontend communicates with the backend by invoking the commands defined in t
 ## Technology Stack
 
 - **Backend:** Rust with Tauri, `ts-rs` for TypeScript type generation
-- **Frontend:** React, TypeScript, and shadcn/ui
-- **Package Manager:** pnpm
+- **Frontend:** React, Redux Toolkit, TanStack Query, TypeScript, and shadcn/ui
+- **Package Manager:** cargo and pnpm
 
 ## Project Structure
 
 - `cat-launcher/`: The main project directory.
   - `src/`: Frontend source code.
   - `src-tauri/`: Backend (Rust) source code.
-    - `src/main.rs`: The main entry point for the Rust application.
     - `tauri.conf.json`: Tauri configuration file.
 - `README.md`: Project README file.
 
@@ -50,7 +43,7 @@ The frontend communicates with the backend by invoking the commands defined in t
 -   `cat-launcher/`: The root directory for the Tauri project.
     -   `src/`: Contains all the frontend React source code.
         -   `lib/utils.ts`: A crucial file that wraps all Tauri backend commands, decoupling the UI components from the backend API.
-        -   `PlayPage/`: An example of a feature-based component directory on the frontend.
+        -   `PlayPage/`: An example of a screen-based vertical slice on the frontend.
     -   `src-tauri/`: Contains all the backend Rust source code.
         -   `src/`: The Rust crate for the backend.
             -   `<feature>/`: Each directory here represents a vertical slice of the application's features (e.g., `fetch_releases/`, `install_release/`).
@@ -72,6 +65,7 @@ The backend employs a two-tier error handling strategy to separate internal busi
     -   These errors are defined within the core logic files (e.g., `fetch_releases.rs`).
     -   They use `thiserror::Error` for clean error propagation within the backend.
     -   They are **not** intended to be sent to the frontend and therefore do **not** implement `serde::Serialize` or derive `strum::IntoStaticStr`.
+    -   Each function has its own error enums.
 
     *Example from `fetch_releases/fetch_releases.rs`*:
     ```rust
@@ -157,11 +151,11 @@ This end-to-end system ensures that backend errors are structured, propagated cl
 
 ## ts-rs: TypeScript Type Generation
 
-This project uses the `ts-rs` crate to automatically generate TypeScript type definitions (`.d.ts` files) from Rust structs and enums. This ensures that the frontend and backend types are always in sync.
+This project uses the `ts-rs` crate to automatically generate TypeScript type definitions from Rust structs and enums. This ensures that the frontend and backend types are always in sync.
 
 ### How it Works
 
-The type generation is integrated into the testing process. When you run the backend tests, a test case specifically for exporting types is executed. This test will:
+When you run the backend tests, a test case specifically for exporting types is executed. This test will:
 
 1.  Find all Rust types decorated with `#[ts(export)]`.
 2.  Generate the corresponding TypeScript types.
@@ -177,15 +171,6 @@ cargo test --manifest-path ./cat-launcher/src-tauri/Cargo.toml
 
 This ensures the frontend has access to the latest type definitions.
 
-## Running Tests
-
-The project has both frontend and backend tests.
-
-- **Backend Tests:**
-  ```bash
-  cargo test --manifest-path ./cat-launcher/src-tauri/Cargo.toml
-  ```
-
 ### Checking for Syntax Errors
 
 To quickly check your Rust code for syntax errors without compiling, you can run the following command:
@@ -194,8 +179,11 @@ To quickly check your Rust code for syntax errors without compiling, you can run
 cargo check --manifest-path ./cat-launcher/src-tauri/Cargo.toml
 ```
 
-- **Frontend Tests:**
-  - No frontend tests have been set up yet.
+## Best Practices
+
+### Prefer Enums Over Booleans
+
+When adding a field to a struct or a payload that represents a state, prefer using an enum over a boolean. For example, instead of `is_finished: bool`, prefer a `status: UpdateStatus` enum with variants like `InProgress` and `Finished`.
 
 ## Agent Workflow
 
@@ -206,5 +194,4 @@ When working on this project, please follow these guidelines:
 3.  **Perform Self-Review:** After making any change, run `cr review --plain -t uncommitted` if the command is available. Address any feedback provided before proceeding.
 4.  **Run Tests:** After making any changes, run the relevant tests to ensure that you haven't introduced any regressions.
 5.  **Update Documentation:** If you add or modify features, update this `AGENTS.md` file and the `README.md` as needed.
-6.  **Keep Dependencies Updated:** Regularly check for and update outdated dependencies.
-7.  **Follow Existing Conventions:** Adhere to the coding style and conventions already present in the codebase.
+6.  **Follow Existing Conventions:** Adhere to the coding style and conventions already present in the codebase.


### PR DESCRIPTION
Clarify and tighten architecture documentation to better reflect the
current project structure and dependencies. Key changes:
- Remove redundant project overview and simplify architecture wording to
  emphasize testability a clear backend/frontend separation- Correct frontend description to a screen-based vertical slice and add
  Redux Toolkit and TanStack Query to the frontend tech list.
- Add cargo to the package manager list and normalize package manager
  references.
- Remove statement about lack of a database and unnecessary persistence
  details.
- Adjust project structure notes (move/trim entries) and mark PlayPage
  as a screen-based example.
- Note that each function has its own error enums and simplify ts-rs
  type generation wording.
- Remove a duplicated "running tests" section and some extraneous
  instructions to make the document more concise.

These edits improve accuracy, reduce duplication, and make the agent
guidance easier to follow.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Streamlined AGENTS.md to match the current architecture and tooling, reducing duplication and making the guide easier to follow.

- **Refactors**
  - Emphasized testability and clear backend/frontend separation.
  - Documented frontend as screen-based vertical slices (e.g., PlayPage).
  - Added Redux Toolkit and TanStack Query; included cargo alongside pnpm.
  - Clarified error handling (per-function enums) and simplified ts-rs type generation.
  - Removed outdated “no database” note, trimmed structure details, dropped duplicate test section, and added enum-over-boolean best practice.

<!-- End of auto-generated description by cubic. -->

