### PR TITLE
fix(status): treat missing executable dir as not downloaded

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -144,7 +144,14 @@ pub fn get_game_executable_filepath(
     os: &str,
     data_dir: &Path,
 ) -> Result<PathBuf, GetExecutablePathError> {
-    let dir = get_game_executable_dir(variant, release_version, data_dir)?;
+    let dir = match get_game_executable_dir(variant, release_version, data_dir) {
+        Ok(dir) => dir,
+        Err(GetGameExecutableDirError::NoInstallation) => {
+            return Err(GetExecutablePathError::DoesNotExist)
+        }
+        Err(err) => return Err(GetExecutablePathError::LauncherDirectory(err)),
+    };
+
     let filename = get_game_executable_filename(variant, os)?;
     let filepath = dir.join(filename);
 

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -49,18 +49,22 @@ impl GameRelease {
         // if !is_uncorrupted {
         //     return Ok(GameReleaseStatus::Corrupted);
         // }
+        //
+        // Since we don't verify the integrity of the downloaded file, if downloaded asset is present
+        // but the installation dir or executable file is missing, we still consider the asset to not
+        // be downloaded.
 
         let executable_path =
             match get_game_executable_filepath(&self.variant, &self.version, os, data_dir) {
                 Ok(path) => path,
                 Err(GetExecutablePathError::DoesNotExist) => {
-                    return Ok(GameReleaseStatus::NotInstalled)
+                    return Ok(GameReleaseStatus::NotDownloaded)
                 }
                 Err(e) => return Err(GetInstallationStatusError::ExecutableDir(e)),
             };
 
         if !executable_path.exists() {
-            return Ok(GameReleaseStatus::NotInstalled);
+            return Ok(GameReleaseStatus::NotDownloaded);
         }
 
         Ok(GameReleaseStatus::ReadyToPlay)


### PR DESCRIPTION
Adjust installation status and path resolution so that a missing
installation directory is treated as "NotDownloaded" rather than
"NotInstalled". When get_game_executable_filepath cannot find the
executable directory, it now returns GetExecutablePathError::DoesNotExist
so the status check maps that case to GameReleaseStatus::NotDownloaded.
Also map get_game_executable_dir's NoInstallation error to
GetExecutablePathError::DoesNotExist and surface other directory errors
as LauncherDirectory.

This avoids reporting an asset as installed when the downloaded file
exists but the installation directory or executable is missing, and
keeps integrity/verification logic separate from presence checks.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Treat a missing game executable directory as NotDownloaded instead of NotInstalled to avoid false “installed” status when the directory or executable is absent. get_game_executable_filepath now returns DoesNotExist for NoInstallation and surfaces other directory errors, and status checks map DoesNotExist and a missing executable to NotDownloaded.

<!-- End of auto-generated description by cubic. -->

