### PR TITLE
docs: add to avoid panic-pr methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,10 @@ cargo check --manifest-path ./cat-launcher/src-tauri/Cargo.toml
 
 When adding a field to a struct or a payload that represents a state, prefer using an enum over a boolean. For example, instead of `is_finished: bool`, prefer a `status: UpdateStatus` enum with variants like `InProgress` and `Finished`.
 
+### Avoid Methods that May Panic
+
+In Rust, avoid methods that may panic. Instead, use the `Result` type to handle errors gracefully. For example, instead of using `unwrap()` or `expect()` use `if let` or `match` to handle errors.
+
 ## Agent Workflow
 
 When working on this project, please follow these guidelines:


### PR DESCRIPTION
Add new subsection "Avoid Methods that May Panic" to AGENTS.md.
Explain that Rust code should avoid panic-causing calls (like unwrap())
and prefer returning Result and handling errors with expect, match, or
other explicit error-handling patterns. Clarify the rationale: graceful
error handling improves robustness and avoids unwinding in production.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new "Avoid Methods that May Panic" subsection to AGENTS.md to standardize Rust error handling.
It recommends using Result with expect or match instead of panic-prone calls like unwrap, improving robustness and preventing unwinding in production.

<!-- End of auto-generated description by cubic. -->

