### PR TITLE
docs: add guidance to avoid Box<dyn Error>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,10 @@ When adding a field to a struct or a payload that represents a state, prefer usi
 
 In Rust, avoid methods that may panic. Instead, use the `Result` type to handle errors gracefully. For example, instead of using `unwrap()` or `expect()` use `if let` or `match` to handle errors.
 
+### Avoid Box<dyn Error>
+
+Instead, define a custom error type using the `thiserror` crate, and use it.
+
 ## Agent Workflow
 
 When working on this project, please follow these guidelines:


### PR DESCRIPTION
### **User description**
Add a new subsection advising contributors to avoid using Box<dyn Error>
and to define custom error types (suggesting the thiserror crate).
Explain rationale: custom error types improve type safety, make errors
easier to match on, and provide clearer, more descriptive error handling
than boxed trait objects.

Place guidance in AGENTS.md near the existing Rust error-handling
recommendations to encourage consistent, idiomatic error handling across
the codebase.


___

### **PR Type**
Documentation


___

### **Description**
- Add guidance to avoid `Box<dyn Error>` in Rust code

- Recommend using custom error types with `thiserror` crate

- Improve error handling consistency across codebase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Box<dyn Error>"] -- "avoid" --> B["Custom Error Types"]
  B -- "use" --> C["thiserror crate"]
  C --> D["Better Type Safety"]
  C --> E["Clearer Error Handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add Box<dyn Error> avoidance guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Add new subsection "Avoid Box<dyn Error>"<br> <li> Recommend defining custom error types using <code>thiserror</code> crate<br> <li> Place guidance near existing Rust error-handling recommendations</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/63/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

