### PR TITLE
Refactor: Convert all filesystem interactions to async

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -46,7 +46,7 @@ impl GameVariant {
     where
         F: Fn(ReleasesUpdatePayload) -> Result<(), E>,
     {
-        let cached_releases = get_cached_releases(self, cache_dir);
+        let cached_releases = get_cached_releases(self, cache_dir).await;
         let cached_game_releases: Vec<GameRelease> =
             cached_releases.iter().map(|r| (r, *self).into()).collect();
 
@@ -64,7 +64,7 @@ impl GameVariant {
         let to_cache = select_releases_for_cache(&all_releases);
 
         // Successfully writing to cache is not important. Ignore if an error happens.
-        let _ = write_cached_releases(self, &to_cache, cache_dir);
+        let _ = write_cached_releases(self, &to_cache, cache_dir).await;
 
         let game_releases: Vec<GameRelease> = to_cache.iter().map(|r| (r, *self).into()).collect();
 

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -37,8 +37,8 @@ pub enum GameReleaseStatus {
 }
 
 impl GameRelease {
-    pub fn get_asset(&self, os: &str, cache_dir: &Path) -> Option<GitHubAsset> {
-        let assets = get_assets(self, cache_dir);
+    pub async fn get_asset(&self, os: &str, cache_dir: &Path) -> Option<GitHubAsset> {
+        let assets = get_assets(self, cache_dir).await;
 
         get_platform_asset_substr(&self.variant, os)
             .and_then(|substring| assets.into_iter().find(|a| a.name.contains(substring)))

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -41,7 +41,7 @@ pub async fn get_release_by_id(
     cache_dir: &Path,
     data_dir: &Path,
 ) -> Result<GameRelease, GetReleaseError> {
-    let gh_releases = get_cached_releases(variant, cache_dir);
+    let gh_releases = get_cached_releases(variant, cache_dir).await;
     let gh_release = match gh_releases.into_iter().find(|r| r.tag_name == release_id) {
         Some(r) => r,
         None => return Err(GetReleaseError::NotFound(release_id.into())),

--- a/cat-launcher/src-tauri/src/infra/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/utils.rs
@@ -1,11 +1,10 @@
+use std::io;
 use std::path::Path;
-use std::{fs, io};
 
 use serde::de::DeserializeOwned;
+use tokio::fs;
 
 use crate::variants::GameVariant;
-
-
 
 pub fn get_github_repo_for_variant(variant: &GameVariant) -> &'static str {
     match variant {
@@ -24,8 +23,8 @@ pub enum ReadFromFileError {
     Deserialize(#[from] serde_json::Error),
 }
 
-pub fn read_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, ReadFromFileError> {
-    let contents = fs::read_to_string(path)?;
+pub async fn read_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, ReadFromFileError> {
+    let contents = fs::read_to_string(path).await?;
     let v = serde_json::from_str(&contents)?;
     Ok(v)
 }
@@ -39,8 +38,11 @@ pub enum WriteToFileError {
     Write(#[from] std::io::Error),
 }
 
-pub fn write_to_file<T: serde::Serialize>(path: &Path, data: &T) -> Result<(), WriteToFileError> {
+pub async fn write_to_file<T: serde::Serialize>(
+    path: &Path,
+    data: &T,
+) -> Result<(), WriteToFileError> {
     let contents = serde_json::to_string_pretty(data)?;
-    fs::write(path, contents)?;
+    fs::write(path, contents).await?;
     Ok(())
 }

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -54,9 +54,10 @@ impl GameRelease {
             return Ok(());
         }
 
-        let download_dir = get_or_create_asset_download_dir(&self.variant, data_dir)?;
+        let download_dir = get_or_create_asset_download_dir(&self.variant, data_dir).await?;
         let asset = self
             .get_asset(os, cache_dir)
+            .await
             .ok_or(ReleaseInstallationError::NoCompatibleAsset)?;
 
         if self.status == GameReleaseStatus::NotDownloaded
@@ -70,7 +71,7 @@ impl GameRelease {
 
         let download_filepath = download_dir.join(&asset.name);
         let installation_dir =
-            get_or_create_asset_installation_dir(&self.variant, &self.version, data_dir)?;
+            get_or_create_asset_installation_dir(&self.variant, &self.version, data_dir).await?;
         extract_archive(&download_filepath, &installation_dir).await?;
 
         self.status = GameReleaseStatus::ReadyToPlay;

--- a/cat-launcher/src-tauri/src/last_played/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played/commands.rs
@@ -14,13 +14,13 @@ pub enum LastPlayedCommandError {
 }
 
 #[command]
-pub fn get_last_played_version(
+pub async fn get_last_played_version(
     app_handle: AppHandle,
     variant: GameVariant,
 ) -> Result<Option<String>, LastPlayedCommandError> {
     let data_dir = app_handle.path().app_local_data_dir()?;
 
-    let last_played_version = variant.get_last_played_version(&data_dir)?;
+    let last_played_version = variant.get_last_played_version(&data_dir).await?;
 
     Ok(last_played_version)
 }

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -41,14 +41,15 @@ impl GameRelease {
         data_dir: &Path,
     ) -> Result<(), LaunchGameError> {
         let executable_path =
-            get_game_executable_filepath(&self.variant, &self.version, os, data_dir)?;
+            get_game_executable_filepath(&self.variant, &self.version, os, data_dir).await?;
         let executable_dir = executable_path
             .parent()
             .ok_or(LaunchGameError::ExecutableDir)?;
 
         let last_played_version = self
             .variant
-            .get_last_played_version(data_dir)?
+            .get_last_played_version(data_dir)
+            .await?
             .unwrap_or(self.version.clone());
 
         backup_and_copy_save_files(
@@ -65,7 +66,8 @@ impl GameRelease {
             .spawn()?;
 
         self.variant
-            .set_last_played_version(&self.version, data_dir)?;
+            .set_last_played_version(&self.version, data_dir)
+            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
This commit refactors the entire codebase to use asynchronous filesystem interactions.

- Replaced all usages of `std::fs` with `tokio::fs`.
- Updated all functions that interact with the filesystem to be `async`.
- Updated all call sites of the modified functions to use `.await`.
- Added the `futures` crate as a dependency.
- Corrected compilation errors and logical regressions found during the refactoring process.
- Ensured that no `unwrap()` calls or ignored errors were introduced.

a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactors the launcher to use async filesystem I/O with tokio::fs across the codebase. This removes blocking operations and makes release, install, and launch flows more responsive.

- **Refactors**
  - Replaced std::fs with tokio::fs; file read/write helpers are async and use metadata checks.
  - Made paths.rs helpers async (dir creation, read_dir iteration, executable discovery).
  - Made GameRelease and LastPlayed disk APIs async; Tauri get_last_played_version is now async.
  - Archive extract/create use async prep; heavy ZIP/TAR work runs in spawn_blocking; checksum reader is async.

- **Migration**
  - Update callers to await filesystem helpers and GameRelease/LastPlayed APIs (e.g., get_cached_releases, get_or_create_asset_* dirs, get_game_executable_* and get_game_save_dirs, GameRelease::get_asset/get_installation_status, GameVariant::get_last_played_version/set_last_played_version).

<!-- End of auto-generated description by cubic. -->

