### PR TITLE
chore(release): bump app version to 0.3.0

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
Update package and manifest versions from 0.2.0 to 0.3.0 across
project config files so the application and build metadata reflect the
next release.

Files changed:
- src-tauri/Cargo.toml
- package.json
- src-tauri/tauri.conf.json

This prepares the project for the 0.3.0 release and keeps Rust,
npm, and Tauri version fields consistent.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped app version from 0.2.0 to 0.3.0 across package.json, Cargo.toml, and tauri.conf.json to prepare the 0.3.0 release. Ensures Rust, npm, and Tauri configs stay in sync.

<!-- End of auto-generated description by cubic. -->

