### PR TITLE
build: add pnpm packageManager field to package.json

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -2,6 +2,7 @@
   "name": "cat-launcher",
   "private": true,
   "version": "0.3.0",
+  "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Include a packageManager entry specifying pnpm@10.15.1 in the
cat-launcher package.json. This pins the expected package manager
version for contributors and CI, improving consistency across
installations and avoiding mismatches between npm, pnpm, and yarn
behaviors. No functional code changes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pin the package manager to pnpm@10.15.1 in cat-launcher/package.json to standardize installs across local dev and CI. Avoids npm/pnpm/yarn differences; no functional changes.

<!-- End of auto-generated description by cubic. -->

