### PR TITLE
chore(ci): pass package to pnpm setup in release workflow

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -32,6 +32,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: cat-launcher/package.json
+          run_install: |
+            - cwd: cat-launcher
+            - args: [--frozen-lockfile]
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -44,9 +49,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Install frontend dependencies
-        run: pnpm --dir cat-launcher install --frozen-lockfile
 
       - name: Build and publish
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
Update GitHub Actions release workflow to explicitly point the
pnpm/action-setup step at the package.json for the cat-launcher
subproject. This adds a with: package_json_file: cat-launcher/package.json
argument and removes a redundant separate "Install frontend
dependencies" step.

This ensures pnpm config is initialized for the correct workspace
package during the build-on-release job, avoiding reliance on the
default workspace root and preventing missing dependency installs
when building the cat-launcher.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the release workflow to point pnpm/action-setup at cat-launcher/package.json and remove the separate install step. This initializes pnpm for the correct workspace during the build, preventing missing dependency installs for cat-launcher.

<!-- End of auto-generated description by cubic. -->

