### PR TITLE
ci: install frontend deps manually

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -34,9 +34,6 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           package_json_file: cat-launcher/package.json
-          run_install: |
-            - cwd: cat-launcher
-            - args: [--frozen-lockfile]
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -49,6 +46,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: pnpm install --dir cat-launcher --frozen-lockfile
 
       - name: Build and publish
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
Remove the pnpm/action-setup run_install block and add an explicit
"Install frontend dependencies" step that runs pnpm install --dir
cat-launcher --frozen-lockfile. This ensures frontend deps are installed
reliably on the runner during the build-on-release workflow and avoids
misconfigured run_install arguments for pnpm/action-setup. Also remove
the redundant explicit cwd/args lines to simplify the workflow.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Install frontend dependencies explicitly in the build-on-release workflow to ensure reliable installs and simplify CI. Replaces pnpm/action-setup run_install with pnpm install --dir cat-launcher --frozen-lockfile and removes redundant cwd/args.

<!-- End of auto-generated description by cubic. -->

