### PR TITLE
chore(ci): add env and tauri signing secrets for release

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  TS_RS_EXPORT_DIR: "../src/generated-types"
+
 jobs:
   build-and-publish:
     permissions:
@@ -54,6 +57,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: "./cat-launcher"
           updaterJsonPreferNsis: true


### PR DESCRIPTION
Add TS_RS_EXPORT_DIR env variable to point generated TypeScript types
into src/generated-types to ensure released artifacts include the
correct type output location.

Expose TAURI_SIGNING_PRIVATE_KEY and
TAURI_SIGNING_PRIVATE_KEY_PASSWORD to the tauri-action during build on
release so automated release builds can sign binaries. This allows
published releases to produce signed Tauri artifacts.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Configure the release CI to export TS_RS_EXPORT_DIR to src/generated-types and pass Tauri signing secrets to the tauri-action. This ensures generated TypeScript types are published in the right path and release binaries are signed.

<!-- End of auto-generated description by cubic. -->

