### PR TITLE
feat(release): publish v0.3. release metadata

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,11 +1,23 @@
 {
-  "version": "0.2.0",
-  "notes": "This release adds last-played tracking, significantly improves the installation flow with better status checks and download skipping, and introduces error toast notifications.",
-  "pub_date": "2025-10-10T16:05:22Z",
+  "version": "0.3.0",
+  "notes": "Introducing version 0.3.0 with auto-updater functionality, asynchronous filesystem interactions, and various refactors and improvements.",
+  "pub_date": "2025-10-12T12:23:27.646Z",
   "platforms": {
+    "darwin-aarch64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEp5TlRVbG01UkJQZiswZmQrWWIzaytialkvTVFMempOL2Ryd3pjZSsxTVF3aEdjTUVLdW44ek5Ya0I4ZnlZZWE3NjZUYkkvNjA3R2huK2ltK1AyQVFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwMjcxNDM4CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKM2VPQ01PNWtmVVB2di9HZnRSd2RtRG1GSEFDdWdzTFNqUFVkRVpUMUh5cmhBck41V3BsQkFyUGNQY25kU2RGMUY5RDdCUXZGR1hyUzJsSHlJRXFLRFE9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.3.0/cat-launcher_aarch64.app.tar.gz"
+    },
+    "darwin-x86_64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEJteGFBZ1BjNWVhazRRcHJqOE9sSGhmbm9RY1R3UG5TYWl6cWtoUUJSVmhzVkVhNldaL0FFbUVzQ1FqSk14SUNUZk1GdGlHSzNHUlFXdE9yT1o3YkE4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwMjcxNDk3CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKNXBMWE13Y1FWbkJzUC90NW9ZQmlocUdmd0FpdE9TMW5jMEVIMlpKWURuRzV1UkorSU9ZNWh2bDZkbWd2c0IwdzJzV1QvVDIvVXdLUTYzQmlGQ3dsQ3c9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.3.0/cat-launcher_x64.app.tar.gz"
+    },
     "linux-x86_64": {
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.2.0/cat-launcher_0.2.0_amd64.AppImage",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VExZcEhjdDJiZTR2ZDQ3Vm91eFlibk9zNDdTU2s0QWRvN0Fkd3ZFMVV6MUhSRkltdG1WOThaNFUyc3BmZm5pa3pSZW14QjFvR2w3bFEzZXJwU3IzUHc0PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwMjUxMzgxCWZpbGU6Y2F0LWxhdW5jaGVyXzAuMi4wX2FtZDY0LkFwcEltYWdlClExbGVrWkduQkNFQitPZ3VPTEcvLzJubGJXeStKazA0WStrdERzdW55UUZvOWNxWkNKTlpmbXIyWVZPaUtlUzVsSEZ2dWlHaEtOQU9XNW5XckxqUkRnPT0K"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEp1TEJxbjlUOG80NFBCOU9zZUxjM1BBbm5lUW54WWcxYWwrVkFNNGUwb3NoVFlwZEZxZnFWaC91SUVlN1NsaWFNNVhYTGMwbGV4UDdIVldWWDVuYmdFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwMjcxNzYxCWZpbGU6Y2F0LWxhdW5jaGVyXzAuMy4wX2FtZDY0LkFwcEltYWdlCjA5Szc0bVFUSGpjaktWckdaM2ZXcTdqT29jV2Iya0JEUGJtVEZHUy83MU5kb0FvYWRMQzRCVTkraGlOdXRMRUNIOElKS1hKd3oyWkVNMy8yNit1TkFnPT0K",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.3.0/cat-launcher_0.3.0_amd64.AppImage"
+    },
+    "windows-x86_64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEdVQlIrS2RnUjhvSmFWalNWWmg3cnoyS3Q0NDdIZ29RRnFzVzlWV2J4Sk9xUWlmVllId2JleDhVa1dyTkZ1eXJPYlNvczJlbVI1WEw5bFV0bmlhdHdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwMjcxODA0CWZpbGU6Y2F0LWxhdW5jaGVyXzAuMy4wX3g2NC1zZXR1cC5leGUKc2t4OC9iZHQ5TjE5TzVvTklkL1pxVUNjTFpJNkJ3bXM0Wm9sVm5raU12cHZvRU1ueTJFMzJUQUhyREJiamVYaVRMcjdOaGhXd1ZoMHVZVkRGYTRKQWc9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.3.0/cat-launcher_0.3.0_x64-setup.exe"
     }
   }
 }


### PR DESCRIPTION
Update latest.json to publish v0.3.0 release metadata with new
platform artifacts and updated release notes and timestamp.

- Bump version to 0.3.0 and update pub_date to 2025-10-12.
- Replace high-level notes to describe auto-updater, async FS
 , and various refactors/improvements.
- Add darwin-aarch64 and darwin-x86_64 platform entries with URLs
  and signatures for macOS arm64 and x86_64 builds.
- Update linux-x86_64 entry to point to the 0.3.0 AppImage and
  replace its signature to match the new artifact.
- Add windows-x86_64 entry with setup.exe URL and signature.

These changes publish the new installers and checksums so clients
and updaters can discover and verify the 0.3.0 release.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Publish v0.3.0 release metadata in latest.json so clients and auto-updaters can discover and verify the new installers. Adds macOS (arm64 and x64) and Windows x64 artifacts, updates the Linux AppImage, refreshes notes (auto-updater, async FS) and pub_date, and updates all URLs and signatures.

<!-- End of auto-generated description by cubic. -->

