### PR TITLE
chore(ci): pin Ubuntu runner to 20.04 in release workflow

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -20,7 +20,7 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based Macs
             args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04"
+          - platform: "ubuntu-20.04"
             args: ""
           - platform: "windows-latest"
             args: ""


### PR DESCRIPTION
### **User description**
Update the release GitHub Actions workflow to use the Ubuntu 20.04
runner instead of Ubuntu 22.04. This should make the AppImage more 
portable.


___

### **PR Type**
Other


___

### **Description**
- Pin Ubuntu runner to version 20.04 in release workflow for improved AppImage portability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] --> B["Ubuntu Runner Version"]
  B -- "Changed from" --> C["ubuntu-22.04"]
  B -- "Changed to" --> D["ubuntu-20.04"]
  D --> E["Improved AppImage Portability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-on-release.yml</strong><dd><code>Update Ubuntu runner version to 20.04</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-on-release.yml

<ul><li>Changed Ubuntu runner version from <code>ubuntu-22.04</code> to <code>ubuntu-20.04</code> in the <br>build matrix<br> <li> Affects the Linux build configuration in the release workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/77/files#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

