### PR TITLE
chore(ci): Ubuntu runner to .04 in release workflow

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -20,7 +20,7 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based Macs
             args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04"
+          - platform: "ubuntu-24.04"
             args: ""
           - platform: "windows-latest"
             args: ""
@@ -45,7 +45,7 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Install dependencies for Linux
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf


### PR DESCRIPTION
### **User description**
Update the GitHub Actions release to use Ubuntu 24.04
instead of 22.04 for the Linux build matrix and conditional steps.

This ensures the CI runs on the newer LTS image, aligning with
platform updates and package availability, and avoids mismatches
between the matrix entry and the step conditional that installs
Linux dependencies.


___

### **PR Type**
Other


___

### **Description**
- Update Ubuntu runner from 22.04 to 24.04 in release workflow

- Align matrix platform and conditional check for Linux dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Matrix"] --> B["ubuntu-24.04"]
  B --> C["Linux Dependencies Install"]
  C --> D["Build & Publish"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-on-release.yml</strong><dd><code>Upgrade Ubuntu runner version to 24.04</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-on-release.yml

<ul><li>Updated matrix platform from <code>ubuntu-22.04</code> to <code>ubuntu-24.04</code><br> <li> Updated conditional check in Linux dependencies step to match new <br>platform version</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/78/files#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

