### PR TITLE
chore(bundle): skip bundling AppImage

### DIFF
--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app", "deb", "dmg", "nsis", "rpm"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
The built AppImages don't run reliably across distros.

Replace generic "all" target with an explicit array of packaging
targets ("app", "deb", "dmg", "msi", "nsis", "rpm") in tauri.conf.json.
This ensures predictable build behavior across platforms and avoids
ambiguous or deprecated configuration usage. It clarifies which bundles
are produced and makes and local packaging reproducible.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop bundling AppImage due to reliability issues across distros. Updated tauri.conf.json to replace "all" with explicit targets: app, deb, dmg, msi, nsis, rpm, for predictable and reproducible builds across platforms.

<!-- End of auto-generated description by cubic. -->

