### PR TITLE
feat: Check default releases and refactor path handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,18 @@ Within each slice, the principles of **Clean Architecture** are applied:
 - **Framework Agnostic Core:** The core business logic (e.g., in `fetch_releases.rs`) is decoupled from the Tauri framework. It receives dependencies like paths and HTTP clients via arguments (dependency injection), making it easy to test in isolation.
 - **Framework Bridge:** The `commands.rs` file in each module is the only part that interacts directly with Tauri. It acts as a bridge, exposing the core logic to the frontend as Tauri commands.
 
+#### Directory and Path Handling
+
+To maintain a clean separation of concerns and enhance portability, business logic functions should not be tightly coupled to the application's directory structure.
+
+-   **Parameter Passing:** Business logic functions should only receive the top-level directory paths they need as parameters. These are typically:
+    -   `cache_dir`: The path to the application's cache directory.
+    -   `data_dir`: The path to the application's data directory.
+    -   `resources_dir`: The path to the application's resources directory.
+-   **Path Construction:** Inside the business logic functions, use the helper functions provided in `src-tauri/src/filesystem/paths.rs` to construct the exact paths to specific files or subdirectories.
+
+This approach ensures that the core logic is not cluttered with path manipulation and can be easily tested by passing in mock directory paths.
+
 ### Frontend Architecture
 
 The frontend is a standard React application and follows a similar vertical slice structure as the backend. It is organized by screens (e.g., `PlayPage`).

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -1,7 +1,6 @@
 use serde::ser::SerializeStruct;
 use serde::Serializer;
 use strum_macros::IntoStaticStr;
-use tauri::path::BaseDirectory;
 use tauri::{command, AppHandle, Emitter, Manager};
 
 use crate::fetch_releases::fetch_releases::{FetchReleasesError, ReleasesUpdatePayload};
@@ -23,9 +22,7 @@ pub async fn fetch_releases_for_variant(
     variant: GameVariant,
 ) -> Result<(), FetchReleasesCommandError> {
     let cache_dir = app_handle.path().app_cache_dir()?;
-    let default_releases_dir = app_handle
-        .path()
-        .resolve("releases/", BaseDirectory::Resource)?;
+    let resources_dir = app_handle.path().resource_dir()?;
 
     let on_releases = move |payload: ReleasesUpdatePayload| {
         app_handle.emit("releases-update", payload)?;
@@ -33,7 +30,7 @@ pub async fn fetch_releases_for_variant(
     };
 
     variant
-        .fetch_releases(&HTTP_CLIENT, &cache_dir, &default_releases_dir, on_releases)
+        .fetch_releases(&HTTP_CLIENT, &cache_dir, &resources_dir, on_releases)
         .await?;
 
     Ok(())

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -47,7 +47,7 @@ impl GameVariant {
         &self,
         client: &Client,
         cache_dir: &Path,
-        default_releases_dir: &Path,
+        resources_dir: &Path,
         on_releases: F,
     ) -> Result<(), FetchReleasesError<E>>
     where
@@ -57,7 +57,7 @@ impl GameVariant {
         // Both default and cached releases are stored locally, and are quick to fetch.
         // We fetch them together so that if the last played release was cached, the frontend
         // can preselect it.
-        let default_releases = get_default_releases(self, default_releases_dir).await;
+        let default_releases = get_default_releases(self, resources_dir).await;
         let cached_releases = get_cached_releases(self, cache_dir).await;
         let merged = merge_releases(&default_releases, &cached_releases);
         let payload = get_releases_payload(self, &merged, ReleasesUpdateStatus::Fetching);
@@ -70,7 +70,7 @@ impl GameVariant {
         let payload = get_releases_payload(self, &fetched_releases, ReleasesUpdateStatus::Success);
         on_releases(payload).map_err(FetchReleasesError::Send)?;
 
-        let merged = merge_releases(&cached_releases, &fetched_releases);
+        let merged = merge_releases(&merged, &fetched_releases);
         let to_cache = select_releases_for_cache(&merged);
         write_cached_releases(self, &to_cache, cache_dir).await?;
 

--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -1,9 +1,16 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
+use tokio::fs::{create_dir_all, read_dir};
+
 use crate::filesystem::utils::get_safe_filename;
 use crate::variants::GameVariant;
-use tokio::fs::{create_dir_all, read_dir};
+
+pub fn get_default_releases_file_path(variant: &GameVariant, resources_dir: &Path) -> PathBuf {
+    resources_dir
+        .join("releases")
+        .join(format!("{}.json", variant.id()))
+}
 
 pub fn get_releases_cache_filepath(variant: &GameVariant, cache_dir: &Path) -> PathBuf {
     cache_dir

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -37,8 +37,13 @@ pub enum GameReleaseStatus {
 }
 
 impl GameRelease {
-    pub async fn get_asset(&self, os: &str, cache_dir: &Path) -> Option<GitHubAsset> {
-        let assets = get_assets(self, cache_dir).await;
+    pub async fn get_asset(
+        &self,
+        os: &str,
+        cache_dir: &Path,
+        resources_dir: &Path,
+    ) -> Option<GitHubAsset> {
+        let assets = get_assets(self, cache_dir, resources_dir).await;
 
         get_platform_asset_substr(&self.variant, os)
             .and_then(|substring| assets.into_iter().find(|a| a.name.contains(substring)))

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -31,10 +31,19 @@ pub async fn install_release(
 ) -> Result<GameRelease, InstallReleaseCommandError> {
     let cache_dir = app_handle.path().app_cache_dir()?;
     let data_dir = app_handle.path().app_local_data_dir()?;
+    let resource_dir = app_handle.path().resource_dir()?;
 
-    let mut release = get_release_by_id(&variant, release_id, OS, &cache_dir, &data_dir).await?;
+    let mut release = get_release_by_id(
+        &variant,
+        release_id,
+        OS,
+        &cache_dir,
+        &data_dir,
+        &resource_dir,
+    )
+    .await?;
     release
-        .install_release(&HTTP_CLIENT, OS, &cache_dir, &data_dir)
+        .install_release(&HTTP_CLIENT, OS, &cache_dir, &data_dir, &resource_dir)
         .await?;
 
     Ok(release)

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -43,10 +43,11 @@ impl GameRelease {
         os: &str,
         cache_dir: &Path,
         data_dir: &Path,
+        resources_dir: &Path,
     ) -> Result<(), ReleaseInstallationError> {
         if self.status == GameReleaseStatus::Unknown {
             self.status = self
-                .get_installation_status(os, cache_dir, data_dir)
+                .get_installation_status(os, cache_dir, data_dir, resources_dir)
                 .await?;
         }
 
@@ -56,7 +57,7 @@ impl GameRelease {
 
         let download_dir = get_or_create_asset_download_dir(&self.variant, data_dir).await?;
         let asset = self
-            .get_asset(os, cache_dir)
+            .get_asset(os, cache_dir, resources_dir)
             .await
             .ok_or(ReleaseInstallationError::NoCompatibleAsset)?;
 

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -47,10 +47,17 @@ pub async fn get_installation_status(
 ) -> Result<GameReleaseStatus, InstallationStatusCommandError> {
     let data_dir = app_handle.path().app_local_data_dir()?;
     let cache_dir = app_handle.path().app_cache_dir()?;
+    let resource_dir = app_handle.path().resource_dir()?;
 
-    let release = get_release_by_id(&variant, release_id, OS, &cache_dir, &data_dir).await?;
+    let release = get_release_by_id(
+        &variant,
+        release_id,
+        OS,
+        &cache_dir,
+        &data_dir,
+        &resource_dir,
+    )
+    .await?;
 
-    Ok(release
-        .get_installation_status(OS, &cache_dir, &data_dir)
-        .await?)
+    Ok(release.status)
 }

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
-use tokio::fs;
-use tokio::fs::File;
+use tokio::fs::{self, File};
 use tokio::io::{self, AsyncReadExt};
 
 use crate::filesystem::paths::{
@@ -32,8 +31,9 @@ impl GameRelease {
         os: &str,
         cache_dir: &Path,
         data_dir: &Path,
+        resources_dir: &Path,
     ) -> Result<GameReleaseStatus, GetInstallationStatusError> {
-        let asset = match self.get_asset(os, cache_dir).await {
+        let asset = match self.get_asset(os, cache_dir, resources_dir).await {
             Some(asset) => asset,
             None => return Ok(GameReleaseStatus::NotAvailable),
         };

--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -33,8 +33,17 @@ pub async fn launch_game(
 ) -> Result<(), LaunchGameCommandError> {
     let data_dir = app_handle.path().app_local_data_dir()?;
     let cache_dir = app_handle.path().app_cache_dir()?;
+    let resource_dir = app_handle.path().resource_dir()?;
 
-    let release = get_release_by_id(&variant, release_id, OS, &cache_dir, &data_dir).await?;
+    let release = get_release_by_id(
+        &variant,
+        release_id,
+        OS,
+        &cache_dir,
+        &data_dir,
+        &resource_dir,
+    )
+    .await?;
 
     let time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 


### PR DESCRIPTION
- When fetching the status of an installation, check both the cached releases list and the default releases file.
- Add a helper function to `paths.rs` to centralize default releases path construction.
- Refactor business logic functions to accept `resources_dir` instead of specific sub-paths, improving consistency.
- Update `AGENTS.md` to document the new convention for directory and path handling.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use the default releases file alongside cached data when resolving releases and assets, fixing cases where versions weren’t found. Also standardized path handling by passing resources_dir and centralizing the default releases path.

- **Refactors**
  - Added get_default_releases_file_path in paths.rs.
  - Business logic now accepts resources_dir instead of specific sub-paths; updated fetch, install, status, and launch commands.
  - Updated AGENTS.md with the new directory/path handling convention.

<!-- End of auto-generated description by cubic. -->

