### PR TITLE
fix(utils): avoid logging undefined errors

### DIFF
--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function toastCL(
 ) {
   toast[level](message);
 
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && error !== undefined) {
     toast.info(JSON.stringify(error));
   }
 }


### PR DESCRIPTION
- Only stringify and log the error to the dev toast when an error object
  is actually provided (guard import.meta.DEV with error !== undefined).
  This prevents showing "undefined" in the dev toast and avoids confusing
  debug output.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent "undefined" showing in dev toasts by logging errors only when an error object exists. Keeps debug output clear and leaves normal toast behavior unchanged.

<!-- End of auto-generated description by cubic. -->

