### PR TITLE
feat(monitor): show exit and conditionally render logs

### DIFF
--- a/cat-launcher/src/components/GameSessionMonitor.tsx
+++ b/cat-launcher/src/components/GameSessionMonitor.tsx
@@ -14,7 +14,7 @@ import { copyToClipboard, toastCL } from "@/lib/utils";
 import { GameStatus, useGameSessionEvents } from "@/providers/hooks";
 
 const GameSessionMonitor = () => {
-  const { gameStatus, logsText, resetGameSessionMonitor } =
+  const { gameStatus, logsText, exitCode, resetGameSessionMonitor } =
     useGameSessionEvents();
 
   return (
@@ -22,33 +22,48 @@ const GameSessionMonitor = () => {
       open={gameStatus === GameStatus.CRASHED}
       onOpenChange={resetGameSessionMonitor}
     >
-      <DialogContent className="max-w-4xl">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Game exited unexpectedly</DialogTitle>
           <DialogDescription>
-            The game may have crashed or exited with an error. Here are the
-            logs:
+            The game may have crashed or exited with an error.
           </DialogDescription>
         </DialogHeader>
-        <div className="max-h-96 overflow-y-auto bg-muted p-4 rounded-md">
-          <pre className="text-sm">{logsText}</pre>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold">Exit Status</h3>
+          <pre className="text-sm bg-muted p-4 rounded-md">
+            {exitCode ?? "Unknown"}
+          </pre>
         </div>
+
+        {logsText && (
+          <div className="flex flex-col gap-2">
+            <h3 className="font-semibold">Logs</h3>
+            <pre className="text-sm bg-muted p-4 rounded-md whitespace-pre-wrap max-h-[200px] overflow-auto">
+              {logsText}
+            </pre>
+          </div>
+        )}
+
         <DialogFooter>
-          <Button
-            onClick={() => {
-              copyToClipboard(logsText)
-                .then(() => {
-                  toastCL("success", "Logs copied to clipboard");
-                })
-                .catch((error) => {
-                  toastCL("error", "Error copying logs", error);
-                });
-            }}
-            variant={"ghost"}
-          >
-            <Copy />
-            Copy Logs
-          </Button>
+          {logsText && (
+            <Button
+              onClick={() => {
+                copyToClipboard(logsText)
+                  .then(() => {
+                    toastCL("success", "Logs copied to clipboard");
+                  })
+                  .catch((error) => {
+                    toastCL("error", "Error copying logs", error);
+                  });
+              }}
+              variant={"ghost"}
+            >
+              <Copy />
+              Copy Logs
+            </Button>
+          )}
           <DialogClose asChild>
             <Button>Close</Button>
           </DialogClose>


### PR DESCRIPTION
Add exitCode state to useGameSessionEvents and expose it to the
GameSessionMonitor so the crash dialog shows the process exit status.
Reset exitCode when clearing the monitor. Preserve previous behavior:
clear logs and IDLE status on successful (0) exits, mark CRASHED
for non-zero or null/signal terminations. Log abnormal exits and errors
for easier debugging.

Update the crash dialog UI to:
- show an "Exit Status" section with the exit code or "Unknown"
- render the "Logs" section and "Copy Logs" button only when logs exist
- make the logs area scrollable and preserve whitespace

These changes improve crash diagnostics and avoid showing empty log
controls when no logs are available.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show the process exit status in the crash dialog and only render logs when they exist to improve crash diagnostics and avoid empty controls. The monitor now tracks exit codes and resets cleanly.

- **New Features**
  - Exit Status section shows the exit code or “Unknown”.
  - Logs section and Copy Logs button render only when logs exist.
  - Logs area is scrollable and preserves whitespace.

- **Behavior**
  - Track exitCode in useGameSessionEvents; reset on monitor clear.
  - Exit code 0: clear logs and set status to IDLE.
  - Non-zero or null: set status to CRASHED; log abnormal exits and errors.

<!-- End of auto-generated description by cubic. -->

