### PR TITLE
feat(launcher): add OS parameter to filesystem and backup helpers

### DIFF
--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -6,6 +6,7 @@ use ts_rs::TS;
 use crate::fetch_releases::utils::get_assets;
 use crate::game_release::utils::get_platform_asset_substr;
 use crate::infra::github::asset::GitHubAsset;
+use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, TS)]
@@ -39,13 +40,13 @@ pub enum GameReleaseStatus {
 impl GameRelease {
     pub async fn get_asset(
         &self,
-        os: &str,
+        os: &OS,
         cache_dir: &Path,
         resources_dir: &Path,
     ) -> Option<GitHubAsset> {
         let assets = get_assets(self, cache_dir, resources_dir).await;
+        let substring = get_platform_asset_substr(&self.variant, os);
 
-        get_platform_asset_substr(&self.variant, os)
-            .and_then(|substring| assets.into_iter().find(|a| a.name.contains(substring)))
+        assets.into_iter().find(|a| a.name.contains(substring))
     }
 }

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -3,21 +3,21 @@ use std::path::Path;
 use crate::fetch_releases::utils::{get_cached_releases, get_default_releases, merge_releases};
 use crate::game_release::game_release::{GameReleaseStatus, ReleaseType};
 use crate::game_release::GameRelease;
+use crate::infra::utils::OS;
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
-pub fn get_platform_asset_substr(variant: &GameVariant, os: &str) -> Option<&'static str> {
+pub fn get_platform_asset_substr(variant: &GameVariant, os: &OS) -> &'static str {
     match (variant, os) {
-        (GameVariant::DarkDaysAhead, "windows") => Some("windows-with-graphics-and-sounds"),
-        (GameVariant::DarkDaysAhead, "macos") => Some("osx-terminal-only"),
-        (GameVariant::DarkDaysAhead, "linux") => Some("linux-with-graphics-and-sounds"),
-        (GameVariant::BrightNights, "windows") => Some("windows-tiles"),
-        (GameVariant::BrightNights, "macos") => Some("osx-tiles-arm"),
-        (GameVariant::BrightNights, "linux") => Some("linux-tiles"),
-        (GameVariant::TheLastGeneration, "windows") => Some("windows-tiles-sounds-x64-msvc"),
-        (GameVariant::TheLastGeneration, "macos") => Some("osx-tiles-universal"),
-        (GameVariant::TheLastGeneration, "linux") => Some("linux-tiles-sounds"),
-        _ => None,
+        (GameVariant::DarkDaysAhead, OS::Windows) => "windows-with-graphics-and-sounds",
+        (GameVariant::DarkDaysAhead, OS::MacOS) => "osx-terminal-only",
+        (GameVariant::DarkDaysAhead, OS::Linux) => "linux-with-graphics-and-sounds",
+        (GameVariant::BrightNights, OS::Windows) => "windows-tiles",
+        (GameVariant::BrightNights, OS::MacOS) => "osx-tiles-arm",
+        (GameVariant::BrightNights, OS::Linux) => "linux-tiles",
+        (GameVariant::TheLastGeneration, OS::Windows) => "windows-tiles-sounds-x64-msvc",
+        (GameVariant::TheLastGeneration, OS::MacOS) => "osx-tiles-universal",
+        (GameVariant::TheLastGeneration, OS::Linux) => "linux-tiles-sounds",
     }
 }
 
@@ -33,7 +33,7 @@ pub enum GetReleaseError {
 pub async fn get_release_by_id(
     variant: &GameVariant,
     release_id: &str,
-    os: &str,
+    os: &OS,
     cache_dir: &Path,
     data_dir: &Path,
     resources_dir: &Path,

--- a/cat-launcher/src-tauri/src/infra/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/utils.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::Path;
 
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tokio::fs;
 
 use crate::variants::GameVariant;
@@ -45,4 +46,26 @@ pub async fn write_to_file<T: serde::Serialize>(
     let contents = serde_json::to_string_pretty(data)?;
     fs::write(path, contents).await?;
     Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+pub enum OS {
+    Linux,
+    Windows,
+    MacOS,
+}
+
+#[derive(Debug, thiserror::Error, Serialize)]
+#[error("OS not supported: {os}")]
+pub struct OSNotSupportedError {
+    os: &'static str,
+}
+
+pub fn get_os_enum(os: &'static str) -> Result<OS, OSNotSupportedError> {
+    match os {
+        "linux" => Ok(OS::Linux),
+        "windows" => Ok(OS::Windows),
+        "macos" => Ok(OS::MacOS),
+        _ => Err(OSNotSupportedError { os }),
+    }
 }

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -10,6 +10,7 @@ use crate::game_release::game_release::{GameRelease, GameReleaseStatus};
 use crate::infra::archive::{extract_archive, ExtractionError};
 use crate::infra::github::asset::AssetDownloadError;
 use crate::infra::http_client::create_downloader;
+use crate::infra::utils::OS;
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 
 #[derive(thiserror::Error, Debug)]
@@ -40,7 +41,7 @@ impl GameRelease {
     pub async fn install_release(
         &mut self,
         client: &Client,
-        os: &str,
+        os: &OS,
         cache_dir: &Path,
         data_dir: &Path,
         resources_dir: &Path,

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -7,6 +7,7 @@ use tauri::{command, AppHandle, Manager};
 
 use crate::game_release::game_release::GameReleaseStatus;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
@@ -20,6 +21,9 @@ pub enum InstallationStatusCommandError {
 
     #[error("failed to obtain release: {0}")]
     Release(#[from] GetReleaseError),
+
+    #[error("failed to get OS enum: {0}")]
+    Os(#[from] OSNotSupportedError),
 }
 
 impl serde::Serialize for InstallationStatusCommandError {
@@ -49,10 +53,12 @@ pub async fn get_installation_status(
     let cache_dir = app_handle.path().app_cache_dir()?;
     let resource_dir = app_handle.path().resource_dir()?;
 
+    let os = get_os_enum(OS)?;
+
     let release = get_release_by_id(
         &variant,
         release_id,
-        OS,
+        &os,
         &cache_dir,
         &data_dir,
         &resource_dir,

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -9,6 +9,7 @@ use crate::filesystem::paths::{
     AssetExtractionDirError, GetExecutablePathError,
 };
 use crate::game_release::game_release::{GameRelease, GameReleaseStatus};
+use crate::infra::utils::OS;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetInstallationStatusError {
@@ -28,7 +29,7 @@ pub enum GetInstallationStatusError {
 impl GameRelease {
     pub async fn get_installation_status(
         &self,
-        os: &str,
+        os: &OS,
         cache_dir: &Path,
         data_dir: &Path,
         resources_dir: &Path,
@@ -57,7 +58,7 @@ impl GameRelease {
         // be downloaded.
 
         let executable_path =
-            match get_game_executable_filepath(&self.variant, &self.version, os, data_dir).await {
+            match get_game_executable_filepath(&self.variant, &self.version, data_dir, os).await {
                 Ok(path) => path,
                 Err(GetExecutablePathError::DoesNotExist) => {
                     return Ok(GameReleaseStatus::NotDownloaded)

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -15,6 +15,7 @@ use crate::filesystem::paths::{
 };
 use crate::game_release::game_release::GameRelease;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
+use crate::infra::utils::OS;
 use crate::last_played::last_played::LastPlayedError;
 use crate::launch_game::utils::{backup_and_copy_save_files, BackupAndCopyError};
 use crate::variants::GameVariant;
@@ -79,12 +80,12 @@ pub struct GameExitPayload {
 impl GameRelease {
     pub async fn prepare_launch(
         &self,
-        os: &str,
+        os: &OS,
         timestamp: u64,
         data_dir: &Path,
     ) -> Result<Command, LaunchGameError> {
         let executable_path =
-            get_game_executable_filepath(&self.variant, &self.version, os, data_dir).await?;
+            get_game_executable_filepath(&self.variant, &self.version, data_dir, os).await?;
 
         let executable_dir = executable_path
             .parent()
@@ -177,7 +178,7 @@ where
 pub async fn launch_and_monitor_game<F, Fut>(
     variant: &GameVariant,
     release_id: &str,
-    os: &str,
+    os: &OS,
     timestamp: u64,
     cache_dir: &Path,
     data_dir: &Path,

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -6,6 +6,7 @@ use crate::filesystem::paths::{
     GetBackupArchivePathError, GetGameExecutableDirError, GetVersionExecutableDirError,
 };
 use crate::infra::archive::{create_zip_archive, ArchiveCreationError};
+use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -22,7 +23,7 @@ pub async fn backup_and_copy_save_files(
     to_version: &str,
     variant: &GameVariant,
     data_dir: &Path,
-    os: &str,
+    os: &OS,
     timestamp: u64,
 ) -> Result<(), BackupAndCopyError> {
     if from_version == to_version {
@@ -55,7 +56,7 @@ async fn copy_save_files(
     to_version: &str,
     variant: &GameVariant,
     data_dir: &Path,
-    os: &str,
+    os: &OS,
 ) -> Result<(), SaveCopyError> {
     let to_dir = get_game_executable_dir(variant, to_version, data_dir, os).await?;
 
@@ -113,7 +114,7 @@ async fn backup_save_files(
     variant: &GameVariant,
     version: &str,
     data_dir: &Path,
-    os: &str,
+    os: &OS,
     timestamp: u64,
 ) -> Result<(), BackupError> {
     let executable_dir = get_game_executable_dir(variant, version, data_dir, os).await?;


### PR DESCRIPTION
### **User description**
Pass the OS string through launcher functions to make path and filename
resolution OS-aware. Update utils, launch_game, and filesystem paths
to accept and forward an os argument, and adapt calls to:
- backup_save_files, copy_save_files, get_game_executable_dir,
  get_game_save_dirs, and get_or_create_backup_archive_filepath.
- get_game_executable_dir now returns the installation root on Windows
  and finds the nested Cataclysm directory on Linux/Mac.
- Launcher filename logic is revised to return platform-specific
  executable names per variant (Windows gets variant-specific .exe
  names; Linux/Mac use the generic launcher name).

This enables correct backup, copy, and executable lookup behavior across
platforms.


___

### **PR Type**
Enhancement


___

### **Description**
- Add OS parameter to filesystem and backup helper functions

- Update `get_game_executable_dir` to return platform-specific paths
  - Windows returns installation root directly
  - Linux/macOS searches for nested Cataclysm directory

- Revise `get_game_executable_filename` to return variant-specific executable names
  - Windows: variant-specific .exe files (e.g., cataclysm-bn-tiles.exe)
  - Linux/macOS: generic cataclysm-launcher name

- Thread OS parameter through backup and save file operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OS Parameter"] --> B["get_game_executable_dir"]
  A --> C["get_game_executable_filename"]
  B --> D["get_game_save_dirs"]
  B --> E["get_or_create_backup_archive_filepath"]
  D --> F["backup_and_copy_save_files"]
  E --> F
  C --> G["Variant-specific Executables"]
  B --> H["Platform-specific Paths"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>paths.rs</strong><dd><code>OS-aware path and filename resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/filesystem/paths.rs

<ul><li>Add <code>os</code> parameter to <code>get_game_executable_dir</code>, <code>get_game_save_dirs</code>, and <br><code>get_or_create_backup_archive_filepath</code> functions<br> <li> Implement OS-aware logic in <code>get_game_executable_dir</code>: return <br>installation root on Windows, search for nested Cataclysm directory on <br>Linux/macOS<br> <li> Refactor <code>get_game_executable_filename</code> to return variant-specific <br>executable names for Windows (.exe files) and generic launcher name <br>for Linux/macOS<br> <li> Update <code>get_game_executable_filepath</code> to pass <code>os</code> parameter to <br><code>get_game_executable_dir</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/88/files#diff-a63c67209f4aa5eba003895988e9711ee945d81570a43bbfa797f997299612f6">+21/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>launch_game.rs</strong><dd><code>Thread OS parameter through game launch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/launch_game/launch_game.rs

<ul><li>Add <code>os</code> parameter to <code>backup_and_copy_save_files</code> function call in <br><code>GameRelease</code> implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/88/files#diff-e0af1e526282c234e69308809193c6c834da1fe02862127f7573e52c1f7d6ec1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Thread OS parameter through backup and copy operations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/launch_game/utils.rs

<ul><li>Add <code>os</code> parameter to <code>backup_and_copy_save_files</code>, <code>backup_save_files</code>, and <br><code>copy_save_files</code> functions<br> <li> Forward <code>os</code> parameter to all filesystem helper function calls<br> <li> Update calls to <code>get_game_executable_dir</code>, <code>get_game_save_dirs</code>, and <br><code>get_or_create_backup_archive_filepath</code> with <code>os</code> argument</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/88/files#diff-beb8ce256f0a7aab66f1bec3322c303bc6a9a9d0a764baade69ac304ad753fb5">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

