### PR TITLE
feat(hooks): ignore BrightNights non-zero exit codes

### DIFF
--- a/cat-launcher/src/components/GameSessionMonitor.tsx
+++ b/cat-launcher/src/components/GameSessionMonitor.tsx
@@ -17,21 +17,34 @@ const GameSessionMonitor = () => {
   const { gameStatus, logsText, exitCode, resetGameSessionMonitor } =
     useGameSessionEvents();
 
+  const title =
+    gameStatus === GameStatus.CRASHED
+      ? "Game crashed"
+      : gameStatus === GameStatus.TERMINATED
+        ? "Game was terminated by an external source"
+        : gameStatus === GameStatus.ERROR
+          ? "Game exited unexpectedly or failed to start"
+          : null;
+
   return (
     <Dialog
-      open={gameStatus === GameStatus.CRASHED}
+      open={[
+        GameStatus.CRASHED,
+        GameStatus.ERROR,
+        GameStatus.TERMINATED,
+      ].includes(gameStatus)}
       onOpenChange={resetGameSessionMonitor}
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Game exited unexpectedly</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
-            The game may have crashed or exited with an error.
+            The following information may help you diagnose the issue.
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">Exit Status</h3>
+          <h3 className="font-semibold">Exit Code</h3>
           <pre className="text-sm bg-muted p-4 rounded-md">
             {exitCode ?? "Unknown"}
           </pre>


### PR DESCRIPTION
### **User description**
Add selection of currently playing game from the store and use it
in the frontend-ready hook to suppress crash handling for BrightNights.

Previously the hook treated any non-zero exit code as a crash and
triggered crash logs and session reset. BrightNights commonly returns
non-zero exit codes even on successful exits, which caused false crash
reports. By reading state.gameSession.currentlyPlaying and treating
BrightNights as a successful exit, the change prevents misleading crash
handling. Also add the new dependency to the effect hook to ensure it
reacts correctly when the current game changes.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent false crash reports for BrightNights game

- Add selector for currently playing game from store

- Treat BrightNights non-zero exit codes as successful

- Update effect hook dependencies for proper reactivity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Game Exit Event"] --> B["Check Exit Code"]
  B --> C["Is BrightNights?"]
  C -->|Yes or Code 0| D["Reset Session"]
  C -->|No and Code != 0| E["Mark as Crashed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Handle BrightNights non-zero exit codes gracefully</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/providers/hooks.ts

<ul><li>Import <code>useAppSelector</code> hook to access Redux store state<br> <li> Add selector to retrieve <code>currentlyPlaying</code> game from <code>gameSession</code> state<br> <li> Modify exit code handling to treat BrightNights non-zero exits as <br>successful<br> <li> Update effect hook dependencies to include <code>currentlyPlaying</code> and <br><code>resetGameSessionMonitor</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/90/files#diff-2ee707e9bcf55719d501e890089a3a4a2d4ad1581565ff6c395ab0b47fab6a58">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

