### PR TITLE
docs: add Gatekeeper disable link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ CatLauncher is 100% open-source and the .exe is built directly from the source c
 
 By default, macOS does not allow running applications from unidentified developers. To allow CatLauncher, open System Preferences > Security & Privacy > General and click on the lock icon to make changes. Then, click on the "Open Anyway" button next to CatLauncher. You should do this after trying to run the .dmg file and failing.
 
+Another way to accomplish this is by disabling Gatekeeper. See https://disable-gatekeeper.github.io/.
+
 CatLauncher is 100% open-source and the .dmg is built directly from the source code via GitHub Actions. This ensures there is no opportunity for malicious actors to tamper with the executable. CatLauncher is safe to use.
 
 ## License


### PR DESCRIPTION
### **User description**
Add an alternative instruction for macOS users to disable Gatekeeper,
linking to https://disable-gatekeeper.github.io/. Clarify that disabling
Gatekeeper is another way to run the downloaded .dmg when macOS blocks
unidentified developers, and keep reassurance about the project being
open-source and built via GitHub Actions.

This improves usability for users who prefer an explicit workaround
when the "Open Anyway" flow does not resolve launch issues.


___

### **PR Type**
Documentation


___

### **Description**
- Add Gatekeeper disable link for macOS users

- Provide alternative workaround when "Open Anyway" fails

- Reference external guide for disabling Gatekeeper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS Security Issue"] --> B["Open Anyway Method"]
  A --> C["Disable Gatekeeper Method"]
  C --> D["disable-gatekeeper.github.io"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Gatekeeper disable alternative to macOS setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added alternative instruction for disabling Gatekeeper as workaround<br> <li> Included link to https://disable-gatekeeper.github.io/<br> <li> Positioned between existing "Open Anyway" instructions and security <br>reassurance<br> <li> Maintains context about open-source nature and GitHub Actions build <br>process</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/104/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

