### PR TITLE
fix(fetch-releases): remove artificial 100-release limit

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -74,9 +74,8 @@ pub fn select_releases_for_cache(releases: &[GitHubRelease]) -> Vec<GitHubReleas
 
     non_prereleases
         .into_iter()
-        .take(100)
         .cloned()
-        .chain(prereleases.into_iter().take(100).cloned())
+        .chain(prereleases.into_iter().cloned())
         .collect()
 }
 


### PR DESCRIPTION
Drop the hard-coded .take(100) caps when combining non-prerelease
and prerelease iterators in fetch_releases utils. Previously the code
truncated each iterator to 100 items which could silently discard
relevant releases. Removing the limits ensures all available releases
are considered and prevents unexpected data loss when more than 100
entries exist.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the hard-coded 100-item limit when selecting releases for the cache, so all non-prerelease and prerelease entries are included. This prevents silent truncation and unexpected data loss when more than 100 releases exist.

<!-- End of auto-generated description by cubic. -->

