### PR TITLE
feat(ui): require release selection before play action

### DIFF
--- a/cat-launcher/src/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/PlayPage/InteractionButton.tsx
@@ -37,6 +37,7 @@ export default function InteractionButton({
   const { play } = usePlayGame(variant);
 
   const actionButtonLabel = getActionButtonLabel(
+    selectedReleaseId,
     isThisVariantRunning,
     installationStatus,
     installationProgressStatus,
@@ -91,10 +92,15 @@ interface InteractionButtonProps {
 }
 
 function getActionButtonLabel(
+  selectedReleaseId: string | undefined,
   isThisVariantRunning: boolean,
   installationStatus: GameReleaseStatus,
   installationProgressStatus: InstallationProgressStatus | null,
 ) {
+  if (!selectedReleaseId) {
+    return "Select a Release to Play";
+  }
+
   if (isThisVariantRunning) {
     return "Running...";
   }


### PR DESCRIPTION
Make the Play button reflect whether a release is selected by passing
selectedReleaseId into getActionButtonLabel and returning an explicit
"Select a Release to Play" label when none is chosen.

This prevents showing misleading actions when no release is selected and
guides the user to pick a release before attempting to play.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
InteractionButton now requires a selected release before Play. It passes selectedReleaseId to getActionButtonLabel, which shows “Select a Release to Play” when none is chosen.

<!-- End of auto-generated description by cubic. -->

