### PR TITLE
fix(ui): avoid id collisions in ReleaseFilter checkboxes

### DIFF
--- a/cat-launcher/src/PlayPage/ReleaseFilter.tsx
+++ b/cat-launcher/src/PlayPage/ReleaseFilter.tsx
@@ -82,20 +82,24 @@ export default function ReleaseFilter({
 
   return (
     <div className="flex items-center space-x-4">
-      {filters.map((filter) => (
-        <div key={filter.id} className="flex items-center space-x-2">
-          <Checkbox
-            id={filter.id}
-            checked={selectedFilterIds.includes(filter.id)}
-            onCheckedChange={(checked: boolean) =>
-              handleCheckedChange(checked, filter.id)
-            }
-          />
-          <Label htmlFor={filter.id} className="text-sm font-medium">
-            {filter.label}
-          </Label>
-        </div>
-      ))}
+      {filters.map((filter) => {
+        const key = `${variant}-${filter.id}`;
+
+        return (
+          <div key={key} className="flex items-center space-x-2">
+            <Checkbox
+              id={key}
+              checked={selectedFilterIds.includes(filter.id)}
+              onCheckedChange={(checked: boolean) =>
+                handleCheckedChange(checked, filter.id)
+              }
+            />
+            <Label htmlFor={key} className="text-sm font-medium">
+              {filter.label}
+            </Label>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
Use a variant-prefixed key and id for each filter checkbox to prevent
duplicate element IDs when multiple ReleaseFilter instances render on the
same page. Keep selection logic using the filter.id for state checks and
callbacks, but bind the DOM id/Label htmlFor to `${variant}-${filter.id}`
so labels correctly target their associated inputs without colliding. This
fixes accessibility issues and unpredictable behavior caused by duplicate
IDs.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent duplicate checkbox ids and React keys in ReleaseFilter by prefixing them with the component variant. State still uses filter.id; only DOM id and Label htmlFor use the prefixed value, fixing label targeting, accessibility, and collisions when multiple instances render.

<!-- End of auto-generated description by cubic. -->

