### PR TITLE
fix(release-selector): guard and update deps for selected release

### DIFF
--- a/cat-launcher/src/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/PlayPage/ReleaseSelector.tsx
@@ -100,10 +100,13 @@ export default function ReleaseSelector({
 
   useEffect(() => {
     // Selected release may become unavailable after filtering
-    if (!comboboxItems.find((item) => item.value === selectedReleaseId)) {
+    if (
+      selectedReleaseId &&
+      !comboboxItems.find((item) => item.value === selectedReleaseId)
+    ) {
       setSelectedReleaseId(undefined);
     }
-  }, [comboboxItems, selectedReleaseId]);
+  }, [comboboxItems, selectedReleaseId, setSelectedReleaseId]);
 
   const autoselect = useCallback(
     (items: ComboboxItem[]) => {


### PR DESCRIPTION
- Prevent clearing selectedReleaseId when it's falsy by checking that a
  selectedReleaseId exists before searching comboboxItems. This avoids
  unnecessary state updates and potential flicker when no selection is
  present.
- Add setSelectedReleaseId to the useEffect dependency list to satisfy
  React Hook rules and ensure effect has correct closure dependencies.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Guarded release clearing to only run when a selection exists, preventing unnecessary state updates and flicker in the ReleaseSelector after filtering. Also added setSelectedReleaseId to the effect dependencies to follow React Hook rules and keep the effect in sync.

<!-- End of auto-generated description by cubic. -->

