### PR TITLE
perf(ui): memoize release name and handle 'cdda-' prefix

### DIFF
--- a/cat-launcher/src/PlayPage/ReleaseLabel.tsx
+++ b/cat-launcher/src/PlayPage/ReleaseLabel.tsx
@@ -4,6 +4,7 @@ import { Check, Loader2 } from "lucide-react";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { useAppSelector } from "@/store/hooks";
 import { useInstallationStatus } from "./hooks";
+import { useMemo } from "react";
 
 interface ReleaseLabelProps {
   variant: GameVariant;
@@ -11,7 +12,7 @@ interface ReleaseLabelProps {
   isLastPlayed: boolean;
 }
 
-function get_short_release_name(variant: GameVariant, version: string): string {
+function getShortReleaseName(variant: GameVariant, version: string): string {
   switch (variant) {
     case "BrightNights": {
       return version;
@@ -19,6 +20,9 @@ function get_short_release_name(variant: GameVariant, version: string): string {
     case "DarkDaysAhead": {
       if (version.startsWith("cdda-experimental-")) {
         return version.slice("cdda-experimental-".length);
+      }
+      if (version.startsWith("cdda-")) {
+        return version.slice("cdda-".length);
       }
       return version;
     }
@@ -36,7 +40,10 @@ export default function ReleaseLabel({
   version,
   isLastPlayed,
 }: ReleaseLabelProps) {
-  const shortReleaseName = get_short_release_name(variant, version);
+  const shortReleaseName = useMemo(
+    () => getShortReleaseName(variant, version),
+    [variant, version],
+  );
 
   const { installationStatus } = useInstallationStatus(variant, version);
   const progressStatus = useAppSelector(


### PR DESCRIPTION
Improve ReleaseLabel rendering by memoizing the computed short
release name with useMemo to avoid recalculating on every render.
Add handling for versions that start with the "cdda-" prefix so the
short name drops that prefix (in addition to existing
"cdda-experimental-" handling). Also import useMemo.

These changes reduce unnecessary work during render and ensure
consistent short name formatting for CDDA variants.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Memoize the short release name in ReleaseLabel to avoid recalculating on every render. Strip the "cdda-" prefix so CDDA short names are consistent (still handles "cdda-experimental-").

<!-- End of auto-generated description by cubic. -->

