### PR TITLE
feat(html): add react-scan auto script to index.html

### DIFF
--- a/cat-launcher/index.html
+++ b/cat-launcher/index.html
@@ -1,14 +1,15 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
-  </head>
+    <head>
+        <script src="https://cdn.jsdelivr.net/npm/react-scan/dist/auto.global.js"></script>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Tauri + React + Typescript</title>
+    </head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
 </html>


### PR DESCRIPTION
Include react-scan's auto.global.js via CDN in the HTML head so the
library initializes automatically for the app. This change injects the
script tag before existing meta and title tags and keeps existing
structure intact. Formatting adjusted to consistent indentation.

Reason: enable automatic scanning/initialization of React components
in the launcher without additional manual imports in source files.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add react-scan auto script via CDN to index.html so the app initializes react-scan automatically at runtime. Enables React component scanning without imports or code changes.

<!-- End of auto-generated description by cubic. -->

