### PR TITLE
feat(play): backup on game start

### DIFF
--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -27,11 +27,12 @@ pub async fn backup_and_copy_save_files(
     os: &OS,
     timestamp: u64,
 ) -> Result<(), BackupAndCopyError> {
+    backup_save_files(variant, from_version, data_dir, os, timestamp).await?;
+
+    // Don't need to copy save files if the versions are the same
     if from_version == to_version {
         return Ok(());
     }
-
-    backup_save_files(variant, from_version, data_dir, os, timestamp).await?;
     copy_save_files(from_version, to_version, variant, data_dir, os).await?;
 
     Ok(())

--- a/cat-launcher/src/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/PlayPage/InteractionButton.tsx
@@ -34,11 +34,11 @@ export default function InteractionButton({
     selectedReleaseId,
   );
 
-  const { play } = usePlayGame(variant);
+  const { play, isStartingGame } = usePlayGame(variant);
 
   const actionButtonLabel = getActionButtonLabel(
     selectedReleaseId,
-    isThisVariantRunning,
+    isThisVariantRunning || isStartingGame,
     installationStatus,
     installationProgressStatus,
   );
@@ -52,7 +52,8 @@ export default function InteractionButton({
     installationProgressStatus === "Installing" ||
     // Only one variant should be running at a time.
     // Disable button if any variant is already running.
-    isAnyVariantRunning;
+    isAnyVariantRunning ||
+    isStartingGame;
 
   const button = (
     <Button
@@ -93,7 +94,7 @@ interface InteractionButtonProps {
 
 function getActionButtonLabel(
   selectedReleaseId: string | undefined,
-  isThisVariantRunning: boolean,
+  isRunning: boolean,
   installationStatus: GameReleaseStatus,
   installationProgressStatus: InstallationProgressStatus | null,
 ) {
@@ -101,7 +102,7 @@ function getActionButtonLabel(
     return "Select a Release to Play";
   }
 
-  if (isThisVariantRunning) {
+  if (isRunning) {
     return "Running...";
   }
 

--- a/cat-launcher/src/PlayPage/hooks.ts
+++ b/cat-launcher/src/PlayPage/hooks.ts
@@ -208,7 +208,7 @@ export function useInstallationStatus(
 export function usePlayGame(variant: GameVariant) {
   const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
-  const { mutate: play } = useMutation({
+  const { mutate: play, isPending: isStartingGame } = useMutation({
     mutationFn: (releaseId: string | undefined) => {
       if (!releaseId) {
         throw new Error("No release selected");
@@ -227,5 +227,5 @@ export function usePlayGame(variant: GameVariant) {
     },
   });
 
-  return { play };
+  return { play, isStartingGame };
 }


### PR DESCRIPTION
- Expose isStartingGame from useMutation in usePlayGame and return it
  alongside play so callers can detect when a game launch is pending.
- Use isStartingGame in InteractionButton to:
  - include starting state in action label logic (now treated as running)
  - disable the action button when a game is starting (prevent multiple
    launches)
- Rename getActionButtonLabel parameter to isRunning for clarity.

fix(launch): avoid double backup when launching same version

- Move backup_save_files call before equality check and remove duplicate
  call so backups are always created, but copy_save_files is skipped when
  from_version == to_version. This ensures a backup exists even if no
  file copy is required.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Create a save backup at game start and prevent double backups when launching the same version. Also treat “starting” as running and disable Play to avoid duplicate launches.

- **New Features**
  - Expose isStartingGame from usePlayGame and use it in InteractionButton.
  - Show “Running...” while starting and disable the button during launch.
  - Rename getActionButtonLabel parameter to isRunning for clarity.

- **Bug Fixes**
  - Call backup_save_files before the version equality check and remove the duplicate call. Backup always runs; copy is skipped when from_version == to_version.

<!-- End of auto-generated description by cubic. -->

