### PR TITLE
feat(game-release): match multiple platform asset substrings

### DIFF
--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::fetch_releases::utils::get_assets;
-use crate::game_release::utils::get_platform_asset_substr;
+use crate::game_release::utils::get_platform_asset_substrs;
 use crate::infra::github::asset::GitHubAsset;
 use crate::infra::utils::{Arch, OS};
 use crate::variants::GameVariant;
@@ -48,8 +48,11 @@ impl GameRelease {
         resources_dir: &Path,
     ) -> Option<GitHubAsset> {
         let assets = get_assets(self, cache_dir, resources_dir).await;
-        let substring = get_platform_asset_substr(&self.variant, os, arch);
+        let substrings = get_platform_asset_substrs(&self.variant, os, arch);
 
-        assets.into_iter().find(|a| a.name.contains(substring))
+        substrings
+            .iter()
+            .find_map(|substr| assets.iter().find(|a| a.name.contains(substr)))
+            .cloned()
     }
 }

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -7,18 +7,28 @@ use crate::infra::utils::{Arch, OS};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
-pub fn get_platform_asset_substr(variant: &GameVariant, os: &OS, arch: &Arch) -> &'static str {
+pub fn get_platform_asset_substrs(
+    variant: &GameVariant,
+    os: &OS,
+    arch: &Arch,
+) -> Vec<&'static str> {
     match (variant, os, arch) {
-        (GameVariant::DarkDaysAhead, OS::Windows, _) => "windows-with-graphics-and-sounds",
-        (GameVariant::DarkDaysAhead, OS::MacOS, _) => "osx-terminal-only",
-        (GameVariant::DarkDaysAhead, OS::Linux, _) => "linux-with-graphics-and-sounds",
-        (GameVariant::BrightNights, OS::Windows, _) => "windows-tiles",
-        (GameVariant::BrightNights, OS::MacOS, Arch::ARM64) => "osx-tiles-arm",
-        (GameVariant::BrightNights, OS::MacOS, Arch::X64) => "osx-tiles-x64",
-        (GameVariant::BrightNights, OS::Linux, _) => "linux-tiles",
-        (GameVariant::TheLastGeneration, OS::Windows, _) => "windows-tiles-sounds-x64-msvc",
-        (GameVariant::TheLastGeneration, OS::MacOS, _) => "osx-tiles-universal",
-        (GameVariant::TheLastGeneration, OS::Linux, _) => "linux-tiles-sounds",
+        (GameVariant::DarkDaysAhead, OS::Windows, _) => vec!["windows-with-graphics-and-sounds"],
+        (GameVariant::DarkDaysAhead, OS::MacOS, _) => {
+            vec!["osx-with-graphics", "osx-terminal-only"]
+        }
+        (GameVariant::DarkDaysAhead, OS::Linux, _) => vec!["linux-with-graphics-and-sounds"],
+
+        (GameVariant::BrightNights, OS::Windows, _) => vec!["windows-tiles"],
+        (GameVariant::BrightNights, OS::MacOS, Arch::ARM64) => vec!["osx-tiles-arm"],
+        (GameVariant::BrightNights, OS::MacOS, Arch::X64) => vec!["osx-tiles-x64"],
+        (GameVariant::BrightNights, OS::Linux, _) => vec!["linux-tiles"],
+
+        (GameVariant::TheLastGeneration, OS::Windows, _) => {
+            vec!["windows-tiles-sounds-x64-msvc"]
+        }
+        (GameVariant::TheLastGeneration, OS::MacOS, _) => vec!["osx-tiles-universal"],
+        (GameVariant::TheLastGeneration, OS::Linux, _) => vec!["linux-tiles-sounds"],
     }
 }
 


### PR DESCRIPTION
Update asset selection to consider candidate substrings per
variant/OS/arch combination and return the first matching asset.

- Rename get_platform_asset_substr to get_platform_asset_substrs and
  change its signature to return Vec<&'static str>.
- Expand DarkDaysAhead macOS mapping to prefer "osx-with-graphics"
  before falling back to "osx-terminal-only".
- Modify get_release_asset to iterate over substrings and return the
  first asset whose name contains any of them, returning None if none
  match.

This allows more flexible matching for macOS assets and improves asset
selection robustness across variants and architectures.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable matching multiple platform asset substrings during release asset selection, returning the first match. Improves macOS asset selection for DarkDaysAhead by preferring "osx-with-graphics" before falling back to "osx-terminal-only".

- **New Features**
  - Asset selection checks a list of substrings per variant/OS/arch and returns the first matching asset; None if no match.

- **Refactors**
  - Renamed get_platform_asset_substr to get_platform_asset_substrs; it now returns Vec<&'static str>.

<!-- End of auto-generated description by cubic. -->

