### PR TITLE
feat(ui): add virtualized combobox for release selector

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-devtools": "^0.7.6",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",
+    "@tanstack/react-virtual": "^3.13.12",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-opener": "~2",
     "@tauri-apps/plugin-updater": "~2.9.0",

--- a/cat-launcher/pnpm-lock.yaml
+++ b/cat-launcher/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.90.2
         version: 5.90.2(@tanstack/react-query@5.90.2(react@19.2.0))(react@19.2.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tauri-apps/api':
         specifier: ^2.8.0
         version: 2.8.0
@@ -1004,6 +1007,15 @@ packages:
     resolution: {integrity: sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@tauri-apps/api@2.8.0':
     resolution: {integrity: sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==}
@@ -2460,6 +2472,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.2
       react: 19.2.0
+
+  '@tanstack/react-virtual@3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@tauri-apps/api@2.8.0': {}
 

--- a/cat-launcher/src/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/PlayPage/ReleaseSelector.tsx
@@ -3,7 +3,10 @@ import { RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import Combobox, { ComboboxItem } from "@/components/ui/combobox";
+import {
+  VirtualizedCombobox,
+  type ComboboxItem,
+} from "@/components/virtualized-combobox";
 import type { GameRelease } from "@/generated-types/GameRelease";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import {
@@ -147,7 +150,7 @@ export default function ReleaseSelector({
       />
       <div className="flex items-end gap-2">
         <div className="flex-grow">
-          <Combobox
+          <VirtualizedCombobox
             label="Version"
             items={comboboxItems}
             value={selectedReleaseId}

--- a/cat-launcher/src/components/virtualized-combobox.tsx
+++ b/cat-launcher/src/components/virtualized-combobox.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ChevronsUpDown } from "lucide-react";
+import { ReactNode, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export interface ComboboxItem {
+  value: string;
+  label: ReactNode;
+}
+
+interface VirtualizedCommandProps {
+  height: string;
+  items: ComboboxItem[];
+  placeholder: string;
+  value?: string;
+  onSelect?: (value: string) => void;
+}
+
+const VirtualizedCommand = ({
+  height,
+  items,
+  placeholder,
+  value,
+  onSelect,
+}: VirtualizedCommandProps) => {
+  const [filteredItems, setFilteredItems] = useState<ComboboxItem[]>(items);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  const parentRef = useRef<HTMLDivElement | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count: filteredItems.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 35,
+    overscan: 5,
+  });
+
+  const virtualOptions = virtualizer.getVirtualItems();
+
+  const handleSearch = (search: string) => {
+    setFilteredItems(
+      items.filter((option) =>
+        option.value.toLowerCase().includes(search.toLowerCase()),
+      ),
+    );
+  };
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+
+    const option = filteredItems.find((option) => option.value === value);
+    if (!option) {
+      return;
+    }
+
+    const index = filteredItems.indexOf(option);
+    setFocusedIndex(index);
+    virtualizer.scrollToIndex(index, {
+      align: "center",
+    });
+  }, [value, filteredItems, virtualizer]);
+
+  return (
+    <Command shouldFilter={false}>
+      <CommandInput onValueChange={handleSearch} placeholder={placeholder} />
+      <CommandList
+        ref={parentRef}
+        style={{
+          height: height,
+          width: "100%",
+          overflow: "auto",
+        }}
+      >
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup>
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualOptions.map((virtualOption) => (
+              <CommandItem
+                key={filteredItems[virtualOption.index].value}
+                className={cn(
+                  "absolute left-0 top-0 w-full bg-transparent",
+                  focusedIndex === virtualOption.index &&
+                    "bg-accent text-accent-foreground",
+                )}
+                style={{
+                  height: `${virtualOption.size}px`,
+                  transform: `translateY(${virtualOption.start}px)`,
+                }}
+                value={filteredItems[virtualOption.index].value}
+                onMouseEnter={() => setFocusedIndex(virtualOption.index)}
+                onMouseLeave={() => setFocusedIndex(-1)}
+                onSelect={onSelect}
+              >
+                {filteredItems[virtualOption.index].label}
+              </CommandItem>
+            ))}
+          </div>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+};
+
+interface ComboboxProps {
+  items: ComboboxItem[];
+  value?: string;
+  label?: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  autoselect?: boolean | ((items: ComboboxItem[]) => ComboboxItem | undefined);
+  className?: string;
+}
+
+export function VirtualizedCombobox({
+  items,
+  value,
+  onChange,
+  label,
+  placeholder,
+  disabled,
+  autoselect,
+  className,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  // Auto-select an item if autoselect is enabled.
+  useEffect(() => {
+    if (value || items.length === 0 || !autoselect) {
+      return;
+    }
+
+    let selectedValue: string | undefined;
+
+    if (typeof autoselect === "function") {
+      selectedValue = autoselect(items)?.value;
+    } else if (autoselect) {
+      selectedValue = items[0]?.value;
+    }
+
+    if (selectedValue) {
+      onChange(selectedValue);
+    }
+  }, [autoselect, value, items, onChange]);
+
+  return (
+    <div className={className}>
+      {label ? (
+        <div className="text-sm text-muted-foreground mb-2">{label}</div>
+      ) : null}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className="w-full"
+          >
+            <div className="flex items-center justify-between w-full">
+              {value
+                ? items.find((i) => i.value === value)?.label
+                : placeholder}
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </div>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="p-0">
+          <VirtualizedCommand
+            height="400px"
+            items={items}
+            placeholder="Search..."
+            value={value}
+            onSelect={(currentValue) => {
+              const selectedValue = items.find(
+                (i) => i.value === currentValue,
+              )?.value;
+              if (selectedValue === undefined) {
+                throw new Error("Combobox: Selected value not found in items");
+              }
+              onChange(selectedValue);
+              setOpen(false);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export default VirtualizedCombobox;


### PR DESCRIPTION
Replace the existing Combobox with a VirtualizedCombobox to improve
performance when rendering long lists of game releases. Implement a new
virtualized-combobox component that uses @tanstack/react-virtual to
virtualize command list items, supports search filtering, focused-item
scrolling, and exposes a ComboboxItem type for compatibility.

Update the PlayPage ReleaseSelector to import and render
VirtualizedCombobox instead of the previous Combobox.

Add @tanstack/react-virtual and @tanstack/virtual-core entries to the
pnpm lockfile to pin the new dependency and its peer dependencies.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the ReleaseSelector’s Combobox with a virtualized version to speed up long release lists and make search and scrolling smoother.

- **New Features**
  - Added VirtualizedCombobox using @tanstack/react-virtual to virtualize list items for fast rendering.
  - Supports search filtering and focused-item scrolling; keeps the ComboboxItem type for drop-in compatibility.

- **Dependencies**
  - Added @tanstack/react-virtual and @tanstack/virtual-core.

<!-- End of auto-generated description by cubic. -->

