### PR TITLE
feat(paths): separate saves and configs

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -195,6 +195,18 @@ pub async fn get_game_save_dirs(
     data_dir: &Path,
     os: &OS,
 ) -> Result<Vec<PathBuf>, GetGameExecutableDirError> {
+    let dirs = &["save"];
+
+    let executable_dir = get_game_executable_dir(variant, release_version, data_dir, os).await?;
+    Ok(dirs.iter().map(|d| executable_dir.join(d)).collect())
+}
+
+pub async fn get_game_save_and_config_dirs(
+    variant: &GameVariant,
+    release_version: &str,
+    data_dir: &Path,
+    os: &OS,
+) -> Result<Vec<PathBuf>, GetGameExecutableDirError> {
     let dirs = &[
         "achievements",
         "config",

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -2,8 +2,9 @@ use std::io;
 use std::path::Path;
 
 use crate::filesystem::paths::{
-    get_game_executable_dir, get_game_save_dirs, get_or_create_backup_archive_filepath,
-    GetBackupArchivePathError, GetGameExecutableDirError, GetVersionExecutableDirError,
+    get_game_executable_dir, get_game_save_and_config_dirs, get_game_save_dirs,
+    get_or_create_backup_archive_filepath, GetBackupArchivePathError, GetGameExecutableDirError,
+    GetVersionExecutableDirError,
 };
 use crate::filesystem::utils::{copy_dir_all, CopyDirError};
 use crate::infra::archive::{create_zip_archive, ArchiveCreationError};
@@ -33,7 +34,7 @@ pub async fn backup_and_copy_save_files(
     if from_version == to_version {
         return Ok(());
     }
-    copy_save_files(from_version, to_version, variant, data_dir, os).await?;
+    copy_save_and_config_files(from_version, to_version, variant, data_dir, os).await?;
 
     Ok(())
 }
@@ -56,7 +57,7 @@ pub enum SaveCopyError {
     Copy(#[from] CopyDirError),
 }
 
-async fn copy_save_files(
+async fn copy_save_and_config_files(
     from_version: &str,
     to_version: &str,
     variant: &GameVariant,
@@ -65,7 +66,7 @@ async fn copy_save_files(
 ) -> Result<(), SaveCopyError> {
     let to_dir = get_game_executable_dir(variant, to_version, data_dir, os).await?;
 
-    let save_dirs = get_game_save_dirs(variant, from_version, data_dir, os).await?;
+    let save_dirs = get_game_save_and_config_dirs(variant, from_version, data_dir, os).await?;
 
     for save_dir in save_dirs {
         if let Ok(metadata) = tokio::fs::metadata(&save_dir).await {


### PR DESCRIPTION
Add get_game_save_and_config_dirs to both save and config
subdirectories within a game's executable directory. Update launch
utilities to use this combined resolver when copying between versions
so both save files and config are preserved during version migration.

- Introduce get_game_save_and_config_dirs in filesystem paths module.
- Switch launch_game utils to call copy_save_and_config_files and
  get_game_save_and_config_dirs.
- Rename internal copy function from copy_save_files to
  copy_save_and_config_files and wire it into the version migration
  flow.

This ensures config data is migrated alongside saves to reduce data
loss when changing game versions.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Preserves both save files and config when migrating between game versions to prevent data loss.

- **New Features**
  - Added get_game_save_and_config_dirs to resolve save and config folders in the game executable directory.
  - Updated migration to use copy_save_and_config_files with the unified resolver.

- **Refactors**
  - Renamed copy_save_files to copy_save_and_config_files and integrated it into the version migration flow.

<!-- End of auto-generated description by cubic. -->

