### PR TITLE
docs: clarify macOS .dmg selection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ CatLauncher is 100% open-source and the .exe is built directly from the source c
 
 By default, macOS does not allow running applications from unidentified developers. To allow CatLauncher, open System Preferences > Security & Privacy > General and click on the lock icon to make changes. Then, click on the "Open Anyway" button next to CatLauncher. You should do this after trying to run the .dmg file and failing.
 
+Ensure that you download the correct .dmg file depending on your macOS architecture. You can check your macOS architecture by running the command `uname -m` in the terminal. If the output is `x86_64`, download the `x86_64.dmg` file. If the output is `arm64`, download the `arm64.dmg` file.
+
 Another way to accomplish this is by disabling Gatekeeper. See https://disable-gatekeeper.github.io/.
 
 CatLauncher is 100% open-source and the .dmg is built directly from the source code via GitHub Actions. This ensures there is no opportunity for malicious actors to tamper with the executable. CatLauncher is safe to use.


### PR DESCRIPTION
Add guidance to README on choosing the correct .dmg for macOS
architecture and how to check it via `uname -m`. Explain which
download to use for `x86_64` and `arm64` outputs so users run the
appropriate binary their machine.

This reduces user confusion and prevents running incompatible
installers on Apple Silicon vs Intel Macs.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified macOS download instructions in the README to help users choose the correct .dmg for their CPU (x86_64 vs arm64) using uname -m. This prevents installing the wrong binary on Apple Silicon and Intel Macs.

<!-- End of auto-generated description by cubic. -->

