### PR TITLE
chore(re): bump version to 0.5.0

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dmg",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
Update project version from 0.4.1 to 0.5.0 across Tauri and JS
manifests. Files changed:
- src-tauri/tauri.conf.json
- src-tauri/Cargo.toml
- src-tauri/Cargo.lock
- package.json

This prepares the codebase for the 0.5.0 release and ensures
consistent versioning between Rust and JavaScript packages.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the app version to 0.5.0 across package.json, Cargo.toml/Cargo.lock, and tauri.conf.json to prepare the release and keep Rust and JavaScript packages in sync. No functional changes.

<!-- End of auto-generated description by cubic. -->

