### PR TITLE
chore(tauri): set bundle targets to "all" instead of array

### DIFF
--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "dmg", "nsis", "rpm"],
+    "targets": "all",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Change the Tauri bundle configuration in tauri.conf.json to use
string "all" for the targets field rather than an explicit array of
["deb", "dmg", "nsis", "rpm"]. This simplifies the configuration and
ensures the bundler builds all supported targets without listing them
manually.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use "all" for Tauri bundle targets in tauri.conf.json so builds include all supported installers automatically (deb, dmg, nsis, rpm, etc.).
This simplifies the config and avoids manual updates when Tauri adds or changes targets.

<!-- End of auto-generated description by cubic. -->

