### PR TITLE
docs: add AppImage to installers and usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An opinionated cross-platform launcher for Cataclysm games with modern social fe
 
 - Windows: .exe
 - macOS: .dmg
-- Linux: .deb, .rpm
+- Linux: .deb, .rpm, .AppImage
 
 ### Windows
 
@@ -38,6 +38,14 @@ Ensure that you download the correct .dmg file depending on your macOS architect
 Another way to accomplish this is by disabling Gatekeeper. See https://disable-gatekeeper.github.io/.
 
 CatLauncher is 100% open-source and the .dmg is built directly from the source code via GitHub Actions. This ensures there is no opportunity for malicious actors to tamper with the executable. CatLauncher is safe to use.
+
+### Linux
+
+Downloading the AppImage is the easiest way to install CatLauncher and keep it automatically up-to-date. However, the AppImage may not work on all Linux distros. It's been tested to work on Ubuntu 24.04.
+
+To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.5.1_amd64.AppImage`, and then run it like you would any other executable.
+
+If you encounter issues with the AppImage, you can try installing CatLauncher using the .deb or the .rpm package. It would also help if you can open an issue on GitHub with details of your distro.
 
 ## License
 


### PR DESCRIPTION
Update README include AppImage as a supported Linux artifact and
provide short Linux section explaining installation and compatibility.
Specify that App is the easiest way to install and keep CatLauncher
up-to-date, it may not work on distros, and mention testing on
Ubuntu 24.04. Add fallback guidance try .deb or .rpm packages and ask
users to open GitHub issues with distro details when encountering
problems.

This clarifies Linux installation options and improves user guidance.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds AppImage as a supported Linux installer and updates the README with a short Linux section covering installation, compatibility, and fallbacks. Clarifies that AppImage is the easiest way to install and auto-update, notes testing on Ubuntu 24.04, and suggests using .deb/.rpm or opening an issue with distro details if needed.

<!-- End of auto-generated description by cubic. -->

