### PR TITLE
chore(release): bump app version to 0.5.1

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "dmg",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
Update application version from 0.5.0 to 0.5. across Tauri andJavaScript manifests.

Files updated:
--tauri/ta.conf.json
--tauri/Cargo.toml
- src-tauri/Cargo.lock
- package

This prepares a patch release and keeps package metadata in sync
between the Rust and JS sides.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump app version from 0.5.0 to 0.5.1 across Tauri and JS manifests to prepare the patch release. Keeps Rust and JavaScript metadata in sync for consistent builds and distribution.

<!-- End of auto-generated description by cubic. -->

