### PR TITLE
feat(extract): add RAR extraction

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "ts-rs",
+ "unrar",
  "zip 6.0.0",
 ]
 
@@ -4979,6 +4980,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unrar"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ec61343a630d2b50d13216dea5125e157d3fc180a7d3f447d22fe146b648fc"
+dependencies = [
+ "bitflags 2.9.4",
+ "regex",
+ "unrar_sys",
+ "widestring",
+]
+
+[[package]]
+name = "unrar_sys"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b77675b883cfbe6bf41e6b7a5cd6008e0a83ba497de3d96e41a064bbeead765"
+dependencies = [
+ "cc",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5303,6 +5327,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ flate2 = "1.1.4"
 sha2 = "0.10.9"
 regex = "1.12.1"
 dmg = "0.1.2"
+unrar = "0.5.8"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.9.0"


### PR DESCRIPTION
Add unrar crate and integrateAR handling into the archive
extraction logic. Introduce UnrarError into the ExtractionError
 so rar-related failures map to the common error type. Implement
 blocking extraction path for ".rar" archives that opens the RAR
archive, iterates headers, and extracts entries to the target
directory using spawn_blocking to avoid blocking the async runtime.

Update Cargo.toml and Cargo.lock to include unrar, unrar_sys and
widestring dependencies and their checksums.

This enables extraction of rar archives alongside existing zip,
tar and dmg handlers and provides proper error propagation for rar
failures.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add RAR extraction support to the archive extractor. Uses unrar with spawn_blocking to avoid blocking the async runtime and reports failures via ExtractionError::Rar.

- **New Features**
  - Add .rar handling in extract_archive: open archive, iterate headers, extract entries to the target dir.
  - Map unrar errors to ExtractionError::Rar for consistent error handling.

- **Dependencies**
  - Add unrar = "0.5.8" (plus unrar_sys, widestring) in Cargo.toml/Cargo.lock.

<!-- End of auto-generated description by cubic. -->

