### PR TITLE
feat(game-launch): Use variant-specific user data directory

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -275,3 +275,24 @@ pub async fn get_tip_file_paths(
 
     Ok(vec![tips_path, hints_path])
 }
+
+pub fn get_user_game_data_dir(variant: &GameVariant, data_dir: &Path) -> PathBuf {
+    data_dir.join("UserData").join(variant.id())
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetUserDataBackupArchivePathError {
+    #[error("failed to create backup directory: {0}")]
+    DirFailed(#[from] io::Error),
+}
+
+pub async fn get_or_create_user_data_backup_archive_filepath(
+    variant: &GameVariant,
+    data_dir: &Path,
+    timestamp: u64,
+) -> Result<PathBuf, GetUserDataBackupArchivePathError> {
+    let backup_dir = get_user_game_data_dir(variant, data_dir).join("backups");
+    tokio::fs::create_dir_all(&backup_dir).await?;
+
+    Ok(backup_dir.join(format!("{}.zip", timestamp)))
+}

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -1,117 +1,36 @@
-use std::io;
 use std::path::Path;
 
 use crate::filesystem::paths::{
-    get_game_executable_dir, get_game_save_and_config_dirs, get_game_save_dirs,
-    get_or_create_backup_archive_filepath, GetBackupArchivePathError, GetGameExecutableDirError,
-    GetVersionExecutableDirError,
+    get_or_create_user_data_backup_archive_filepath, get_user_game_data_dir,
+    GetUserDataBackupArchivePathError,
 };
-use crate::filesystem::utils::{copy_dir_all, CopyDirError};
 use crate::infra::archive::{create_zip_archive, ArchiveCreationError};
-use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
-pub enum BackupAndCopyError {
-    #[error("failed to backup save files: {0}")]
-    Backup(#[from] BackupError),
-
-    #[error("failed to copy save files: {0}")]
-    Copy(#[from] SaveCopyError),
-}
-
-pub async fn backup_and_copy_save_files(
-    from_version: &str,
-    to_version: &str,
-    variant: &GameVariant,
-    data_dir: &Path,
-    os: &OS,
-    timestamp: u64,
-) -> Result<(), BackupAndCopyError> {
-    backup_save_files(variant, from_version, data_dir, os, timestamp).await?;
-
-    // Don't need to copy save files if the versions are the same
-    if from_version == to_version {
-        return Ok(());
-    }
-    copy_save_and_config_files(from_version, to_version, variant, data_dir, os).await?;
-
-    Ok(())
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum SaveCopyError {
-    #[error("failed to get version executable dir: {0}")]
-    VersionExecutableDir(#[from] GetVersionExecutableDirError),
-
-    #[error("failed to get game executable dir: {0}")]
-    GameExecutableDir(#[from] GetGameExecutableDirError),
-
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
-
-    #[error("invalid save directory path")]
-    InvalidSaveDirPath,
-
-    #[error("failed to copy directory: {0}")]
-    Copy(#[from] CopyDirError),
-}
-
-async fn copy_save_and_config_files(
-    from_version: &str,
-    to_version: &str,
-    variant: &GameVariant,
-    data_dir: &Path,
-    os: &OS,
-) -> Result<(), SaveCopyError> {
-    let to_dir = get_game_executable_dir(variant, to_version, data_dir, os).await?;
-
-    let save_dirs = get_game_save_and_config_dirs(variant, from_version, data_dir, os).await?;
-
-    for save_dir in save_dirs {
-        if let Ok(metadata) = tokio::fs::metadata(&save_dir).await {
-            if !metadata.is_dir() {
-                continue;
-            }
-            let file_name = save_dir
-                .file_name()
-                .ok_or_else(|| SaveCopyError::InvalidSaveDirPath)?;
-            let dest_path = to_dir.join(file_name);
-            copy_dir_all(&save_dir, &dest_path, os).await?;
-        }
-    }
-
-    Ok(())
-}
-
-#[derive(thiserror::Error, Debug)]
 pub enum BackupError {
-    #[error("failed to get version executable dir: {0}")]
-    VersionExecutableDir(#[from] GetVersionExecutableDirError),
-
-    #[error("failed to get game executable dir: {0}")]
-    GameExecutableDir(#[from] GetGameExecutableDirError),
-
     #[error("failed to get backup archive path: {0}")]
-    BackupArchivePath(#[from] GetBackupArchivePathError),
+    BackupArchivePath(#[from] GetUserDataBackupArchivePathError),
 
     #[error("failed to create archive: {0}")]
     ArchiveCreation(#[from] ArchiveCreationError),
 }
 
-async fn backup_save_files(
+pub async fn backup_save_files(
     variant: &GameVariant,
-    version: &str,
     data_dir: &Path,
-    os: &OS,
     timestamp: u64,
 ) -> Result<(), BackupError> {
-    let executable_dir = get_game_executable_dir(variant, version, data_dir, os).await?;
-    let dirs_to_backup = get_game_save_dirs(variant, version, data_dir, os).await?;
-    let archive_path =
-        get_or_create_backup_archive_filepath(variant, version, data_dir, timestamp, os).await?;
+    let user_data_dir = get_user_game_data_dir(variant, data_dir);
+    if !user_data_dir.exists() {
+        return Ok(());
+    }
 
-    create_zip_archive(&executable_dir, &dirs_to_backup, &archive_path).await?;
+    let dirs_to_backup = vec![user_data_dir.join("save")];
+    let archive_path =
+        get_or_create_user_data_backup_archive_filepath(variant, data_dir, timestamp).await?;
+
+    create_zip_archive(&user_data_dir, &dirs_to_backup, &archive_path).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This change modifies the game launch process to use a centralized, variant-specific user data directory. This new implementation correctly separates the concerns of game releases and user data.

- A new `user_game_data_dir` is introduced at `$data_dir/user_data/$variant`.
- A new, separate function named `get_or_create_user_data_backup_archive_filepath` is added to handle backups inside the `user_data` directory.
- The game is now launched with the `--userdir` argument pointing to this new directory.
- The previous logic for copying save files between different game versions has been removed.
- The backup process now targets the new user data directory for creating save backups.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches game launch to a variant-specific user data directory and updates backups to use it. This separates release files from user data and removes cross-version save copying.

- **Refactors**
  - Centralizes user data at $data_dir/UserData/{variant} and launches the game with --userdir pointing to it.
  - Adds get_or_create_user_data_backup_archive_filepath; backups are saved to UserData/backups/{timestamp}.zip.
  - Backs up from UserData/save and removes save/config copy logic between versions.

<!-- End of auto-generated description by cubic. -->

