### PR TITLE
feat(tips): auto-shuffle tips immediately and remove manual button

### DIFF
--- a/cat-launcher/src/game-tips/TipOfTheDay.tsx
+++ b/cat-launcher/src/game-tips/TipOfTheDay.tsx
@@ -1,29 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
-import { Lightbulb, Shuffle } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { getTips } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
-import { randomInt } from "@/lib/utils";
+import { randomInt, setImmediateInterval } from "@/lib/utils";
 import { TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS } from "@/lib/constants";
 
 interface TipOfTheDayContentProps {
   tip: string;
-  onShuffle: () => void;
 }
 
-function TipOfTheDayContent({ tip, onShuffle }: TipOfTheDayContentProps) {
+function TipOfTheDayContent({ tip }: TipOfTheDayContentProps) {
   return (
     <Alert>
       <AlertTitle className="flex items-center gap-2">
         <Lightbulb />
         Tip of the Day
-        <Button variant="ghost" size="icon" onClick={onShuffle}>
-          <Shuffle />
-        </Button>
       </AlertTitle>
       <AlertDescription className="h-20 overflow-y-auto">
         {tip}
@@ -51,13 +46,7 @@ export function TipOfTheDay({ variant }: TipOfTheDayProps) {
     return data;
   }, [data, status]);
 
-  useEffect(() => {
-    if (tips.length > 0) {
-      setRandomIndex(randomInt(tips.length));
-    }
-  }, [tips]);
-
-  const handleShuffle = useCallback(() => {
+  const shuffleTips = useCallback(() => {
     if (tips.length === 0) {
       return;
     }
@@ -67,15 +56,14 @@ export function TipOfTheDay({ variant }: TipOfTheDayProps) {
 
   useEffect(() => {
     // auto shuffle every 10 seconds
-
-    const cleanup = setInterval(() => {
-      handleShuffle();
+    const timerId = setImmediateInterval(() => {
+      shuffleTips();
     }, TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS);
 
     return () => {
-      clearInterval(cleanup);
+      clearInterval(timerId);
     };
-  }, [handleShuffle]);
+  }, [shuffleTips]);
 
   return (
     <TipOfTheDayContent
@@ -84,7 +72,6 @@ export function TipOfTheDay({ variant }: TipOfTheDayProps) {
           ? "Install and play a game to start getting tips and hints."
           : tips[randomIndex]
       }
-      onShuffle={handleShuffle}
     />
   );
 }

--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -58,3 +58,9 @@ export function setupEventListener<T>(
 export function randomInt(n: number): number {
   return Math.floor(Math.random() * n);
 }
+
+export function setImmediateInterval(callback: () => void, timeout?: number) {
+  callback();
+
+  return setInterval(callback, timeout);
+}


### PR DESCRIPTION
- Invoke tip shuffle immediately when the interval starts by adding  setImmediateInterval which calls the once before
  scheduling setInterval. This ensures users see a tip right when
  the component mounts instead of waiting for the first interval tick.
- Replace previous setInterval usage with setImmediateInterval and wire
  it to the new shuffleTips callback; clean up by clearing the returned
  timer id on unmount.
- Remove the manual shuffle button and related Shuffle import/prop since
  auto-shuffling makes the button redundant. Simplify TipOfTheDayContent
  props accordingly.
- Keep randomInt helper for generating a random tip index.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show a tip immediately and auto-shuffle tips, removing the manual shuffle button. This makes Tip of the Day instant and hands-free.

- **New Features**
  - Added setImmediateInterval to run the first shuffle immediately, then on the configured interval.
  - Auto-shuffle tips using shuffleTips every TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS.

- **Refactors**
  - Removed the Shuffle button and onShuffle prop; simplified TipOfTheDayContent props.
  - Replaced setInterval with setImmediateInterval and clear the timer on unmount.
  - Kept randomInt for tip index generation.

<!-- End of auto-generated description by cubic. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #159 
- <kbd>&nbsp;1&nbsp;</kbd> #158 👈 
<!-- GitButler Footer Boundary Bottom -->

