### PR TITLE
fix(ui): make TipOfTheDay layout use column flexbox

### DIFF
--- a/cat-launcher/src/game-tips/TipOfTheDay.tsx
+++ b/cat-launcher/src/game-tips/TipOfTheDay.tsx
@@ -15,12 +15,12 @@ interface TipOfTheDayContentProps {
 
 function TipOfTheDayContent({ tip }: TipOfTheDayContentProps) {
   return (
-    <Alert>
+    <Alert className="flex flex-col">
       <AlertTitle className="flex items-center gap-2">
         <Lightbulb />
         Tip of the Day
       </AlertTitle>
-      <AlertDescription className="h-20 overflow-y-auto">
+      <AlertDescription className="h-20 overflow-y-auto flex-grow items-center">
         {tip}
       </AlertDescription>
     </Alert>


### PR DESCRIPTION
Adjust the TipOfTheDay to use a column flex layout so the
title and description stack vertically and the description grow
to fill available. Add flex classes to the Alert container and
to AlertDescription (flex-grow and items-center) to ensure proper
vertical alignment and scrolling behavior for long tips. This fixes
layout issues where descriptions did not expand or center correctly.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #159 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #158 
<!-- GitButler Footer Boundary Bottom -->

