### PR TITLE
refactor(game-releases): inject ReleasesRepository into release flow

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
 name = "cat-launcher"
 version = "0.6.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "dmg",
  "downloader",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ sha2 = "0.10.9"
 regex = "1.12.1"
 dmg = "0.1.2"
 unrar = "0.5.8"
+async-trait = "0.1.89"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.9.0"

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -5,13 +5,11 @@ use reqwest::Client;
 use serde::Serialize;
 use ts_rs::TS;
 
-use crate::fetch_releases::utils::{
-    get_cached_releases, get_default_releases, get_releases_payload, merge_releases,
-    select_releases_for_cache, write_cached_releases, WriteCacheError,
-};
+use crate::fetch_releases::utils::{get_default_releases, get_releases_payload, merge_releases};
 use crate::game_release::game_release::GameRelease;
 use crate::infra::github::utils::{fetch_github_releases, GitHubReleaseFetchError};
 use crate::infra::utils::get_github_repo_for_variant;
+use crate::repository::releases_repository::{ReleasesRepository, ReleasesRepositoryError};
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -19,8 +17,8 @@ pub enum FetchReleasesError<E: Error> {
     #[error("failed to get releases from github: {0}")]
     Fetch(#[from] GitHubReleaseFetchError),
 
-    #[error("failed to cache releases: {0}")]
-    Cache(#[from] WriteCacheError),
+    #[error("failed to access releases cache: {0}")]
+    Repository(#[from] ReleasesRepositoryError),
 
     #[error("failed to send release update: {0}")]
     Send(E),
@@ -46,8 +44,8 @@ impl GameVariant {
     pub async fn fetch_releases<E, F>(
         &self,
         client: &Client,
-        cache_dir: &Path,
         resources_dir: &Path,
+        releases_repository: &dyn ReleasesRepository,
         on_releases: F,
     ) -> Result<(), FetchReleasesError<E>>
     where
@@ -58,7 +56,7 @@ impl GameVariant {
         // We fetch them together so that if the last played release was cached, the frontend
         // can preselect it.
         let default_releases = get_default_releases(self, resources_dir).await;
-        let cached_releases = get_cached_releases(self, cache_dir).await;
+        let cached_releases = releases_repository.get_cached_releases(self).await?;
         let merged = merge_releases(&default_releases, &cached_releases);
         let payload = get_releases_payload(self, &merged, ReleasesUpdateStatus::Fetching);
         on_releases(payload).map_err(FetchReleasesError::Send)?;
@@ -70,9 +68,9 @@ impl GameVariant {
         let payload = get_releases_payload(self, &fetched_releases, ReleasesUpdateStatus::Success);
         on_releases(payload).map_err(FetchReleasesError::Send)?;
 
-        let merged = merge_releases(&merged, &fetched_releases);
-        let to_cache = select_releases_for_cache(&merged);
-        write_cached_releases(self, &to_cache, cache_dir).await?;
+        releases_repository
+            .update_cached_releases(self, &fetched_releases)
+            .await?;
 
         Ok(())
     }

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -7,6 +7,7 @@ use crate::fetch_releases::utils::get_assets;
 use crate::game_release::utils::get_platform_asset_substrs;
 use crate::infra::github::asset::GitHubAsset;
 use crate::infra::utils::{Arch, OS};
+use crate::repository::releases_repository::ReleasesRepository;
 use crate::variants::GameVariant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, TS)]
@@ -44,10 +45,10 @@ impl GameRelease {
         &self,
         os: &OS,
         arch: &Arch,
-        cache_dir: &Path,
         resources_dir: &Path,
+        releases_repository: &dyn ReleasesRepository,
     ) -> Option<GitHubAsset> {
-        let assets = get_assets(self, cache_dir, resources_dir).await;
+        let assets = get_assets(self, resources_dir, releases_repository).await;
         let substrings = get_platform_asset_substrs(&self.variant, os, arch);
 
         substrings

--- a/cat-launcher/src-tauri/src/game_tips/commands.rs
+++ b/cat-launcher/src-tauri/src/game_tips/commands.rs
@@ -1,18 +1,20 @@
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, AppHandle, Manager, State};
 
 use crate::game_tips::error::CommandError;
 use crate::game_tips::game_tips::get_all_tips_for_variant;
 use crate::infra::utils::get_os_enum;
+use crate::repository::file_last_played_repository::FileLastPlayedVersionRepository;
 use crate::variants::GameVariant;
 
 #[command]
 pub async fn get_tips(
     app_handle: AppHandle,
     variant: GameVariant,
+    last_played_repository: State<'_, FileLastPlayedVersionRepository>,
 ) -> Result<Vec<String>, CommandError> {
     let data_dir = app_handle.path().app_local_data_dir()?;
     let os = get_os_enum(std::env::consts::OS)?;
 
-    let tips = get_all_tips_for_variant(&variant, &data_dir, &os).await?;
+    let tips = get_all_tips_for_variant(&variant, &data_dir, &os, &*last_played_repository).await?;
     Ok(tips)
 }

--- a/cat-launcher/src-tauri/src/game_tips/game_tips.rs
+++ b/cat-launcher/src-tauri/src/game_tips/game_tips.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::filesystem::paths::{get_tip_file_paths, GetTipFilePathsError};
 use crate::infra::utils::OS;
 use crate::last_played::last_played::LastPlayedError;
+use crate::repository::last_played_repository::LastPlayedVersionRepository;
 use crate::variants::GameVariant;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -32,8 +33,12 @@ pub async fn get_all_tips_for_variant(
     variant: &GameVariant,
     data_dir: &Path,
     os: &OS,
+    last_played_repository: &dyn LastPlayedVersionRepository,
 ) -> Result<Vec<String>, GetAllTipsForVariantError> {
-    let last_played_version = match variant.get_last_played_version(data_dir).await? {
+    let last_played_version = match variant
+        .get_last_played_version(last_played_repository)
+        .await?
+    {
         Some(version) => version,
         None => return Ok(vec![]),
     };

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -3,11 +3,12 @@ use std::env::consts::OS;
 use serde::ser::SerializeStruct;
 use serde::Serializer;
 use strum_macros::IntoStaticStr;
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, AppHandle, Manager, State};
 
 use crate::game_release::game_release::GameReleaseStatus;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
 use crate::infra::utils::{get_arch_enum, get_os_enum, ArchNotSupportedError, OSNotSupportedError};
+use crate::repository::file_releases_repository::FileReleasesRepository;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug, IntoStaticStr)]
@@ -47,8 +48,8 @@ pub async fn get_installation_status(
     app_handle: AppHandle,
     variant: GameVariant,
     release_id: &str,
+    releases_repository: State<'_, FileReleasesRepository>,
 ) -> Result<GameReleaseStatus, GetInstallationStatusCommandError> {
-    let cache_dir = app_handle.path().app_cache_dir()?;
     let data_dir = app_handle.path().app_local_data_dir()?;
     let resource_dir = app_handle.path().resource_dir()?;
 
@@ -60,9 +61,9 @@ pub async fn get_installation_status(
         release_id,
         &os,
         &arch,
-        &cache_dir,
         &data_dir,
         &resource_dir,
+        &*releases_repository,
     )
     .await?;
 

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -10,6 +10,7 @@ use crate::filesystem::paths::{
 };
 use crate::game_release::game_release::{GameRelease, GameReleaseStatus};
 use crate::infra::utils::{Arch, OS};
+use crate::repository::releases_repository::ReleasesRepository;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetInstallationStatusError {
@@ -31,11 +32,14 @@ impl GameRelease {
         &self,
         os: &OS,
         arch: &Arch,
-        cache_dir: &Path,
         data_dir: &Path,
         resources_dir: &Path,
+        releases_repository: &dyn ReleasesRepository,
     ) -> Result<GameReleaseStatus, GetInstallationStatusError> {
-        let asset = match self.get_asset(os, arch, cache_dir, resources_dir).await {
+        let asset = match self
+            .get_asset(os, arch, resources_dir, releases_repository)
+            .await
+        {
             Some(asset) => asset,
             None => return Ok(GameReleaseStatus::NotAvailable),
         };

--- a/cat-launcher/src-tauri/src/last_played/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played/commands.rs
@@ -1,8 +1,10 @@
 use serde::{ser::SerializeStruct, Serializer};
 use strum_macros::IntoStaticStr;
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, State};
 
-use crate::{last_played::last_played::LastPlayedError, variants::GameVariant};
+use crate::last_played::last_played::LastPlayedError;
+use crate::repository::file_last_played_repository::FileLastPlayedVersionRepository;
+use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug, IntoStaticStr)]
 pub enum LastPlayedCommandError {
@@ -15,12 +17,10 @@ pub enum LastPlayedCommandError {
 
 #[command]
 pub async fn get_last_played_version(
-    app_handle: AppHandle,
     variant: GameVariant,
+    repository: State<'_, FileLastPlayedVersionRepository>,
 ) -> Result<Option<String>, LastPlayedCommandError> {
-    let data_dir = app_handle.path().app_local_data_dir()?;
-
-    let last_played_version = variant.get_last_played_version(&data_dir).await?;
+    let last_played_version = variant.get_last_played_version(&*repository).await?;
 
     Ok(last_played_version)
 }

--- a/cat-launcher/src-tauri/src/last_played/last_played.rs
+++ b/cat-launcher/src-tauri/src/last_played/last_played.rs
@@ -1,69 +1,28 @@
-use std::collections::HashMap;
-use std::path::Path;
-
-use serde::{Deserialize, Serialize};
-use tokio::fs;
-
-use crate::filesystem::paths::{get_last_played_filepath, LastPlayedFileError};
-use crate::infra::utils::{read_from_file, write_to_file, ReadFromFileError, WriteToFileError};
+use crate::repository::last_played_repository::{
+    LastPlayedVersionRepository, LastPlayedVersionRepositoryError,
+};
 use crate::variants::GameVariant;
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct LastPlayedData {
-    pub versions: HashMap<String, String>,
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum LastPlayedError {
-    #[error("failed to read last played data: {0}")]
-    Read(#[from] ReadFromFileError),
-
-    #[error("failed to write last played data: {0}")]
-    Write(#[from] WriteToFileError),
-
-    #[error("failed to get last played file path: {0}")]
-    GetFilePath(#[from] LastPlayedFileError),
+    #[error("failed to access last played version: {0}")]
+    Repository(#[from] LastPlayedVersionRepositoryError),
 }
 
 impl GameVariant {
     pub async fn get_last_played_version(
         &self,
-        data_dir: &Path,
+        repository: &dyn LastPlayedVersionRepository,
     ) -> Result<Option<String>, LastPlayedError> {
-        let file_path = get_last_played_filepath(self, data_dir).await?;
-
-        match fs::metadata(&file_path).await {
-            Ok(metadata) if metadata.is_file() => {}
-            _ => return Ok(None),
-        };
-
-        let mut data: LastPlayedData = read_from_file(&file_path).await?;
-        let variant_key: &'static str = self.into();
-
-        Ok(data.versions.remove(variant_key))
+        Ok(repository.get_last_played_version(self).await?)
     }
 
     pub async fn set_last_played_version(
         &self,
         version: &str,
-        data_dir: &Path,
+        repository: &dyn LastPlayedVersionRepository,
     ) -> Result<(), LastPlayedError> {
-        let file_path = get_last_played_filepath(self, data_dir).await?;
-
-        let mut data = match fs::metadata(&file_path).await {
-            Ok(metadata) if metadata.is_file() => read_from_file(&file_path).await?,
-            _ => LastPlayedData {
-                versions: std::collections::HashMap::new(),
-            },
-        };
-
-        let variant_key: &'static str = self.into();
-
-        data.versions
-            .insert(variant_key.into(), version.to_string());
-
-        write_to_file(&file_path, &data).await?;
-
+        repository.set_last_played_version(self, version).await?;
         Ok(())
     }
 }

--- a/cat-launcher/src-tauri/src/repository/file_last_played_repository.rs
+++ b/cat-launcher/src-tauri/src/repository/file_last_played_repository.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+use crate::filesystem::paths::get_last_played_filepath;
+use crate::infra::utils::{read_from_file, write_to_file};
+use crate::repository::last_played_repository::{
+    LastPlayedVersionRepository, LastPlayedVersionRepositoryError,
+};
+use crate::variants::game_variant::GameVariant;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LastPlayedData {
+    pub versions: HashMap<String, String>,
+}
+
+pub struct FileLastPlayedVersionRepository {
+    data_dir: PathBuf,
+}
+
+impl FileLastPlayedVersionRepository {
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            data_dir: data_dir.to_path_buf(),
+        }
+    }
+}
+
+#[async_trait]
+impl LastPlayedVersionRepository for FileLastPlayedVersionRepository {
+    async fn get_last_played_version(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Option<String>, LastPlayedVersionRepositoryError> {
+        let path = get_last_played_filepath(game_variant, &self.data_dir)
+            .await
+            .map_err(|err| LastPlayedVersionRepositoryError::Get(Box::new(err)))?;
+
+        match fs::metadata(&path).await {
+            Ok(metadata) if metadata.is_file() => {}
+            _ => return Ok(None),
+        };
+
+        let mut data = read_from_file::<LastPlayedData>(&path)
+            .await
+            .map_err(|err| LastPlayedVersionRepositoryError::Get(Box::new(err)))?;
+        let variant_key: &'static str = game_variant.into();
+
+        Ok(data.versions.remove(variant_key))
+    }
+
+    async fn set_last_played_version(
+        &self,
+        game_variant: &GameVariant,
+        version: &str,
+    ) -> Result<(), LastPlayedVersionRepositoryError> {
+        let path = get_last_played_filepath(game_variant, &self.data_dir)
+            .await
+            .map_err(|err| LastPlayedVersionRepositoryError::Set(Box::new(err)))?;
+
+        let mut data = match fs::metadata(&path).await {
+            Ok(metadata) if metadata.is_file() => read_from_file(&path)
+                .await
+                .map_err(|err| LastPlayedVersionRepositoryError::Set(Box::new(err)))?,
+            _ => LastPlayedData {
+                versions: std::collections::HashMap::new(),
+            },
+        };
+
+        let variant_key: &'static str = game_variant.into();
+
+        data.versions
+            .insert(variant_key.into(), version.to_string());
+
+        write_to_file(&path, &data)
+            .await
+            .map_err(|err| LastPlayedVersionRepositoryError::Set(Box::new(err)))?;
+
+        Ok(())
+    }
+}

--- a/cat-launcher/src-tauri/src/repository/file_releases_repository.rs
+++ b/cat-launcher/src-tauri/src/repository/file_releases_repository.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::filesystem::paths::get_releases_cache_filepath;
+use crate::infra::github::release::GitHubRelease;
+use crate::infra::utils::{read_from_file, write_to_file};
+use crate::repository::releases_repository::{ReleasesRepository, ReleasesRepositoryError};
+use crate::variants::game_variant::GameVariant;
+
+pub struct FileReleasesRepository {
+    cache_dir: PathBuf,
+}
+
+impl FileReleasesRepository {
+    pub fn new(cache_dir: &Path) -> Self {
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+        }
+    }
+}
+
+#[async_trait]
+impl ReleasesRepository for FileReleasesRepository {
+    async fn get_cached_releases(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<GitHubRelease>, ReleasesRepositoryError> {
+        let cache_file = get_releases_cache_filepath(game_variant, &self.cache_dir);
+
+        if !cache_file.exists() {
+            return Ok(Vec::new());
+        }
+
+        let releases = read_from_file::<Vec<GitHubRelease>>(&cache_file)
+            .await
+            .map_err(|err| ReleasesRepositoryError::Get(Box::new(err)))?;
+
+        Ok(releases)
+    }
+
+    async fn update_cached_releases(
+        &self,
+        game_variant: &GameVariant,
+        releases: &[GitHubRelease],
+    ) -> Result<(), ReleasesRepositoryError> {
+        let cache_file = get_releases_cache_filepath(game_variant, &self.cache_dir);
+
+        if let Some(parent) = cache_file.parent() {
+            if !parent.exists() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|err| ReleasesRepositoryError::Update(Box::new(err)))?;
+            }
+        }
+
+        let existing_releases = self.get_cached_releases(game_variant).await?;
+
+        let mut releases_map: HashMap<u64, GitHubRelease> =
+            existing_releases.into_iter().map(|r| (r.id, r)).collect();
+
+        for release in releases {
+            releases_map.insert(release.id, release.clone());
+        }
+
+        let updated_releases: Vec<GitHubRelease> = releases_map.into_values().collect();
+
+        write_to_file(&cache_file, &updated_releases)
+            .await
+            .map_err(|err| ReleasesRepositoryError::Update(Box::new(err)))?;
+
+        Ok(())
+    }
+}

--- a/cat-launcher/src-tauri/src/repository/last_played_repository.rs
+++ b/cat-launcher/src-tauri/src/repository/last_played_repository.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::variants::game_variant::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LastPlayedVersionRepositoryError {
+    #[error("failed to get last played version: {0}")]
+    Get(Box<dyn Error + Send + Sync>),
+
+    #[error("failed to set last played version: {0}")]
+    Set(Box<dyn Error + Send + Sync>),
+}
+
+#[async_trait]
+pub trait LastPlayedVersionRepository: Send + Sync {
+    async fn get_last_played_version(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Option<String>, LastPlayedVersionRepositoryError>;
+
+    async fn set_last_played_version(
+        &self,
+        game_variant: &GameVariant,
+        version: &str,
+    ) -> Result<(), LastPlayedVersionRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/repository/mod.rs
@@ -1,0 +1,5 @@
+pub mod last_played_repository;
+pub mod releases_repository;
+
+pub mod file_last_played_repository;
+pub mod file_releases_repository;

--- a/cat-launcher/src-tauri/src/repository/releases_repository.rs
+++ b/cat-launcher/src-tauri/src/repository/releases_repository.rs
@@ -1,0 +1,29 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::infra::github::release::GitHubRelease;
+use crate::variants::game_variant::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReleasesRepositoryError {
+    #[error("failed to get cached releases: {0}")]
+    Get(Box<dyn Error + Send + Sync>),
+
+    #[error("failed to update cached releases: {0}")]
+    Update(Box<dyn Error + Send + Sync>),
+}
+
+#[async_trait]
+pub trait ReleasesRepository: Send + Sync {
+    async fn get_cached_releases(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<GitHubRelease>, ReleasesRepositoryError>;
+
+    async fn update_cached_releases(
+        &self,
+        game_variant: &GameVariant,
+        releases: &[GitHubRelease],
+    ) -> Result<(), ReleasesRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -1,0 +1,32 @@
+use tauri::{App, Listener, Manager};
+
+use crate::infra::autoupdate::update::run_updater;
+use crate::repository::file_last_played_repository::FileLastPlayedVersionRepository;
+use crate::repository::file_releases_repository::FileReleasesRepository;
+
+pub fn autoupdate(app: &App) {
+    let handle = app.handle();
+    let handle_for_closure = handle.clone();
+    handle.once("frontend-ready", move |_event| {
+        let handle = handle_for_closure.clone();
+        tauri::async_runtime::spawn(async move {
+            run_updater(handle).await;
+        });
+    });
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RepositoryError {
+    #[error("failed to get system directory: {0}")]
+    SystemDir(#[from] tauri::Error),
+}
+
+pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
+    let cache_dir = app.path().app_cache_dir()?;
+    let data_dir = app.path().app_local_data_dir()?;
+
+    app.manage(FileReleasesRepository::new(&cache_dir));
+    app.manage(FileLastPlayedVersionRepository::new(&data_dir));
+
+    Ok(())
+}


### PR DESCRIPTION
Replace filesystem cache_dir usage with a ReleasesRepository trait and
thread a releases_repository dependency through major release-related
functions. Update callers to accept and forward a &dyn ReleasesRepository
(or State<FileReleasesRepository> at the Tauri command boundary).

Key changes:
- game_release::utils: remove cache_dir parameter, obtain cached releases
  via ReleasesRepository::get_cached_releases and pass repository into
  get_installation_status.
- install_release: accept releases_repository instead of cache_dir, use
  it when checking installation status and resolving the asset.
- installation_status::status: accept releases_repository and use it to
  fetch assets when determining installation status.
- fetch_releases::commands: add State<FileReleasesRepository> param at
  the Tauri command boundary so the repository can be provided to flows.

Motivation: decouple release caching/storage from file-system paths,
enable dependency injection for release storage, and centralize cache
access behind a repository interface to improve testability and flexibility.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced filesystem-based release caching and last-played storage with repository interfaces injected via Tauri State to decouple storage from paths and improve testability.

- **Refactors**
  - Added ReleasesRepository and FileReleasesRepository; updated fetch, install, status, and asset resolution to use it and removed cache_dir threading.
  - Added LastPlayedVersionRepository and FileLastPlayedVersionRepository; updated last_played, game_tips, and launch flows to use it and removed direct data_dir access.
  - Registered repositories in app setup (manage_repositories) and moved autoupdate wiring to utils.
  - Updated Tauri commands to accept State<FileReleasesRepository> and/or State<FileLastPlayedVersionRepository>.

- **Dependencies**
  - Added async-trait.

<!-- End of auto-generated description by cubic. -->

