### PR TITLE
docs: updateImage filename to v.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CatLauncher is 100% open-source and the .dmg is built directly from the source c
 
 Downloading the AppImage is the easiest way to install CatLauncher and keep it automatically up-to-date. However, the AppImage may not work on all Linux distros. It's been tested to work on Ubuntu 24.04.
 
-To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.5.1_amd64.AppImage`, and then run it like you would any other executable.
+To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.6.0_amd64.AppImage`, and then run it like you would any other executable.
 
 If you encounter issues with the AppImage, you can try installing CatLauncher using the .deb or the .rpm package. It would also help if you can open an issue on GitHub with details of your distro.
 


### PR DESCRIPTION
Update README to reference the new AppImage filename for CatLauncherChange the example chmod from v05.1 to v0.60 so the
 matches the current and prevents confusion whenusers download the AppImage.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update README to reference the correct AppImage filename (cat-launcher_0.6.0_amd64.AppImage) in the chmod example, replacing v0.5.1 to match the current release and prevent confusion.

<!-- End of auto-generated description by cubic. -->

