### PR TITLE
fix(github): add clarifying comment for regex unwrap

### DIFF
--- a/cat-launcher/src-tauri/src/infra/github/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/github/utils.rs
@@ -19,6 +19,7 @@ pub enum GitHubReleaseFetchError {
 }
 
 static NEXT_PAGE_URL_RE: LazyLock<Regex> =
+    // safe to unwrap as the regex is hardcoded and should always compile successfully
     LazyLock::new(|| Regex::new(r#"<([^>]+)>; rel="next""#).unwrap());
 
 pub async fn fetch_github_releases(


### PR DESCRIPTION
Add a comment explaining why unwrapping the Regex is safe for the
statically initialized NEXT_PAGE_URL_RE. This documents the rationale
that the regex is hardcoded and guaranteed to compile, clarifying the
intent and silencing potential lints or reviewer concerns.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified why unwrapping the GitHub pagination regex is safe by adding a comment to NEXT_PAGE_URL_RE. The pattern is hardcoded and always compiles, reducing lint noise and reviewer questions.

<!-- End of auto-generated description by cubic. -->

