### PR TITLE
feat(paths): create and return user game data dir async

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -314,14 +314,29 @@ pub async fn get_tip_file_paths(
     Ok(vec![tips_path, hints_path])
 }
 
-pub fn get_user_game_data_dir(variant: &GameVariant, data_dir: &Path) -> PathBuf {
-    data_dir.join("UserData").join(variant.id())
+#[derive(thiserror::Error, Debug)]
+pub enum GetUserGameDataDirError {
+    #[error("failed to create user data directory: {0}")]
+    DirFailed(#[from] io::Error),
+}
+
+pub async fn get_or_create_user_game_data_dir(
+    variant: &GameVariant,
+    data_dir: &Path,
+) -> Result<PathBuf, GetUserGameDataDirError> {
+    let dir = data_dir.join("UserData").join(variant.id());
+    create_dir_all(&dir).await?;
+
+    Ok(dir)
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetUserDataBackupArchivePathError {
     #[error("failed to create backup directory: {0}")]
     DirFailed(#[from] io::Error),
+
+    #[error("failed to create user game data directory: {0}")]
+    UserDataDirFailed(#[from] GetUserGameDataDirError),
 }
 
 pub async fn get_or_create_user_data_backup_archive_filepath(
@@ -329,7 +344,9 @@ pub async fn get_or_create_user_data_backup_archive_filepath(
     data_dir: &Path,
     timestamp: u64,
 ) -> Result<PathBuf, GetUserDataBackupArchivePathError> {
-    let backup_dir = get_user_game_data_dir(variant, data_dir).join("backups");
+    let backup_dir = get_or_create_user_game_data_dir(variant, data_dir)
+        .await?
+        .join("backups");
     tokio::fs::create_dir_all(&backup_dir).await?;
 
     Ok(backup_dir.join(format!("{}.zip", timestamp)))

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -10,8 +10,8 @@ use tokio::task::JoinError;
 use ts_rs::TS;
 
 use crate::filesystem::paths::{
-    get_game_executable_filepath, get_user_game_data_dir, AssetDownloadDirError,
-    AssetExtractionDirError, GetExecutablePathError,
+    get_game_executable_filepath, get_or_create_user_game_data_dir, AssetDownloadDirError,
+    AssetExtractionDirError, GetExecutablePathError, GetUserGameDataDirError,
 };
 use crate::game_release::game_release::GameRelease;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
@@ -44,6 +44,9 @@ pub enum LaunchGameError {
 
     #[error("failed to backup and copy saves: {0}")]
     Backup(#[from] BackupError),
+
+    #[error("failed to get user data directory: {0}")]
+    UserGameDataDir(#[from] GetUserGameDataDirError),
 
     #[error("failed to get stdout from child process")]
     Stdout,
@@ -101,7 +104,7 @@ impl GameRelease {
 
         backup_save_files(&self.variant, data_dir, timestamp).await?;
 
-        let user_data_dir = get_user_game_data_dir(&self.variant, data_dir);
+        let user_data_dir = get_or_create_user_game_data_dir(&self.variant, data_dir).await?;
         let mut command = Command::new(executable_path);
 
         command


### PR DESCRIPTION
Introduce an helper that ensures the game's UserData directory
exists and returns its path.

- Add GetUserGameDataDirError to represent directory creation errors.
- Replace synchronous get_user_game_data_dir with
get_or_create_user_game_data_dir that creates directories using
create_dir_all and returns Result\<PathBuf, GetUserGameDataDirError>.
- Propagate the new error type into functions that need the user data
path: get_or_create_user_data_backup_archive_filepath,
launch_game::launch, and launch_game::utils::backup_save_files.
- Update callers to await the async helper and handle errors, and
ensure backup directory creation uses the created path.

This ensures the user game data directory is created on demand and
errors are correctly propagated.

<!-- This is an auto-generated description by cubic. -->

---

## Summary by cubic

Make user game data directory creation async and guaranteed, so backups and game launch don’t fail when the directory is missing. Errors are now propagated cleanly to calling code.

- **New Features**
    - Added get_or_create_user_game_data_dir (async) to create and return UserData/\<variant>.
    - Introduced GetUserGameDataDirError and propagated it through backup and launch flows.
    - Updated backup archive path helper to use the ensured user data directory.

<!-- End of auto-generated description by cubic. -->