### PR TITLE
refactor: remove dependency on downloaded asset file

### DIFF
--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -46,7 +46,6 @@ pub async fn get_release_by_id(
     variant: &GameVariant,
     release_id: &str,
     os: &OS,
-    arch: &Arch,
     data_dir: &Path,
     resources_dir: &Path,
     releases_repository: &dyn ReleasesRepository,
@@ -77,9 +76,7 @@ pub async fn get_release_by_id(
         status: GameReleaseStatus::Unknown,
         created_at: gh_release.created_at,
     };
-    release.status = release
-        .get_installation_status(os, arch, data_dir, resources_dir, releases_repository)
-        .await?;
+    release.status = release.get_installation_status(os, data_dir).await?;
 
     Ok(release)
 }

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -49,7 +49,6 @@ pub async fn install_release(
         &variant,
         release_id,
         &os,
-        &arch,
         &data_dir,
         &resource_dir,
         &*releases_repository,

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -60,9 +60,7 @@ impl GameRelease {
         Fut: std::future::Future<Output = Result<(), E>> + Send,
     {
         if self.status == GameReleaseStatus::Unknown {
-            self.status = self
-                .get_installation_status(os, arch, data_dir, resources_dir, releases_repository)
-                .await?;
+            self.status = self.get_installation_status(os, data_dir).await?;
         }
 
         if self.status == GameReleaseStatus::ReadyToPlay {

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -7,7 +7,7 @@ use tauri::{command, AppHandle, Manager, State};
 
 use crate::game_release::game_release::GameReleaseStatus;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
-use crate::infra::utils::{get_arch_enum, get_os_enum, ArchNotSupportedError, OSNotSupportedError};
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::variants::GameVariant;
 
@@ -21,9 +21,6 @@ pub enum GetInstallationStatusCommandError {
 
     #[error("failed to get OS enum: {0}")]
     Os(#[from] OSNotSupportedError),
-
-    #[error("failed to get arch enum: {0}")]
-    Arch(#[from] ArchNotSupportedError),
 }
 
 impl serde::Serialize for GetInstallationStatusCommandError {
@@ -54,13 +51,11 @@ pub async fn get_installation_status(
     let resource_dir = app_handle.path().resource_dir()?;
 
     let os = get_os_enum(OS)?;
-    let arch = get_arch_enum(std::env::consts::ARCH)?;
 
     let release = get_release_by_id(
         &variant,
         release_id,
         &os,
-        &arch,
         &data_dir,
         &resource_dir,
         &*releases_repository,

--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -7,7 +7,7 @@ use strum_macros::IntoStaticStr;
 use tauri::State;
 use tauri::{command, AppHandle, Emitter, Manager};
 
-use crate::infra::utils::{get_arch_enum, get_os_enum, ArchNotSupportedError, OSNotSupportedError};
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::launch_game::launch_game::{launch_and_monitor_game, GameEvent, LaunchGameError};
 use crate::repository::sqlite_last_played_repository::SqliteLastPlayedVersionRepository;
 use crate::repository::sqlite_releases_repository::SqliteReleasesRepository;
@@ -26,9 +26,6 @@ pub enum LaunchGameCommandError {
 
     #[error("failed to get OS enum: {0}")]
     Os(#[from] OSNotSupportedError),
-
-    #[error("failed to get arch enum: {0}")]
-    Arch(#[from] ArchNotSupportedError),
 }
 
 #[command]
@@ -45,7 +42,6 @@ pub async fn launch_game(
     let time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
     let os = get_os_enum(OS)?;
-    let arch = get_arch_enum(std::env::consts::ARCH)?;
 
     let emitter = app_handle.clone();
     let on_game_event = move |event: GameEvent| {
@@ -60,7 +56,6 @@ pub async fn launch_game(
         &variant,
         release_id,
         &os,
-        &arch,
         time,
         &data_dir,
         &resource_dir,

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -15,7 +15,7 @@ use crate::filesystem::paths::{
 };
 use crate::game_release::game_release::GameRelease;
 use crate::game_release::utils::{get_release_by_id, GetReleaseError};
-use crate::infra::utils::{Arch, OS};
+use crate::infra::utils::OS;
 use crate::last_played::last_played::LastPlayedError;
 use crate::launch_game::utils::{backup_save_files, BackupError};
 use crate::repository::last_played_repository::LastPlayedVersionRepository;
@@ -174,7 +174,6 @@ pub async fn launch_and_monitor_game<F, Fut>(
     variant: &GameVariant,
     release_id: &str,
     os: &OS,
-    arch: &Arch,
     timestamp: u64,
     data_dir: &Path,
     resource_dir: &Path,
@@ -190,7 +189,6 @@ where
         variant,
         release_id,
         os,
-        arch,
         data_dir,
         resource_dir,
         releases_repository,


### PR DESCRIPTION
Remove the Arch type usage from game launch and installation flows,
simplifying function signatures and installation status checks.

- Remove Arch import and parameters from launch_game, commands,
  install_release, and game_release utilities.
- Update calls to get_installation_status to use only OS and data_dir.
- Remove unused get_arch_enum calls in command handlers.
- Clean up imports and unused filesystem/crypto code in installation
  status module.

This simplifies platform detection by relying solely on OS and removes
dead/unused code paths, preparing the codebase for a simpler platform
support model and reducing maintenance surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dependency on the downloaded asset file and the Arch type across launch and install flows. Installation status now uses only OS and the presence of the installed executable, simplifying APIs and platform detection.

- **Refactors**
  - Dropped Arch from function signatures and call sites in launch_game, install_release, and get_release_by_id.
  - Updated get_installation_status to (os, data_dir) only; removed asset lookup, download-dir checks, and checksum code.
  - Removed get_arch_enum usage and cleaned up related imports and unused filesystem/crypto utilities.
  - Adjusted callers to use the new installation status API; behavior now returns NotInstalled or ReadyToPlay based on the executable.

<!-- End of auto-generated description by cubic. -->

