### PR TITLE
feat(installer): prevent concurrent installs and clean old dirs

### DIFF
--- a/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
@@ -1,9 +1,6 @@
 import { Badge } from "@/components/ui/badge";
-import { Check, Loader2 } from "lucide-react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
-import { useAppSelector } from "@/store/hooks";
-import { useInstallationStatus } from "./hooks";
 import { useMemo } from "react";
 
 interface ReleaseLabelProps {
@@ -45,26 +42,10 @@ export default function ReleaseLabel({
     [variant, version],
   );
 
-  const { installationStatus } = useInstallationStatus(variant, version);
-  const progressStatus = useAppSelector(
-    (state) => state.installationProgress.statusByVariant[variant]?.[version],
-  );
-
-  let statusIcon = null;
-  if (progressStatus === "Downloading" || progressStatus === "Installing") {
-    statusIcon = <Loader2 className="h-4 w-4 animate-spin" />;
-  } else if (
-    progressStatus === "Success" ||
-    installationStatus === "ReadyToPlay"
-  ) {
-    statusIcon = <Check className="h-4 w-4 text-green-500" />;
-  }
-
   return (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">
-        <span>{shortReleaseName}</span>
-        {statusIcon}
+        {shortReleaseName}
       </div>
       {isLastPlayed && (
         <div className="flex items-center gap-1">

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -143,6 +143,13 @@ export default function ReleaseSelector({
   const isReleaseFetchingLoading =
     isReleasesTriggerLoading && comboboxItems.length === 0;
 
+  const installationStatusByVersion = useAppSelector(
+    (state) => state.installationProgress.statusByVariant[variant],
+  );
+  const isInstalling = Object.values(installationStatusByVersion ?? {}).some(
+    (status) => status === "Downloading" || status === "Installing",
+  );
+
   const placeholderText = isReleaseFetchingLoading
     ? "Loading..."
     : comboboxItems.length === 0
@@ -164,14 +171,14 @@ export default function ReleaseSelector({
             onChange={setSelectedReleaseId}
             autoselect={autoselect}
             placeholder={placeholderText}
-            disabled={isReleaseFetchingLoading}
+            disabled={isReleaseFetchingLoading || isInstalling}
           />
         </div>
         <Button
           variant="outline"
           size="icon"
           onClick={() => triggerFetchReleases(variant)}
-          disabled={!isReleaseFetchingComplete}
+          disabled={!isReleaseFetchingComplete || isInstalling}
         >
           <RefreshCw
             className={cn(!isReleaseFetchingComplete && "animate-spin")}


### PR DESCRIPTION
### **User description**
- Remove unused hook and rely on global installation progress state in
  ReleaseLabel to determine and render download/install status icons.
- Disable release selector controls while any installation for the
  variant is active to avoid triggering conflicting operations.
- On successful installation, delete other installation directories
  beside the current one to keep the install location clean and
  stale artifacts.

These changes prevent concurrent installs for the same variant,
improve UI feedback during installs, and ensure old installations are
removed after a successful install.


___

### **PR Type**
Enhancement


___

### **Description**
- Prevent concurrent installations by disabling release selector during active installs

- Clean up old installation directories after successful installation

- Simplify ReleaseLabel by removing unused installation status tracking logic

- Improve UI consistency by relying on global installation progress state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Completes"] --> B["Delete Other Installation Dirs"]
  B --> C["Clean Install Location"]
  D["Installation Active"] --> E["Disable Release Selector"]
  E --> F["Prevent Concurrent Installs"]
  G["Global Progress State"] --> H["Simplify ReleaseLabel Component"]
  H --> I["Remove Unused Hooks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install_release.rs</strong><dd><code>Add cleanup of old installation directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/install_release/install_release.rs

<ul><li>Add <code>delete_other_installations()</code> function to remove stale installation <br>directories<br> <li> Call cleanup function after successful installation to maintain clean <br>install location<br> <li> Function safely handles missing parent directories and read errors</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/207/files#diff-622ba6613a6ee5508c7e96fd54321d16adfbf604cc47bdda936440d15be7478a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReleaseLabel.tsx</strong><dd><code>Remove unused installation status tracking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx

<ul><li>Remove unused <code>useInstallationStatus</code> hook and related imports<br> <li> Remove status icon rendering logic that relied on local installation <br>state<br> <li> Simplify component to rely on global installation progress state <br>instead<br> <li> Remove <code>Loader2</code> and <code>Check</code> icon imports no longer needed</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/207/files#diff-d9e9323882d463074e5976634b4f6ac07f2f264dc654905d99a5da9e2bbbca40">+1/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReleaseSelector.tsx</strong><dd><code>Disable controls during active installations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx

<ul><li>Add check for active installations using global installation progress <br>state<br> <li> Disable version selector combobox when any installation is in progress<br> <li> Disable refresh button when any installation is in progress<br> <li> Prevent users from triggering conflicting operations during active <br>installs</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/207/files#diff-d4edef2318e1b05f17a9f0d94a0b580b1bf82554cee672573d5e1f80067c0b07">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent installs per variant and cleans up old installation folders after a successful install. Disables release selection while an install is in progress to avoid conflicting actions.

- **New Features**
  - Delete other installation directories after a successful install to keep the install location clean.
  - Disable release selector and refresh actions while the variant is downloading or installing.

- **Refactors**
  - Removed an unused installation status hook and simplified ReleaseLabel by dropping local status icon logic.

<sup>Written for commit 5cb24d4f29c75efb5bafe2e915d8c58f2c8ef95c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



