### PR TITLE
feat(releases): determine latest release by created_at and fix ordering

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -82,12 +82,10 @@ pub fn get_releases_payload(
     gh_releases: &[GitHubRelease],
     status: ReleasesUpdateStatus,
 ) -> ReleasesUpdatePayload {
-    let mut releases: Vec<GameRelease> = gh_releases
+    let releases: Vec<GameRelease> = gh_releases
         .iter()
         .map(|r| gh_release_to_game_release(r, variant))
         .collect();
-
-    releases.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
     ReleasesUpdatePayload {
         variant: *variant,

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -90,11 +90,25 @@ export default function ReleaseSelector({
   );
 
   const comboboxItems = useMemo<ComboboxItem[]>(() => {
-    const latestRelease = releases[0];
+    const latestRelease = releases.reduce(
+      (prev: undefined | GameRelease, curr) => {
+        if (!prev) {
+          return curr;
+        }
+
+        if (curr.created_at > prev.created_at) {
+          return curr;
+        }
+
+        return prev;
+      },
+      undefined,
+    );
+
     return (
       releases.filter(appliedFilter).map((r) => {
         const isActive = r.version === activeRelease;
-        const isLatest = r.id === latestRelease?.id;
+        const isLatest = r.version === latestRelease?.version;
 
         return {
           value: r.version,


### PR DESCRIPTION
### **User description**
Change latest-release selection logic to compute the most recent release
by comparing created_at timestamps in TypeScript instead of assuming the
first element is the newest. Update Rust payload construction to stop
unnecessary sorting and return releases in the original order.

This reduces incorrect identification of the latest release when the
releases array is not pre-sorted and avoids an extra sort operation on
the Rust side.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Determine latest release by comparing `created_at` timestamps instead of assuming first element

- Remove unnecessary sorting operation from Rust payload construction

- Fix latest release identification to use `version` comparison for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rust: Remove sort operation"] --> B["Return releases in original order"]
  C["TypeScript: Compute latest by created_at"] --> D["Identify latest release correctly"]
  B --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Remove unnecessary release sorting in Rust</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/utils.rs

<ul><li>Removed <code>mut</code> keyword from <code>releases</code> variable declaration<br> <li> Removed <code>sort_by</code> operation that sorted releases by <code>created_at</code> in <br>descending order<br> <li> Releases now returned in original order without unnecessary sorting</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/218/files#diff-119eef27e04fbf03c964f89066867f12f0152b9c1a8cc05acb2df48bc0fdd721">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReleaseSelector.tsx</strong><dd><code>Determine latest release by timestamp comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx

<ul><li>Changed latest release detection from array index access to <code>reduce</code> <br>operation comparing <code>created_at</code> timestamps<br> <li> Updated latest release comparison from <code>id</code> to <code>version</code> field for <br>consistency<br> <li> Properly handles unsorted releases array by iterating through all <br>elements</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/218/files#diff-d4edef2318e1b05f17a9f0d94a0b580b1bf82554cee672573d5e1f80067c0b07">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix latest release detection by comparing created_at timestamps on the client and remove Rust-side sorting to preserve original order. This prevents incorrect "latest" tagging when releases aren’t pre-sorted and avoids an unnecessary sort.

- **Bug Fixes**
  - Compute latest release via created_at in ReleaseSelector instead of assuming the first item.
  - Mark latest by version match for consistent UI behavior.

- **Refactors**
  - Remove release sorting in Rust payload construction; return releases as received.

<sup>Written for commit 730ca4ad6cd2f70696fa1b042e52a783ec00b388. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

