### PR TITLE
feat(backups): add backup filter UI and apply filtering

### DIFF
--- a/cat-launcher/src/pages/BackupsPage/BackupFilter.tsx
+++ b/cat-launcher/src/pages/BackupsPage/BackupFilter.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { CombinedBackup } from "./types/backups";
+
+export type BackupFilterFn = (backup: CombinedBackup) => boolean;
+
+export type BackupFilter = {
+  id: "automatic" | "manual";
+  label: string;
+  apply: BackupFilterFn;
+};
+
+interface BackupFilterProps {
+  onChange: (filterFn: BackupFilterFn) => void;
+}
+
+const FILTERS: BackupFilter[] = [
+  {
+    id: "automatic",
+    label: "Automatic",
+    apply: (backup) => backup.type === "automatic",
+  },
+  {
+    id: "manual",
+    label: "Manual",
+    apply: (backup) => backup.type === "manual",
+  },
+];
+
+export default function BackupFilter({ onChange }: BackupFilterProps) {
+  const [selectedFilterIds, setSelectedFilterIds] = useState<
+    ("automatic" | "manual")[]
+  >(FILTERS.map((f) => f.id)); // default to all filters selected
+
+  function handleCheckedChange(
+    checked: boolean,
+    filterId: "automatic" | "manual",
+  ) {
+    const appliedFilterIds = new Set(selectedFilterIds);
+
+    if (checked) {
+      appliedFilterIds.add(filterId);
+    } else {
+      appliedFilterIds.delete(filterId);
+    }
+
+    const appliedFilters = Array.from(appliedFilterIds).map(
+      (fid) => FILTERS.find((f) => f.id === fid)!,
+    );
+    setSelectedFilterIds(appliedFilters.map((f) => f.id));
+
+    const effectiveFilter: BackupFilterFn = (backup) => {
+      // If no filters are selected, show nothing
+      if (appliedFilters.length === 0) {
+        return false;
+      }
+      return appliedFilters.some((f) => f.apply(backup));
+    };
+
+    onChange(effectiveFilter);
+  }
+
+  return (
+    <div className="flex items-center space-x-4">
+      {FILTERS.map((filter) => {
+        const key = `backup-filter-${filter.id}`;
+
+        return (
+          <div key={key} className="flex items-center space-x-2">
+            <Checkbox
+              id={key}
+              checked={selectedFilterIds.includes(filter.id)}
+              onCheckedChange={(checked: boolean) =>
+                handleCheckedChange(checked, filter.id)
+              }
+            />
+            <Label htmlFor={key} className="text-sm font-medium">
+              {filter.label}
+            </Label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
### **User description**
Introduce a BackupFilter component that lets users toggle automatic
and manual backup types. Wire its filter function into BackupsPage,
store the selected filter in state, and compute filteredBackups with
useMemo. Pass filteredBackups to BackupsTable so the table reflects the
active filter selection.

Also:
- create BackupFilter.tsx with Checkbox/Label controls and a composed
  filter function type (BackupFilterFn).
- reorder and clean up imports in BackupsPage.
- initialize appliedFilter to a no-op passthrough and ensure state
  formatting is consistent.
- adjust dialog and backup state declarations for clarity.

This enables client-side filtering of backups for improved UX.


___

### **PR Type**
Enhancement


___

### **Description**
- Add BackupFilter component with automatic/manual backup type toggles

- Implement client-side filtering with useMemo for performance

- Wire filter state into BackupsPage and pass filtered results to table

- Reorganize imports for consistency and clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BackupFilter["BackupFilter Component"]
  BackupFilterFn["BackupFilterFn Type"]
  BackupsPage["BackupsPage State"]
  FilteredBackups["Filtered Backups"]
  BackupsTable["BackupsTable Display"]
  
  BackupFilter -- "onChange callback" --> BackupsPage
  BackupFilterFn -- "defines filter logic" --> BackupFilter
  BackupsPage -- "applies filter with useMemo" --> FilteredBackups
  FilteredBackups -- "passes filtered rows" --> BackupsTable
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackupFilter.tsx</strong><dd><code>New BackupFilter component with toggle controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/BackupsPage/BackupFilter.tsx

<ul><li>New component with checkbox controls for automatic and manual backup <br>filters<br> <li> Defines BackupFilterFn type for composable filter functions<br> <li> Manages selected filter state and composes filter logic with OR <br>operation<br> <li> Returns false when no filters selected to show no results</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/222/files#diff-1f9198961b9774603e14d9ea4c7bf1c4b9ea945dfbc21f2cef4568f36df7aee3">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Integrate backup filtering with state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/BackupsPage/index.tsx

<ul><li>Import BackupFilter component and BackupFilterFn type<br> <li> Add useMemo import for performance optimization<br> <li> Initialize appliedFilter state with no-op passthrough function<br> <li> Compute filteredBackups using useMemo with combinedBackups and <br>appliedFilter<br> <li> Render BackupFilter component and pass filteredBackups to BackupsTable<br> <li> Reorganize imports alphabetically for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/222/files#diff-21a1a501016807e7346ac1c2c6e9ccc1583b7f36e4571c5345e4981374da40e8">+22/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a BackupFilter UI to toggle automatic and manual backups and applies client-side filtering in BackupsPage. The table now shows only backups that match the selected filters.

- **New Features**
  - New BackupFilter component with checkboxes for automatic/manual.
  - BackupFilterFn type and state to hold the active filter.
  - Filtered backups computed with useMemo and passed to BackupsTable.

- **Refactors**
  - Reordered imports in BackupsPage for consistency.

<sup>Written for commit 0145d6b1804701f0586b31afad223d527725bccf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

