### PR TITLE
fix(backups): use BigInt IDs and normalize manual backup fields

### DIFF
--- a/cat-launcher/src/hooks/useCombinedBackups.ts
+++ b/cat-launcher/src/hooks/useCombinedBackups.ts
@@ -11,91 +11,91 @@ import { useRestoreManualBackup } from "./useRestoreManualBackup";
 import { useCreateManualBackup } from "./useCreateManualBackup";
 
 interface UseCombinedBackupsOptions {
-    onDeleteSuccess?: () => void;
-    onDeleteError?: (error: unknown) => void;
-    onRestoreSuccess?: () => void;
-    onRestoreError?: (error: unknown) => void;
-    onCreateSuccess?: () => void;
-    onCreateError?: (error: unknown) => void;
+  onDeleteSuccess?: () => void;
+  onDeleteError?: (error: unknown) => void;
+  onRestoreSuccess?: () => void;
+  onRestoreError?: (error: unknown) => void;
+  onCreateSuccess?: () => void;
+  onCreateError?: (error: unknown) => void;
 }
 
 export function useCombinedBackups(
-    variant: GameVariant,
-    {
-        onDeleteSuccess,
-        onDeleteError,
-        onRestoreSuccess,
-        onRestoreError,
-        onCreateSuccess,
-        onCreateError,
-    }: UseCombinedBackupsOptions = {}
+  variant: GameVariant,
+  {
+    onDeleteSuccess,
+    onDeleteError,
+    onRestoreSuccess,
+    onRestoreError,
+    onCreateSuccess,
+    onCreateError,
+  }: UseCombinedBackupsOptions = {},
 ) {
-    const { backups, isLoading: backupsLoading } = useBackups(variant);
-    const { manualBackups, isLoading: manualBackupsLoading } =
-        useManualBackups(variant);
+  const { backups, isLoading: backupsLoading } = useBackups(variant);
+  const { manualBackups, isLoading: manualBackupsLoading } =
+    useManualBackups(variant);
 
-    const { deleteBackup: deleteAutoBackup } = useDeleteBackup(variant, {
-        onSuccess: onDeleteSuccess,
-        onError: onDeleteError,
-    });
+  const { deleteBackup: deleteAutoBackup } = useDeleteBackup(variant, {
+    onSuccess: onDeleteSuccess,
+    onError: onDeleteError,
+  });
 
-    const { deleteManualBackup } = useDeleteManualBackup(variant, {
-        onSuccess: onDeleteSuccess,
-        onError: onDeleteError,
-    });
+  const { deleteManualBackup } = useDeleteManualBackup(variant, {
+    onSuccess: onDeleteSuccess,
+    onError: onDeleteError,
+  });
 
-    const { restoreBackup: restoreAutoBackup } = useRestoreBackup({
-        onSuccess: onRestoreSuccess,
-        onError: onRestoreError,
-    });
+  const { restoreBackup: restoreAutoBackup } = useRestoreBackup({
+    onSuccess: onRestoreSuccess,
+    onError: onRestoreError,
+  });
 
-    const { restoreManualBackup } = useRestoreManualBackup({
-        onSuccess: onRestoreSuccess,
-        onError: onRestoreError,
-    });
+  const { restoreManualBackup } = useRestoreManualBackup({
+    onSuccess: onRestoreSuccess,
+    onError: onRestoreError,
+  });
 
-    const { createManualBackup } = useCreateManualBackup(variant, {
-        onSuccess: onCreateSuccess,
-        onError: onCreateError,
-    });
+  const { createManualBackup } = useCreateManualBackup(variant, {
+    onSuccess: onCreateSuccess,
+    onError: onCreateError,
+  });
 
-    const combinedBackups = useMemo(() => {
-        if (backupsLoading || manualBackupsLoading) {
-            return [];
-        }
+  const combinedBackups = useMemo(() => {
+    if (backupsLoading || manualBackupsLoading) {
+      return [];
+    }
 
-        return [
-            ...backups.map((b) => ({
-                ...b,
-                type: "automatic" as const,
-                name: `Automatic-${b.id}`,
-                notes: "Automatic backup",
-            })),
-            ...manualBackups.map((b) => ({ ...b, type: "manual" as const })),
-        ];
-    }, [backups, manualBackups, backupsLoading, manualBackupsLoading]);
+    return [
+      ...backups.map((b) => ({
+        ...b,
+        type: "automatic" as const,
+        name: `Automatic-${b.id}`,
+        notes: "Automatic backup",
+      })),
+      ...manualBackups.map((b) => ({ ...b, type: "manual" as const })),
+    ];
+  }, [backups, manualBackups, backupsLoading, manualBackupsLoading]);
 
-    const deleteBackup = (backup: CombinedBackup) => {
-        if (backup.type === "manual") {
-            deleteManualBackup(backup.id);
-        } else {
-            deleteAutoBackup(backup.id);
-        }
-    };
+  const deleteBackup = (backup: CombinedBackup) => {
+    if (backup.type === "manual") {
+      deleteManualBackup(Number(backup.id));
+    } else {
+      deleteAutoBackup(Number(backup.id));
+    }
+  };
 
-    const restoreBackup = (backup: CombinedBackup) => {
-        if (backup.type === "manual") {
-            restoreManualBackup(backup.id);
-        } else {
-            restoreAutoBackup(backup.id);
-        }
-    };
+  const restoreBackup = (backup: CombinedBackup) => {
+    if (backup.type === "manual") {
+      restoreManualBackup(Number(backup.id));
+    } else {
+      restoreAutoBackup(Number(backup.id));
+    }
+  };
 
-    return {
-        combinedBackups,
-        isLoading: backupsLoading || manualBackupsLoading,
-        createManualBackup,
-        deleteBackup,
-        restoreBackup,
-    };
+  return {
+    combinedBackups,
+    isLoading: backupsLoading || manualBackupsLoading,
+    createManualBackup,
+    deleteBackup,
+    restoreBackup,
+  };
 }

--- a/cat-launcher/src/hooks/useCreateManualBackup.ts
+++ b/cat-launcher/src/hooks/useCreateManualBackup.ts
@@ -32,17 +32,18 @@ export function useCreateManualBackup(
         (old) => [
           ...(old ?? []),
           {
-            ...newBackup,
-            id: -1, // Temporary ID
+            id: BigInt(-1), // Temporary ID
+            name: newBackup.name,
             game_variant: variant,
-            timestamp: Date.now() / 1000,
+            timestamp: BigInt(Date.now() / 1000),
+            notes: newBackup.notes ?? null,
           },
         ],
       );
 
       return { previousBackups };
     },
-    onError: (err, newBackup, context) => {
+    onError: (err, _newBackup, context) => {
       queryClient.setQueryData(
         queryKeys.manualBackups(variant),
         context?.previousBackups,

--- a/cat-launcher/src/hooks/useDeleteBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteBackup.ts
@@ -12,7 +12,7 @@ interface UseDeleteBackupOptions {
 
 export function useDeleteBackup(
   variant: GameVariant,
-  { onSuccess, onError }: UseDeleteBackupOptions = {}
+  { onSuccess, onError }: UseDeleteBackupOptions = {},
 ) {
   const queryClient = useQueryClient();
 
@@ -22,12 +22,12 @@ export function useDeleteBackup(
       await queryClient.cancelQueries({ queryKey: queryKeys.backups(variant) });
 
       const previousBackups = queryClient.getQueryData<BackupEntry[]>(
-        queryKeys.backups(variant)
+        queryKeys.backups(variant),
       );
 
       queryClient.setQueryData<BackupEntry[]>(
         queryKeys.backups(variant),
-        (old) => old?.filter((backup) => backup.id !== id) ?? []
+        (old) => old?.filter((backup) => Number(backup.id) !== id) ?? [],
       );
 
       return { previousBackups };
@@ -37,7 +37,7 @@ export function useDeleteBackup(
       if (context?.previousBackups) {
         queryClient.setQueryData(
           queryKeys.backups(variant),
-          context.previousBackups
+          context.previousBackups,
         );
       }
       onError?.(error);

--- a/cat-launcher/src/hooks/useDeleteManualBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteManualBackup.ts
@@ -29,12 +29,12 @@ export function useDeleteManualBackup(
 
       queryClient.setQueryData<ManualBackupEntry[]>(
         queryKeys.manualBackups(variant),
-        (old) => (old ?? []).filter((backup) => backup.id !== id),
+        (old) => (old ?? []).filter((backup) => Number(backup.id) !== id),
       );
 
       return { previousBackups };
     },
-    onError: (err, id, context) => {
+    onError: (err, _id, context) => {
       queryClient.setQueryData(
         queryKeys.manualBackups(variant),
         context?.previousBackups,


### PR DESCRIPTION
### **User description**
Convert temporary and timestamp fields for manual backups to BigInt and
normalize the manual backup object shape before inserting into cache.
Add explicit name and notes fields (notes defaulting to null) and avoid
spreading the entire newBackup into the optimistic update. Rename an
unused parameter to _newBackup in the error handler to clarify intent.

Also apply consistent formatting and indentation in useCombinedBackups to
match project style (minor whitespace and alignment adjustments).


___

### **PR Type**
Bug fix


___

### **Description**
- Convert backup IDs to BigInt type for manual backups

- Normalize manual backup object shape with explicit fields

- Add Number() conversions when comparing BigInt IDs

- Standardize indentation and formatting throughout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual Backup Creation"] -->|"Convert to BigInt"| B["ID and Timestamp"]
  B -->|"Normalize Shape"| C["Explicit name/notes fields"]
  C -->|"Cache Update"| D["Optimistic Update"]
  E["Backup Operations"] -->|"Convert BigInt to Number"| F["ID Comparisons"]
  F -->|"Filter/Delete"| G["Backup Lists"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCombinedBackups.ts</strong><dd><code>Standardize formatting and add ID conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useCombinedBackups.ts

<ul><li>Standardized indentation from 4 spaces to 2 spaces throughout file<br> <li> Added Number() conversion when passing backup IDs to delete/restore <br>functions<br> <li> Improved code consistency and readability</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/224/files#diff-d1c6d596f1b7498d260b1da9ddf0a5d61b200b0260ef5c11d99c24cc0a2fb7fa">+73/-73</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCreateManualBackup.ts</strong><dd><code>Normalize manual backup with BigInt fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useCreateManualBackup.ts

<ul><li>Convert temporary ID from -1 to BigInt(-1)<br> <li> Convert timestamp to BigInt(Date.now() / 1000)<br> <li> Add explicit name and notes fields to normalized backup object<br> <li> Rename unused parameter from newBackup to _newBackup in error handler<br> <li> Remove spread operator to avoid including unnecessary fields</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/224/files#diff-5698e5a92a9c0bb65385b2ceb7812e8a4222fed8adcd74bfdae9e518fe75f828">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useDeleteBackup.ts</strong><dd><code>Add BigInt to Number conversion for ID comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useDeleteBackup.ts

<ul><li>Add Number() conversion when comparing BigInt backup IDs<br> <li> Fix trailing comma formatting in function parameters<br> <li> Improve code consistency with trailing commas in object literals</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/224/files#diff-29159d2cb611041fd7c274b30be3b7e5655740eaa31967a5a95cb929381fdb2e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useDeleteManualBackup.ts</strong><dd><code>Add BigInt conversion and clarify unused parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useDeleteManualBackup.ts

<ul><li>Add Number() conversion when comparing BigInt backup IDs in filter<br> <li> Rename unused parameter from id to _id in error handler</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/224/files#diff-b7cad93b027e2a24b8e7d34eebb29a6f8920b819311549a6ab2be8f0d13d7057">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use BigInt for manual backup IDs and timestamps, and normalize manual backup fields in optimistic updates to resolve type mismatches. Fixes TS prod build issues and makes delete/restore logic and caching consistent.

- **Bug Fixes**
  - Normalize manual backup cache entries: id BigInt(-1), timestamp BigInt, name, notes default to null.
  - Cast backup.id to Number for delete/restore calls and cache filters to avoid BigInt/number comparisons.
  - Avoid spreading the entire newBackup in optimistic updates to keep types stable.

- **Refactors**
  - Apply consistent formatting and indentation in useCombinedBackups.

<sup>Written for commit 5faf305fdce0ec5c61cc72a5979f811e4650b4f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

