### PR TITLE
refactor(play_time): remove PlayTime DTO and unused derives

### DIFF
--- a/cat-launcher/src-tauri/src/play_time/repository.rs
+++ b/cat-launcher/src-tauri/src/play_time/repository.rs
@@ -1,16 +1,6 @@
 use async_trait::async_trait;
-use serde::Serialize;
-use ts_rs::TS;
 
 use crate::variants::GameVariant;
-
-#[derive(Debug, Serialize, TS, Clone)]
-#[ts(export)]
-pub struct PlayTime {
-    pub game_variant: String,
-    pub version: String,
-    pub duration_in_seconds: i64,
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum PlayTimeRepositoryError {


### PR DESCRIPTION
### **User description**
Remove the PlayTime struct and its associated derives (Serialize, TS, Clone)
and ts export from play_time repository module. Also remove the ts_rs and
serde imports that were only used for that DTO.

This eliminates an unused data transfer type and cleans up unused
dependencies in the module, reducing compile noise and avoiding unnecessary
exports.


___

### **PR Type**
Enhancement


___

### **Description**
- Removes unused `PlayTime` struct from repository module

- Eliminates unnecessary `serde` and `ts_rs` imports

- Reduces compile noise and unused exports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["play_time/repository.rs"] -- "removes PlayTime struct" --> B["Cleaner module"]
  A -- "removes serde, ts_rs imports" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repository.rs</strong><dd><code>Remove PlayTime DTO and unused imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/play_time/repository.rs

<ul><li>Removes <code>PlayTime</code> struct definition with <code>Debug</code>, <code>Serialize</code>, <code>TS</code>, and <br><code>Clone</code> derives<br> <li> Removes <code>#[ts(export)]</code> attribute<br> <li> Removes unused <code>serde::Serialize</code> import<br> <li> Removes unused <code>ts_rs::TS</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/225/files#diff-8038de5f87eb9834b829d042eeab6e39948ec65cf807e38e38d70f86e527cc8f">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused PlayTime DTO from the play_time repository, including its derives (Serialize, TS, Clone) and #[ts(export)]. Also removed the unused serde and ts_rs imports to reduce compile noise and avoid unnecessary exports.

<sup>Written for commit e386d4ffb950de85b03e10b9e766dbd4b9824db3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

