### PR TITLE
chore(release): bump project version to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ CatLauncher is 100% open-source and the .dmg is built directly from the source c
 
 Downloading the AppImage is the easiest way to install CatLauncher and keep it automatically up-to-date. However, the AppImage may not work on all Linux distros. It's been tested to work on Ubuntu 24.04.
 
-To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.8.0_amd64.AppImage`, and then run it like you would any other executable.
+To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.8.1_amd64.AppImage`, and then run it like you would any other executable.
 
 If you encounter issues with the AppImage, you can try installing CatLauncher using the .deb or the .rpm package. It would also help if you can open an issue on GitHub with details of your distro.
 

--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "cat-macros",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.8.0"
+version = "0.8.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
### **User description**
Update version references across project files to prepare the
0.8.1 release. Change the AppImage filename in README to match the
new release, and update version fields in Cargo.toml, Cargo.lock,
tauri.conf.json, and package.json so packaging and build metadata
remain consistent.

This ensures installers, build tooling, and documentation all
reference the same release version.


___

### **PR Type**
Other


___

### **Description**
- Bump project version from 0.8.0 to 0.8.1

- Update version in Cargo.toml, package.json, tauri.conf.json

- Update AppImage filename reference in README documentation

- Ensure consistent version across all build and packaging metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 0.8.0"] -->|Update| B["Cargo.toml"]
  A -->|Update| C["package.json"]
  A -->|Update| D["tauri.conf.json"]
  A -->|Update| E["README.md"]
  B --> F["Version 0.8.1"]
  C --> F
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update AppImage filename to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update AppImage filename from <code>cat-launcher_0.8.0_amd64.AppImage</code> to <br><code>cat-launcher_0.8.1_amd64.AppImage</code><br> <li> Reflects new release version in installation instructions</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/234/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump npm package version to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/package.json

<ul><li>Update version field from "0.8.0" to "0.8.1"<br> <li> Ensures npm package metadata matches release version</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/234/files#diff-0f82b8d2b9f21dbc61745f560e387f5e77c43354f5107fcb2547d156eded0f24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Cargo package version to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/Cargo.toml

<ul><li>Update version field from "0.8.0" to "0.8.1"<br> <li> Keeps Rust crate version in sync with release</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/234/files#diff-2b3d88798673dc02d1dc670095173dd88479151362c6e11fab9cbc66502c2f29">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri configuration version to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/tauri.conf.json

<ul><li>Update version field from "0.8.0" to "0.8.1"<br> <li> Ensures Tauri build configuration reflects new release version</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/234/files#diff-a129d0a394e29d198f60425580a5ef2de79dfc1717a9252f1190ec4618cfb0db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped project version to 0.8.1 across Cargo.toml/Cargo.lock, tauri.conf.json, package.json, and README to prepare the release. This keeps packaging, build metadata, and docs aligned and updates the AppImage command so users run the 0.8.1 binary.

<sup>Written for commit b8038bbd7c4366a561da9cf8943e83bff9165b1d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

