### PR TITLE
chore(release): bump latest.json to v0.8.1 and update assets

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,51 +1,51 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "notes": "",
-  "pub_date": "2025-12-10T15:39:25.384Z",
+  "pub_date": "2025-12-11T13:51:56.043Z",
   "platforms": {
     "darwin-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEJod2VhSkkyeE9QY2VJOUwyMENjc2FZK2sweThPTitVZWNHWFJsbkQzTmg1YzE2T3BpclRHV0p4Y0Nkek92VU9aRTVxbm1hd1VaaGl1SEV5ZnVOUFFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwODc1CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKQmN1c2E0d2RDS0VBb0YyRU9KR044TlNYT0JpYzNqcmVZNit2TmlRTXVyYzkvVDR3R1hFZnN5TEdGZmVsd28vWkt2Tm9jT2VNNU5YVjNFdlFZTTZHQ3c9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_x64.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEtyRlVJY3haOUFOU1lGTFZGVm5rdVhXeVd3ZTAvbkloN3phU0NmN0Z4RHBGY1dZb0FSaTZEOC9HUEN5Tis1TFE2bGhiYjJFeitDeW83VXh3NEd1c1F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDU5OTA4CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKV08vZHBMTVZuczdKdVh1cnVNQXB4NFVlcDhnZDIzWWg0UTljQ3h0SE1RQUNvUjlrSlA1NHdXM2FwNDhMcjJUeXZ2WUlINVNnaEtqRmdnWmVTTWxwQlE9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_x64.app.tar.gz"
     },
     "darwin-x86_64-app": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEJod2VhSkkyeE9QY2VJOUwyMENjc2FZK2sweThPTitVZWNHWFJsbkQzTmg1YzE2T3BpclRHV0p4Y0Nkek92VU9aRTVxbm1hd1VaaGl1SEV5ZnVOUFFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwODc1CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKQmN1c2E0d2RDS0VBb0YyRU9KR044TlNYT0JpYzNqcmVZNit2TmlRTXVyYzkvVDR3R1hFZnN5TEdGZmVsd28vWkt2Tm9jT2VNNU5YVjNFdlFZTTZHQ3c9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_x64.app.tar.gz"
-    },
-    "linux-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEZrZWk1RStPeTR2UGJqbW9HYTF5eHdmanZEZDVtMmZ2anVaOUZZT09lb1VGNG5JM1paSzg0cnVPRE5hWUpvemJXSEh3Zm02WUt1bitZd25xeDdYdndvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTM0CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX2FtZDY0LkFwcEltYWdlCjQxcThPYURqTitsSDdJY0MxdFV0OHU4MHBENllDb3g3S2YrYU1tOFYrMGJNSnZqbVg2NzZVNkh3cTJCYnVzNGtXaVJOM0JvVnVnNU4zQXh4VFFRekNBPT0K",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_amd64.AppImage"
-    },
-    "linux-x86_64-appimage": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEZrZWk1RStPeTR2UGJqbW9HYTF5eHdmanZEZDVtMmZ2anVaOUZZT09lb1VGNG5JM1paSzg0cnVPRE5hWUpvemJXSEh3Zm02WUt1bitZd25xeDdYdndvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTM0CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX2FtZDY0LkFwcEltYWdlCjQxcThPYURqTitsSDdJY0MxdFV0OHU4MHBENllDb3g3S2YrYU1tOFYrMGJNSnZqbVg2NzZVNkh3cTJCYnVzNGtXaVJOM0JvVnVnNU4zQXh4VFFRekNBPT0K",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_amd64.AppImage"
-    },
-    "linux-x86_64-deb": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VE1tYkRIUXFzZzhKYU1IMmVZb3RVMWlhSHdFS3lmK0puMlhkSUtySW9UQ3J2eXdOMGFFck9ucVFyd1hmSXNZQy9POHhqN3BzUnFJRTA1UXJERmM3clFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTM0CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX2FtZDY0LmRlYgp4cVBwaFZnZ2hxOVFMM1Vob2x2ZGZMOFltQlo4czZQNTcwMjR6NjA2YjJMUjB2MEhQTFBWUFZ4d0sxejlPZGhLRU51b1JybjlONjE2cDJKYUlsMmxCdz09Cg==",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_amd64.deb"
-    },
-    "linux-x86_64-rpm": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFBZWUhlVktFWEFXdXpaWFVIRHFiN0RlUVBFS0F1R1FMTGVYRG1pQlFUQ3pRbEVML0grYkhKbk53cXpRTytxWEo3MFUzNTZxaFJzWkVtVkhxa2drMlFNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTM0CWZpbGU6Y2F0LWxhdW5jaGVyLTAuOC4wLTEueDg2XzY0LnJwbQo3YXJZLy9adDdoUlMyL1doNHhWUk0xaTZ5NWQ4ZTFYalk3UXAyb1E0b09kTXI0UXZ3dG10S2tyZ0FRWDdTdS9VT2hxWVJwZkJjWS8zd2RYeFc0TXBCQT09Cg==",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher-0.8.0-1.x86_64.rpm"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEtyRlVJY3haOUFOU1lGTFZGVm5rdVhXeVd3ZTAvbkloN3phU0NmN0Z4RHBGY1dZb0FSaTZEOC9HUEN5Tis1TFE2bGhiYjJFeitDeW83VXh3NEd1c1F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDU5OTA4CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKV08vZHBMTVZuczdKdVh1cnVNQXB4NFVlcDhnZDIzWWg0UTljQ3h0SE1RQUNvUjlrSlA1NHdXM2FwNDhMcjJUeXZ2WUlINVNnaEtqRmdnWmVTTWxwQlE9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_x64.app.tar.gz"
     },
     "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VE9EQ3NKM1NuVEcxdUhnZ3FvZ2dkZzlKc2x1dWlLVUVWeW0xL0JiWUxjdWhYenlUNUxrL21pNVY0dnVnV1FIbW9pWk9HRFRzOU5BcldXNStjcDRtYVF3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTgxCWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKRmZla1NYM0hoZ0dsbnNLNCtBbHFLMjhNTmVsa2JiQlkwVm04QzBDSm41a0p5ajA2UmVYWnBjWUluRnVOdHNoY0IxRCtMdHVraExwZUlqZUsvbHljQkE9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_aarch64.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFByenh5Wmk5QTh6Q0M2ZUlvNW9kM053OXhQY3JtM3B6Q2htUTUydFhRYmhUYldKUjhtamVHQlRkL0NhZzV3cG9CMlJwV2YxM0VVY0NSME81Vm9zSWd3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYwMjc2CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKOTRrLzZuVWZaeXB6UlNmWmtEa0VlclBCMmtaSEkwVitQamM1all3Wk45ZjNiN3c1QWNNNXlKYVA2eW8yWktBZnJ5OTNzYUNEMnZDUUpVK0hjazRvQXc9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_aarch64.app.tar.gz"
     },
     "darwin-aarch64-app": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VE9EQ3NKM1NuVEcxdUhnZ3FvZ2dkZzlKc2x1dWlLVUVWeW0xL0JiWUxjdWhYenlUNUxrL21pNVY0dnVnV1FIbW9pWk9HRFRzOU5BcldXNStjcDRtYVF3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgwOTgxCWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKRmZla1NYM0hoZ0dsbnNLNCtBbHFLMjhNTmVsa2JiQlkwVm04QzBDSm41a0p5ajA2UmVYWnBjWUluRnVOdHNoY0IxRCtMdHVraExwZUlqZUsvbHljQkE9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_aarch64.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFByenh5Wmk5QTh6Q0M2ZUlvNW9kM053OXhQY3JtM3B6Q2htUTUydFhRYmhUYldKUjhtamVHQlRkL0NhZzV3cG9CMlJwV2YxM0VVY0NSME81Vm9zSWd3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYwMjc2CWZpbGU6Y2F0LWxhdW5jaGVyLmFwcC50YXIuZ3oKOTRrLzZuVWZaeXB6UlNmWmtEa0VlclBCMmtaSEkwVitQamM1all3Wk45ZjNiN3c1QWNNNXlKYVA2eW8yWktBZnJ5OTNzYUNEMnZDUUpVK0hjazRvQXc9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_aarch64.app.tar.gz"
     },
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFBZYVVoSnNORlBEV3k1d1NmMml1Mk1jdWQ5Wi9TVXJsallEMW1yQUc2RlFia2F2bnV3WS85Ykp6RzVzY3psWGI3dWpjVEt1cWplSzFHVlovYm9FYWdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgxMTYyCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX3g2NC1zZXR1cC5leGUKT1JhaEYvaEJwRWZ1MURiMU5OODZHRThIck1teXRZZ3RFSHRST1UrQnIwUDFDeFBWTWwwZDFwaVBCZXhlQldXb3lrcVdNcTZKUEVsZTFndVBkYk1sRHc9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_x64-setup.exe"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEtyeWtWdTVGY0szV0EyTkhXQ21kVDljcjg0eUduaGJrVmZwRmo1WkVWb3NTK3lNMVhuWjI5aHJHaDZrRnA4eWY1cXllMElZMXJSRlptdUFPRFFBc1FrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYwMzkzCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX3g2NC1zZXR1cC5leGUKTUNZMzRPOTVTdmtHWFpTbmZtTlBQdXljcW00SkQ0YXpreGxWck5aTmhuZUpZMENIOUdCcE91OEVPVXRYTFFtR2pJY2xQMTNDQ1RtQXlTSUY0UEU4QVE9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_x64-setup.exe"
     },
     "windows-x86_64-nsis": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFBZYVVoSnNORlBEV3k1d1NmMml1Mk1jdWQ5Wi9TVXJsallEMW1yQUc2RlFia2F2bnV3WS85Ykp6RzVzY3psWGI3dWpjVEt1cWplSzFHVlovYm9FYWdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgxMTYyCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX3g2NC1zZXR1cC5leGUKT1JhaEYvaEJwRWZ1MURiMU5OODZHRThIck1teXRZZ3RFSHRST1UrQnIwUDFDeFBWTWwwZDFwaVBCZXhlQldXb3lrcVdNcTZKUEVsZTFndVBkYk1sRHc9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_x64-setup.exe"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEtyeWtWdTVGY0szV0EyTkhXQ21kVDljcjg0eUduaGJrVmZwRmo1WkVWb3NTK3lNMVhuWjI5aHJHaDZrRnA4eWY1cXllMElZMXJSRlptdUFPRFFBc1FrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYwMzkzCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX3g2NC1zZXR1cC5leGUKTUNZMzRPOTVTdmtHWFpTbmZtTlBQdXljcW00SkQ0YXpreGxWck5aTmhuZUpZMENIOUdCcE91OEVPVXRYTFFtR2pJY2xQMTNDQ1RtQXlTSUY0UEU4QVE9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_x64-setup.exe"
     },
     "windows-x86_64-msi": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEkrR0h2YnRsUHFoSkZHSllmOExFSUtkREV6OURreklVNklTbllObGZMZHJXM0liRElLeEV0MUk2cmIySnlqaDh1anV6UHEydU1UcFFtSTBKeXRTalFzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1MzgxMTYyCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4wX3g2NF9lbi1VUy5tc2kKdTZvSkpLZStROHgyeW9QeG02TWtrM25qQlFSdEtwbG04UjFwR3VSSEZIQStmaUNKMUdQYWcvcHEvd2d1QWlZQytEQnJieERIN0ZidTgyRm5zbGk0Q3c9PQo=",
-      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.0/cat-launcher_0.8.0_x64_en-US.msi"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VE5zK2poaFBxOFNmNGlXMmRyTVBCWlJkbmR2OGRDWDRXMU1JeVM2QVpYTzBscy9NTUttc3kxOVp1aGIzSFN6MXlhQnpjRExQVzNTdnE2aVgxTE50MHdFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYwMzkzCWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX3g2NF9lbi1VUy5tc2kKZDBCbktoL2tVTjJmQkFUYVU4OXJ2YktaMmVMUlNXME45TkhDeVJUT0RZY3FWdmhVVXUrYzBtbU05bkF3SjEwZ2hGSlZRMkVDRlRXTXczZzdYTFFYQmc9PQo=",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_x64_en-US.msi"
+    },
+    "linux-x86_64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEpuWk1JVU1xbElVZkcvM3hQRHlyTG4xTWxzNnpoaGFhVnMyY3AwbGc2WENXOGdWazA2UE90dHQwaXdzMDk5MlFPL3ozWlpWWG9tTkpjd0JyNTJGZ3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYxMTA3CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX2FtZDY0LkFwcEltYWdlCmRKU2xnTURnL1Y2emI1Y1JRd3RrdEg0TDcvZmRPN0pSM0tOV28wOFFiY0tLcXFEYjdPRkp6VDNGOEhOSk1mYnA3dXBPVFpYWEk3SGhHdUU2UUI2cUFBPT0K",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_amd64.AppImage"
+    },
+    "linux-x86_64-appimage": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEpuWk1JVU1xbElVZkcvM3hQRHlyTG4xTWxzNnpoaGFhVnMyY3AwbGc2WENXOGdWazA2UE90dHQwaXdzMDk5MlFPL3ozWlpWWG9tTkpjd0JyNTJGZ3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYxMTA3CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX2FtZDY0LkFwcEltYWdlCmRKU2xnTURnL1Y2emI1Y1JRd3RrdEg0TDcvZmRPN0pSM0tOV28wOFFiY0tLcXFEYjdPRkp6VDNGOEhOSk1mYnA3dXBPVFpYWEk3SGhHdUU2UUI2cUFBPT0K",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_amd64.AppImage"
+    },
+    "linux-x86_64-deb": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VFBZMngwYzZ5YmVGajZ3S2VvcGM2WnVWZmNJaVZvN09ySTM2a0xYYk1TOC9zc1BTejdIUy9lWkhYSFd0c3NJa1FxQTIzT0pTVTNjckhrREo2RTIxRWdJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYxMTA3CWZpbGU6Y2F0LWxhdW5jaGVyXzAuOC4xX2FtZDY0LmRlYgpxRkhYQ2N3SHlGMVZ6NktTLzRnSTJoU3UvMERlYllLT2NESXhIbFdVRTdiSHRRbG9lZnJwenJyNVIzcTh0Z09GWWF4c2FnWG1DVXJVaTlRWlVaaDNCUT09Cg==",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher_0.8.1_amd64.deb"
+    },
+    "linux-x86_64-rpm": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVUNkZBeFlqS241VEJFU2loWFRKbmNnWEVWQ1FEemJhOGFydzZNUkpXQkJtOXBGSk9ZblpZck9zTDRVSlFEWHFwMlVYSUVKM1VaWnVnYUtINXd5dEZ6Q0dvcHJrSzZnUXdzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzY1NDYxMTA3CWZpbGU6Y2F0LWxhdW5jaGVyLTAuOC4xLTEueDg2XzY0LnJwbQpBVy9HR0VKUTVuOVZKUzZJQSt2U29zcHAvVk5uc1kvTHVxcmJYY1RHZmlEaGFwcnI5U00zNzlFTGd2Rmo1OEZlZzNJY0xzSDl6b2NXMk5HcUkwZlBCZz09Cg==",
+      "url": "https://github.com/abhi-kr-2100/CatLauncher/releases/download/v0.8.1/cat-launcher-0.8.1-1.x86_64.rpm"
     }
   }
 }


### PR DESCRIPTION
### **User description**
Update latest.json version and publication date to 0.8.1 and
2025-12-11T13:51:56.043Z respectively. Replace macOS x64 asset URLs
and corresponding signatures to point to the v0.8.1 release for both
darwin-x86_64 and darwin-x86_64-app entries. Remove obsolete Linux
asset entries (AppImage, deb, rpm, amd64 App) from the manifests.  

These changes publish the new 0.8.1 release and align platform
entries and signatures with the latest release artifacts so clients
can download and verify the correct files.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump version from 0.8.0 to 0.8.1 with updated publication date

- Update macOS (x86_64 and aarch64) asset URLs and signatures

- Update Windows (x86_64) asset URLs and signatures for all installers

- Restore and update Linux (x86_64) asset entries with v0.8.1 releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["latest.json v0.8.0"] -->|Update version & date| B["latest.json v0.8.1"]
  B -->|Update macOS URLs| C["darwin-x86_64 & aarch64"]
  B -->|Update Windows URLs| D["windows-x86_64 variants"]
  B -->|Restore Linux entries| E["linux-x86_64 variants"]
  C -->|New signatures| F["v0.8.1 artifacts"]
  D -->|New signatures| F
  E -->|New signatures| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>latest.json</strong><dd><code>Release manifest update to v0.8.1 with all platforms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

latest.json

<ul><li>Updated version field from 0.8.0 to 0.8.1<br> <li> Updated publication date to 2025-12-11T13:51:56.043Z<br> <li> Updated all macOS (darwin-x86_64, darwin-x86_64-app, darwin-aarch64, <br>darwin-aarch64-app) asset URLs and signatures to point to v0.8.1 <br>release<br> <li> Updated all Windows (windows-x86_64, windows-x86_64-nsis, <br>windows-x86_64-msi) asset URLs and signatures to v0.8.1 release<br> <li> Restored and updated Linux (linux-x86_64, linux-x86_64-appimage, <br>linux-x86_64-deb, linux-x86_64-rpm) entries with v0.8.1 release <br>artifacts and signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/235/files#diff-b8308695435769ec1730cee70510131863d6e7c6e246c2db04ef0c03ae76cb97">+32/-32</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update latest.json to v0.8.1 with a new publication date, and refresh asset URLs and signatures for macOS (x86_64 and aarch64), Windows installers, and Linux (AppImage, deb, rpm). This publishes the 0.8.1 release so clients download and verify the correct artifacts.

<sup>Written for commit 5458d3c48bd92983afa0adf55a54739f20b67504. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

