### PR TITLE
docs: add error-handling and infra utility guidelines

### DIFF
--- a/dev-docs/best-practices.md
+++ b/dev-docs/best-practices.md
@@ -37,3 +37,34 @@ When using `useMutation`, pass arguments to the mutation function, instead of re
 2. Project source files.
 
 These conventions help keep imports tidy and consistent across the codebase.
+
+### Error Handling with Strongly-Typed Errors
+
+Error enums should wrap lower-level errors using strongly-typed error variants, not strings. For example:
+
+```rust
+// Good: Strongly-typed error wrapping
+#[derive(thiserror::Error, Debug)]
+pub enum InstallModError {
+    #[error("failed to get user game data directory: {0}")]
+    UserDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to extract archive: {0}")]
+    Extraction(#[from] ExtractionError),
+}
+
+// Bad: String-based error wrapping
+#[derive(thiserror::Error, Debug)]
+pub enum InstallModError {
+    #[error("failed to get user game data directory: {0}")]
+    UserDataDir(String),  // Don't do this
+}
+```
+
+### Use Shared Infrastructure Utilities
+
+The project provides shared utilities that should be reused:
+
+-   **HTTP Client:** Use `HTTP_CLIENT` from `src-tauri/src/infra/http_client.rs` instead of creating new `reqwest::Client` instances.
+-   **Archive Extraction:** Use `extract_archive` from `src-tauri/src/infra/archive.rs` for extracting zip, tar.gz, dmg, and rar files.
+-   **Directory Copying:** Use `copy_dir_all` from `src-tauri/src/filesystem/utils.rs` for recursive directory copying.


### PR DESCRIPTION
### **User description**
Add a new "Error Handling with Strongly-Typed Errors" section that
recommends wrapping lower-level errors with strongly-typed error enum
variants (using #[from]) instead of using string-based error variants.
Include a short Rust example showing the preferred pattern and the bad
pattern to clarify intent.

Add a "Use Shared Infrastructure Utilities" section that documents
project-wide utilities to prefer:
- HTTP_CLIENT from src-tauri/src/infra/http_client.rs instead of
  creating new reqwest::Client instances,
- extract_archive from src-tauri/src/infra/archive.rs for archive
  extraction (zip, tar.gz, dmg, rar),
- copy_dir_all from src-tauri/src/filesystem/utils.rs for recursive
  directory copying.

These changes improve consistency, error traceability, and reuse of
existing shared utilities across the codebase.


___

### **PR Type**
Documentation


___

### **Description**
- Add error handling guidelines recommending strongly-typed error variants

- Document shared infrastructure utilities for HTTP, archives, directories

- Include Rust code examples showing preferred vs bad patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Best Practices Guide"] --> B["Error Handling Section"]
  A --> C["Infrastructure Utilities Section"]
  B --> D["Strongly-Typed Errors"]
  B --> E["Code Examples"]
  C --> F["HTTP_CLIENT"]
  C --> G["extract_archive"]
  C --> H["copy_dir_all"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>best-practices.md</strong><dd><code>Add error handling and infrastructure utility guidelines</code>&nbsp; </dd></summary>
<hr>

dev-docs/best-practices.md

<ul><li>Added "Error Handling with Strongly-Typed Errors" section with Rust <br>code examples<br> <li> Included good pattern using <code>#[from]</code> attribute for error wrapping<br> <li> Included bad pattern showing string-based error variants to avoid<br> <li> Added "Use Shared Infrastructure Utilities" section documenting three <br>key utilities<br> <li> Listed HTTP_CLIENT, extract_archive, and copy_dir_all with their file <br>locations</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/237/files#diff-d2bda1f7a0c4d9eed5c00b25016adcc8117bfebb69055c67c848e693ca220543">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add best-practices for error handling and infra reuse. Recommend strongly-typed error enums with #[from], and standardize on HTTP_CLIENT (src-tauri/src/infra/http_client.rs), extract_archive (src-tauri/src/infra/archive.rs), and copy_dir_all (src-tauri/src/filesystem/utils.rs) to improve consistency and traceability.

<sup>Written for commit 261cb8e26d86188ef44315868822990c5aace0ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

