### PR TITLE
feat(mods): add mod management helpers and UI list

### DIFF
--- a/cat-launcher/src-tauri/mods.json
+++ b/cat-launcher/src-tauri/mods.json
@@ -1,0 +1,166 @@
+{
+  "DarkDaysAhead": [
+    {
+      "id": "arcana",
+      "name": "Arcana and Magic Items",
+      "authors": ["chaosvolt"],
+      "maintainers": ["Zlorthishen"],
+      "description": "Arcana and Magic Items mod for Cataclysm: Dark Days Ahead",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/cdda-arcana-mod/archive/refs/heads/master.zip",
+        "mod_dir": "cdda-arcana-mod-master/Arcana"
+      }
+    },
+    {
+      "id": "tefnuts_expansion",
+      "name": "Cataclysm: Second Chance",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "An expansion for Cataclysm:DDA that intends to add a little of everything",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Tefnuts-Expansion/archive/refs/heads/master.zip",
+        "mod_dir": "Tefnuts-Expansion-master/Tefnut's Expansion/expansion_tefnut"
+      }
+    },
+    {
+      "id": "fallout_in_cdda",
+      "name": "Fallout New England",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A mod that adds fallout content to CDDA",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Fallout-in-CDDA/archive/refs/heads/master.zip",
+        "mod_dir": "Fallout-in-CDDA-master/Fallout-CDDA"
+      }
+    },
+    {
+      "id": "tame_ants",
+      "name": "Tame Bugs",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A mod for Cataclysm: Dark Days Ahead. Contains the ability to tame various insects.",
+      "category": "creatures",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/CDDA-tame-ants/archive/refs/heads/master.zip",
+        "mod_dir": "CDDA-tame-ants-master"
+      }
+    },
+    {
+      "id": "fallout_new_england_remastered",
+      "name": "Fallout: New England Remastered",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A remastering of my original Fallout mod for C:DDA. Should work with newest Bright Nights release for as long as I update and maintain it.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Fallout-New-England-Remastered/archive/refs/heads/main.zip",
+        "mod_dir": "Fallout-New-England-Remastered-main/FNE-Remastered"
+      }
+    }
+  ],
+
+  "TheLastGeneration": [
+    {
+      "id": "mind_over_matter",
+      "name": "Mind Over Matter",
+      "authors": ["StandingStorm"],
+      "maintainers": ["Vegetabs"],
+      "description": "Port of MoM from CDDA to CTLG. Adds nine separate psionic power paths to Cataclysm including Biokinesis, Clairsentience, Electrokinesis, Photokinesis, Pyrokinesis, Telekinesis, Telepathy, Teleportation, and Vitakinesis.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Vegetabs/MindOverMatter-CTLG/archive/refs/heads/main.zip",
+        "mod_dir": "MindOverMatter-CTLG-main"
+      }
+    },
+    {
+      "id": "bionics_expanded",
+      "name": "Bionics Expanded",
+      "authors": ["Vegetabs"],
+      "maintainers": ["Vegetabs"],
+      "description": "Expanded bionics system for Cataclysm: The Last Generation.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Vegetabs/BionicsExpanded-CTLG/archive/refs/heads/main.zip",
+        "mod_dir": "BionicsExpanded-CTLG-main"
+      }
+    },
+    {
+      "id": "mythical_martial_arts",
+      "name": "Mythical Martial Arts",
+      "authors": ["Photoloss"],
+      "maintainers": ["Vegetabs"],
+      "description": "Mythical martial arts mod ported to Cataclysm: The Last Generation.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Vegetabs/MythicalMartialArts-CTLG/archive/refs/heads/main.zip",
+        "mod_dir": "MythicalMartialArts-CTLG-main"
+      }
+    }
+  ],
+
+  "BrightNights": [
+    {
+      "id": "cataclysm_second_chance",
+      "name": "Cataclysm: Second Chance",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A mod for Cataclysm: Bright Nights which adds my own custom content to it",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Cataclysm-Second-Chance/archive/refs/heads/main.zip",
+        "mod_dir": "Cataclysm-Second-Chance-main/Second Chance Redux"
+      }
+    },
+    {
+      "id": "better_holsters",
+      "name": "Better Holsters",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A mod for Cataclysm: Bright Nights that improves the holster experience",
+      "category": "items",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Better-Holsters/archive/refs/heads/main.zip",
+        "mod_dir": "Better-Holsters-main/Better Holsters"
+      }
+    },
+    {
+      "id": "fallout_new_england_remastered",
+      "name": "Fallout: New England Remastered",
+      "authors": ["Tefnut"],
+      "maintainers": ["Tefnut"],
+      "description": "A remastering of my original Fallout mod for C:DDA. Should work with newest Bright Nights release for as long as I update and maintain it.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Fallout-New-England-Remastered/archive/refs/heads/main.zip",
+        "mod_dir": "Fallout-New-England-Remastered-main/FNE-Remastered"
+      }
+    },
+    {
+      "id": "realdarkskies",
+      "name": "Really Dark Skies",
+      "authors": ["Zlorthishen"],
+      "maintainers": ["Zlorthishen"],
+      "description": "Really Dark Skies. The community supported mod that enhances the Bright Nights experience by adding an inscrutable alien-humanoid paramilitary expeditionary force to your typical survival scenario.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Zlorthishen/Really_Dark_Skies/archive/refs/heads/main.zip",
+        "mod_dir": "Really_Dark_Skies-main/Really_Dark_Skies"
+      }
+    },
+    {
+      "id": "arcology",
+      "name": "The Arcology Mod",
+      "authors": ["Zlorthishen"],
+      "maintainers": ["Zlorthishen"],
+      "description": "The mod that adds Arcology-type buildings, very large, self-contained buildings with a Cyberpunk aesthetic to Bright Nights.",
+      "category": "buildings",
+      "installation": {
+        "download_url": "https://github.com/Zlorthishen/The_Arcology_Mod/archive/refs/heads/main.zip",
+        "mod_dir": "The_Arcology_Mod-main/Arcology_Mod"
+      }
+    }
+  ]
+}

--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 -- This table stores the persisted theme preference for the launcher UI.
 CREATE TABLE IF NOT EXISTS theme_preferences (
-    _id INTEGER PRIMARY KEY CHECK(_id = 1),
+    _id INTEGER PRIMARY KEY DEFAULT 1 CHECK(_id = 1),
     theme TEXT NOT NULL,
     FOREIGN KEY (theme) REFERENCES themes (name)
 );
@@ -107,3 +107,14 @@ CREATE TABLE IF NOT EXISTS manual_backups (
 
 -- This composite index speeds up queries that filter by game_variant and order by timestamp.
 CREATE INDEX IF NOT EXISTS idx_manual_backups_game_variant_timestamp ON manual_backups (game_variant, timestamp);
+
+-- This table stores installed third-party mods for each game variant.
+CREATE TABLE IF NOT EXISTS installed_mods (
+    mod_id TEXT NOT NULL,
+    game_variant TEXT NOT NULL,
+    PRIMARY KEY (mod_id, game_variant),
+    FOREIGN KEY (game_variant) REFERENCES variants (name) ON DELETE CASCADE
+);
+
+-- This index speeds up queries that filter by game_variant.
+CREATE INDEX IF NOT EXISTS idx_installed_mods_game_variant ON installed_mods (game_variant);

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod install_release;
 pub mod active_release;
 mod launch_game;
 mod manual_backups;
+mod mods;
 mod play_time;
 mod theme;
 mod users;
@@ -30,6 +31,7 @@ use crate::manual_backups::commands::{
     create_manual_backup_for_variant, delete_manual_backup_by_id, list_manual_backups_for_variant,
     restore_manual_backup_by_id,
 };
+use crate::mods::commands::{get_mod_installation_status, install_mod, list_all_mods, uninstall_mod_for_variant};
 use crate::play_time::commands::{get_play_time_for_variant, get_play_time_for_version};
 use crate::theme::commands::{get_preferred_theme, set_preferred_theme};
 use crate::users::commands::get_user_id;
@@ -76,6 +78,10 @@ pub fn run() {
             get_user_id,
             get_preferred_theme,
             set_preferred_theme,
+            list_all_mods,
+            install_mod,
+            uninstall_mod_for_variant,
+            get_mod_installation_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/cat-launcher/src-tauri/src/mods/commands.rs
+++ b/cat-launcher/src-tauri/src/mods/commands.rs
@@ -1,0 +1,148 @@
+use tauri::{command, AppHandle, Manager, State};
+
+use cat_macros::CommandErrorSerialize;
+
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::mods::get_mod_installation_status::{self, GetModInstallationStatusError, ModInstallationStatus};
+use crate::mods::install_mod::{self, InstallModError};
+use crate::mods::list_all_mods::{self, ListAllModsError};
+use crate::mods::repository::sqlite_installed_mods_repository::SqliteInstalledModsRepository;
+use crate::mods::uninstall_mod::{self, UninstallModError};
+use crate::mods::Mod;
+use crate::settings::Settings;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize)]
+pub enum ListAllModsCommandError {
+    #[error("failed to list all mods: {0}")]
+    List(#[from] ListAllModsError),
+
+    #[error("failed to get data directory: {0}")]
+    DataDirectoryError(#[from] tauri::Error),
+
+    #[error("failed to get OS: {0}")]
+    OsError(#[from] OSNotSupportedError),
+}
+
+#[command]
+pub async fn list_all_mods(
+    app: AppHandle,
+    variant: GameVariant,
+    active_release_repository: State<'_, SqliteActiveReleaseRepository>,
+    installed_mods_repository: State<'_, SqliteInstalledModsRepository>,
+) -> Result<Vec<Mod>, ListAllModsCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+    let os = get_os_enum(std::env::consts::OS)?;
+
+    let mods = list_all_mods::list_all_mods(
+        &data_dir,
+        &resource_dir,
+        &variant,
+        &os,
+        &*active_release_repository,
+        &*installed_mods_repository,
+    )
+    .await?;
+
+    Ok(mods)
+}
+
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize)]
+pub enum InstallModCommandError {
+    #[error("failed to install mod: {0}")]
+    Install(#[from] InstallModError),
+
+    #[error("failed to get data directory: {0}")]
+    DataDirectoryError(#[from] tauri::Error),
+
+    #[error("failed to get OS: {0}")]
+    OsError(#[from] OSNotSupportedError),
+}
+
+#[command]
+pub async fn install_mod(
+    app: AppHandle,
+    variant: GameVariant,
+    mod_id: String,
+    settings: State<'_, Settings>,
+    installed_mods_repository: State<'_, SqliteInstalledModsRepository>,
+) -> Result<(), InstallModCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+    let temp_dir = app.path().temp_dir()?;
+    let os = get_os_enum(std::env::consts::OS)?;
+
+    install_mod::install_third_party_mod(
+        &variant,
+        &mod_id,
+        &data_dir,
+        &resource_dir,
+        &temp_dir,
+        &os,
+        &settings,
+        &*installed_mods_repository,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize)]
+pub enum UninstallModCommandError {
+    #[error("failed to uninstall mod: {0}")]
+    Uninstall(#[from] UninstallModError),
+
+    #[error("failed to get data directory: {0}")]
+    DataDirectoryError(#[from] tauri::Error),
+}
+
+#[command]
+pub async fn uninstall_mod_for_variant(
+    app: AppHandle,
+    variant: GameVariant,
+    mod_id: String,
+    installed_mods_repository: State<'_, SqliteInstalledModsRepository>,
+) -> Result<(), UninstallModCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+
+    uninstall_mod::uninstall_mod_for_variant(
+        &variant,
+        &mod_id,
+        &data_dir,
+        &*installed_mods_repository,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize)]
+pub enum GetModInstallationStatusCommandError {
+    #[error("failed to get mod installation status: {0}")]
+    Status(#[from] GetModInstallationStatusError),
+
+    #[error("failed to get data directory: {0}")]
+    DataDirectoryError(#[from] tauri::Error),
+}
+
+#[command]
+pub async fn get_mod_installation_status(
+    app: AppHandle,
+    variant: GameVariant,
+    mod_id: String,
+    installed_mods_repository: State<'_, SqliteInstalledModsRepository>,
+) -> Result<ModInstallationStatus, GetModInstallationStatusCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+
+    let status = get_mod_installation_status::get_mod_installation_status(
+        &variant,
+        &mod_id,
+        &data_dir,
+        &*installed_mods_repository,
+    )
+    .await?;
+
+    Ok(status)
+}

--- a/cat-launcher/src-tauri/src/mods/get_mod_details.rs
+++ b/cat-launcher/src-tauri/src/mods/get_mod_details.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+
+use thiserror::Error;
+use tokio::fs;
+
+use crate::mods::mod_info::{ModsJson, ThirdPartyMod};
+use crate::mods::validation::{validate_mod_id, InvalidModIdError};
+use crate::variants::GameVariant;
+
+#[derive(Error, Debug)]
+pub enum GetModDetailsError {
+    #[error("invalid mod ID: {0}")]
+    InvalidModId(#[from] InvalidModIdError),
+
+    #[error("failed to read mods.json: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("failed to parse mods.json: {0}")]
+    ParseError(#[from] serde_json::Error),
+
+    #[error("mod with ID {0} not found")]
+    NotFound(String),
+}
+
+pub async fn get_mod_details(
+    variant: &GameVariant,
+    mod_id: &str,
+    resource_dir: &Path,
+) -> Result<ThirdPartyMod, GetModDetailsError> {
+    // Validate mod_id to prevent path traversal and ensure safety
+    validate_mod_id(mod_id)?;
+
+    let mods_json_path = resource_dir.join("mods.json");
+    let mods_json_content = fs::read_to_string(mods_json_path).await?;
+
+    let mods_data: ModsJson = serde_json::from_str(&mods_json_content)?;
+
+    mods_data
+        .get(variant.id())
+        .and_then(|mods| mods.iter().find(|m| m.id == mod_id))
+        .map(|mod_entry| mod_entry.clone().into())
+        .ok_or_else(|| GetModDetailsError::NotFound(mod_id.to_string()))
+}

--- a/cat-launcher/src-tauri/src/mods/get_mod_installation_status.rs
+++ b/cat-launcher/src-tauri/src/mods/get_mod_installation_status.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::fs;
+use ts_rs::TS;
+
+use crate::filesystem::paths::{get_or_create_user_game_data_dir, GetUserGameDataDirError};
+use crate::mods::repository::{InstalledModsRepository, InstalledModsRepositoryError};
+use crate::mods::validation::{validate_mod_id, InvalidModIdError};
+use crate::variants::GameVariant;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[ts(export)]
+pub enum ModInstallationStatus {
+    Installed,
+    NotInstalled,
+    Corrupted, // In repository but files missing
+}
+
+#[derive(Error, Debug)]
+pub enum GetModInstallationStatusError {
+    #[error("invalid mod ID: {0}")]
+    InvalidModId(#[from] InvalidModIdError),
+
+    #[error("failed to check repository: {0}")]
+    Repository(#[from] InstalledModsRepositoryError),
+
+    #[error("failed to get user data directory: {0}")]
+    UserDataDir(#[from] GetUserGameDataDirError),
+}
+
+
+
+pub async fn get_mod_installation_status(
+    variant: &GameVariant,
+    mod_id: &str,
+    data_dir: &Path,
+    installed_mods_repository: &dyn InstalledModsRepository,
+) -> Result<ModInstallationStatus, GetModInstallationStatusError> {
+    // Validate mod_id to prevent path traversal and ensure safety
+    validate_mod_id(mod_id)?;
+
+    let is_in_repository = installed_mods_repository.is_mod_installed(mod_id, variant).await?;
+
+    if !is_in_repository {
+        return Ok(ModInstallationStatus::NotInstalled);
+    }
+
+    let user_data_dir = get_or_create_user_game_data_dir(variant, data_dir).await?;
+    let mod_dir = user_data_dir.join("mods").join(mod_id);
+
+    let is_valid_dir = fs::metadata(&mod_dir)
+        .await
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false);
+
+    if is_valid_dir {
+        Ok(ModInstallationStatus::Installed)
+    } else {
+        Ok(ModInstallationStatus::Corrupted)
+    }
+}

--- a/cat-launcher/src-tauri/src/mods/install_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/install_mod.rs
@@ -1,0 +1,178 @@
+use std::num::NonZeroU16;
+use std::path::{Path, PathBuf};
+
+use downloader::Download;
+use thiserror::Error;
+use tokio::fs::{create_dir_all, remove_dir_all};
+
+use crate::filesystem::paths::{get_or_create_user_game_data_dir, GetUserGameDataDirError};
+use crate::filesystem::utils::{copy_dir_all, CopyDirError};
+use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::http_client::{create_downloader, HTTP_CLIENT};
+use crate::infra::utils::OS;
+use crate::mods::get_mod_details::{get_mod_details, GetModDetailsError};
+use crate::mods::repository::{InstalledModsRepository, InstalledModsRepositoryError};
+use crate::mods::validation::{validate_mod_id, InvalidModIdError};
+use crate::settings::Settings;
+use crate::variants::GameVariant;
+
+#[derive(Error, Debug)]
+pub enum DownloadModError {
+    #[error("downloader creation failed: {0}")]
+    DownloaderCreation(#[from] downloader::Error),
+
+    #[error("no download result found")]
+    NoDownloadResult,
+}
+
+async fn download_mod(
+    download_url: &str,
+    download_dir: &Path,
+    parallel_requests: NonZeroU16,
+) -> Result<PathBuf, DownloadModError> {
+    let mut downloader = create_downloader(HTTP_CLIENT.clone(), download_dir, parallel_requests)?;
+
+    let dl = Download::new(download_url);
+    let results = downloader.async_download(&[dl]).await?;
+
+    if let Some(res) = results.into_iter().next() {
+        match res {
+            Ok(summary) => Ok(summary.file_name),
+            Err(e) => Err(DownloadModError::DownloaderCreation(e)),
+        }
+    } else {
+        Err(DownloadModError::NoDownloadResult)
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum InstallModError {
+    #[error("invalid mod ID: {0}")]
+    InvalidModId(#[from] InvalidModIdError),
+
+    #[error("failed to get mod details: {0}")]
+    ModDetails(#[from] GetModDetailsError),
+
+    #[error("failed to download mod: {0}")]
+    Download(#[from] DownloadModError),
+
+    #[error("failed to extract archive: {0}")]
+    Extraction(#[from] ExtractionError),
+
+    #[error("failed to copy mod directory: {0}")]
+    Copy(#[from] CopyDirError),
+
+    #[error("failed to get user game data directory: {0}")]
+    UserDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to create directory: {0}")]
+    CreateDir(std::io::Error),
+
+    #[error("failed to clean up temp directory: {0}")]
+    Cleanup(std::io::Error),
+
+    #[error("source directory does not exist: {0}")]
+    SourceNotFound(PathBuf),
+
+    #[error("failed to add mod to repository: {0}")]
+    Repository(#[from] InstalledModsRepositoryError),
+}
+
+pub async fn install_third_party_mod(
+    variant: &GameVariant,
+    mod_id: &str,
+    data_dir: &Path,
+    resource_dir: &Path,
+    temp_dir: &Path,
+    os: &OS,
+    settings: &Settings,
+    installed_mods_repository: &dyn InstalledModsRepository,
+) -> Result<(), InstallModError> {
+    // Validate mod_id to prevent path traversal and ensure safety
+    validate_mod_id(mod_id)?;
+
+    let mod_details = get_mod_details(variant, mod_id, resource_dir).await?;
+
+    let user_data_dir = get_or_create_user_game_data_dir(variant, data_dir).await?;
+
+    let mods_dir = user_data_dir.join("mods");
+    create_dir_all(&mods_dir)
+        .await
+        .map_err(InstallModError::CreateDir)?;
+
+    let download_dir = temp_dir.join("cat-launcher-mod-downloads");
+    create_dir_all(&download_dir)
+        .await
+        .map_err(InstallModError::CreateDir)?;
+
+    let zip_path = download_mod(
+        &mod_details.installation.download_url,
+        &download_dir,
+        settings.parallel_requests,
+    )
+    .await?;
+
+    let extraction_dir = temp_dir.join("cat-launcher-mod-extracted");
+    create_dir_all(&extraction_dir)
+        .await
+        .map_err(InstallModError::CreateDir)?;
+
+    extract_archive(&zip_path, &extraction_dir, os).await?;
+
+    let source_dir = extraction_dir.join(&mod_details.installation.mod_dir);
+    let target_dir = mods_dir.join(&mod_details.id);
+
+    let source_exists = tokio::fs::metadata(&source_dir)
+        .await
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if !source_exists {
+        return Err(InstallModError::SourceNotFound(source_dir));
+    }
+
+    let target_exists = tokio::fs::metadata(&target_dir)
+        .await
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if target_exists {
+        remove_dir_all(&target_dir)
+            .await
+            .map_err(InstallModError::Cleanup)?;
+    }
+
+    copy_dir_all(&source_dir, &target_dir, os).await?;
+
+    cleanup_temp_files(&zip_path, &extraction_dir).await?;
+
+    installed_mods_repository.add_installed_mod(mod_id, variant).await?;
+
+    Ok(())
+}
+
+async fn cleanup_temp_files(zip_path: &Path, extracted_dir: &Path) -> Result<(), InstallModError> {
+    let zip_exists = tokio::fs::metadata(zip_path)
+        .await
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if zip_exists {
+        tokio::fs::remove_file(zip_path)
+            .await
+            .map_err(InstallModError::Cleanup)?;
+    }
+
+    let dir_exists = tokio::fs::metadata(extracted_dir)
+        .await
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if dir_exists {
+        remove_dir_all(extracted_dir)
+            .await
+            .map_err(InstallModError::Cleanup)?;
+    }
+
+    Ok(())
+}

--- a/cat-launcher/src-tauri/src/mods/list_all_mods.rs
+++ b/cat-launcher/src-tauri/src/mods/list_all_mods.rs
@@ -1,0 +1,182 @@
+use std::path::Path;
+
+use thiserror::Error;
+use tokio::fs;
+
+use crate::active_release::active_release::ActiveReleaseError;
+use crate::active_release::repository::ActiveReleaseRepository;
+use crate::filesystem::paths::{get_game_resources_dir, GetGameExecutableDirError};
+use crate::infra::utils::OS;
+use crate::mods::mod_info::{Mod, ModInfoJson, ModInfoJsonEntry, ModStatus, ModType, ModsJson};
+use crate::mods::repository::{InstalledModsRepository, InstalledModsRepositoryError};
+use crate::variants::GameVariant;
+
+#[derive(Error, Debug)]
+pub enum LoadThirdPartyModsError {
+    #[error("failed to read mods.json: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("failed to parse mods.json: {0}")]
+    ParseError(#[from] serde_json::Error),
+}
+
+async fn load_third_party_mods(
+    variant: &GameVariant,
+    installed_mod_ids: &[String],
+    resource_dir: &Path,
+) -> Result<Vec<Mod>, LoadThirdPartyModsError> {
+    let mods_json_path = resource_dir.join("mods.json");
+    let mods_json_content = fs::read_to_string(mods_json_path).await?;
+
+    let mods_data: ModsJson = serde_json::from_str(&mods_json_content)?;
+
+    let Some(mods) = mods_data.get(variant.id()) else {
+        return Ok(Vec::new());
+    };
+
+    let third_party_mods = mods
+        .iter()
+        .map(|mod_entry| {
+            let status = if installed_mod_ids.contains(&mod_entry.id) {
+                ModStatus::Installed
+            } else {
+                ModStatus::NotInstalled
+            };
+
+            Mod {
+                mod_type: ModType::ThirdParty,
+                id: mod_entry.id.clone(),
+                name: mod_entry.name.clone(),
+                description: mod_entry.description.clone(),
+                category: mod_entry.category.clone(),
+                status,
+            }
+        })
+        .collect();
+
+    Ok(third_party_mods)
+}
+
+#[derive(Error, Debug)]
+pub enum LoadStockModsError {
+    #[error("failed to get game resources directory: {0}")]
+    ResourcesDir(#[from] GetGameExecutableDirError),
+}
+
+async fn parse_modinfo_json(modinfo_path: &Path) -> Option<ModInfoJson> {
+    let content = fs::read_to_string(modinfo_path).await.ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn mod_entry_to_mod(entry: ModInfoJsonEntry) -> Mod {
+    Mod {
+        mod_type: ModType::Stock,
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        category: entry.category,
+        status: ModStatus::Installed,
+    }
+}
+
+async fn collect_mods_from_dir(mod_dir: &Path) -> Vec<Mod> {
+    let modinfo_path = mod_dir.join("modinfo.json");
+    let modinfo_exists = fs::metadata(&modinfo_path)
+        .await
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if !modinfo_exists {
+        return Vec::new();
+    }
+
+    let Some(modinfo_json) = parse_modinfo_json(&modinfo_path).await else {
+        return Vec::new();
+    };
+
+    modinfo_json.into_iter().map(mod_entry_to_mod).collect()
+}
+
+async fn load_stock_mods(
+    variant: &GameVariant,
+    release_version: &str,
+    data_dir: &Path,
+    os: &OS,
+) -> Result<Vec<Mod>, LoadStockModsError> {
+    let resources_dir = get_game_resources_dir(variant, release_version, data_dir, os).await?;
+    let mods_dir = resources_dir.join("data").join("mods");
+
+    let mods_dir_exists = fs::metadata(&mods_dir)
+        .await
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false);
+
+    if !mods_dir_exists {
+        return Ok(Vec::new());
+    }
+
+    let Ok(mut mod_entries) = fs::read_dir(&mods_dir).await else {
+        return Ok(Vec::new());
+    };
+
+    let mut stock_mods = Vec::new();
+
+    while let Ok(Some(entry)) = mod_entries.next_entry().await {
+        if let Ok(file_type) = entry.file_type().await {
+            if file_type.is_dir() {
+                let mods_from_dir = collect_mods_from_dir(&entry.path()).await;
+                stock_mods.extend(mods_from_dir);
+            }
+        }
+    }
+
+    Ok(stock_mods)
+}
+
+#[derive(Error, Debug)]
+#[error("no active release found for variant")]
+pub struct NoActiveReleaseError;
+
+#[derive(Error, Debug)]
+pub enum ListAllModsError {
+    #[error("failed to get active release: {0}")]
+    ActiveRelease(#[from] ActiveReleaseError),
+
+    #[error("no active release: {0}")]
+    NoActiveRelease(#[from] NoActiveReleaseError),
+
+    #[error("failed to get installed mods: {0}")]
+    InstalledMods(#[from] InstalledModsRepositoryError),
+
+    #[error("failed to load third-party mods: {0}")]
+    ThirdPartyMods(#[from] LoadThirdPartyModsError),
+
+    #[error("failed to load stock mods: {0}")]
+    StockMods(#[from] LoadStockModsError),
+}
+
+pub async fn list_all_mods(
+    data_dir: &Path,
+    resource_dir: &Path,
+    variant: &GameVariant,
+    os: &OS,
+    active_release_repository: &dyn ActiveReleaseRepository,
+    installed_mods_repository: &dyn InstalledModsRepository,
+) -> Result<Vec<Mod>, ListAllModsError> {
+    let release_version = variant
+        .get_active_release(active_release_repository)
+        .await?
+        .ok_or(NoActiveReleaseError)?;
+
+    let installed_mod_ids = installed_mods_repository.get_all_installed_mods(variant).await?;
+
+    let mut all_mods = Vec::new();
+
+    let third_party_mods = load_third_party_mods(variant, &installed_mod_ids, resource_dir).await?;
+    all_mods.extend(third_party_mods);
+
+    let stock_mods = load_stock_mods(variant, &release_version, data_dir, os).await?;
+    all_mods.extend(stock_mods);
+
+    Ok(all_mods)
+}

--- a/cat-launcher/src-tauri/src/mods/mod.rs
+++ b/cat-launcher/src-tauri/src/mods/mod.rs
@@ -1,0 +1,11 @@
+pub mod commands;
+mod get_mod_details;
+pub mod get_mod_installation_status;
+pub mod install_mod;
+pub mod list_all_mods;
+pub mod mod_info;
+pub mod repository;
+pub mod uninstall_mod;
+pub mod validation;
+
+pub use mod_info::Mod;

--- a/cat-launcher/src-tauri/src/mods/mod_info.rs
+++ b/cat-launcher/src-tauri/src/mods/mod_info.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum ModType {
+    Stock,
+    ThirdParty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum ModStatus {
+    Installed,
+    NotInstalled,
+}
+
+/// Shared mod information structure used for both stock and third-party mods.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct ModInfo {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+}
+
+pub type ModsJson = std::collections::HashMap<String, Vec<ThirdPartyModEntry>>;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ThirdPartyModEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+    pub installation: InstallationInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct ThirdPartyMod {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+    pub installation: InstallationInfo,
+}
+
+impl From<ThirdPartyModEntry> for ThirdPartyMod {
+    fn from(entry: ThirdPartyModEntry) -> Self {
+        Self {
+            id: entry.id,
+            name: entry.name,
+            description: entry.description,
+            category: entry.category,
+            installation: entry.installation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct InstallationInfo {
+    pub download_url: String,
+    pub mod_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct Mod {
+    pub mod_type: ModType,
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: String,
+    pub status: ModStatus,
+}
+
+pub type ModInfoJsonEntry = ModInfo;
+
+pub type ModInfoJson = Vec<ModInfoJsonEntry>;

--- a/cat-launcher/src-tauri/src/mods/repository/installed_mods_repository.rs
+++ b/cat-launcher/src-tauri/src/mods/repository/installed_mods_repository.rs
@@ -1,0 +1,66 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InstalledModsRepositoryError {
+    #[error("failed to add installed mod: {0}")]
+    Add(Box<dyn Error + Send + Sync>),
+
+    #[error("failed to get installed mods: {0}")]
+    Get(Box<dyn Error + Send + Sync>),
+
+    #[error("failed to delete installed mod: {0}")]
+    Delete(Box<dyn Error + Send + Sync>),
+
+    #[error("failed to check if mod is installed: {0}")]
+    Check(Box<dyn Error + Send + Sync>),
+}
+
+/// Repository trait for managing installed mods.
+///
+/// Provides CRUD operations for tracking which mods are currently installed.
+/// All operations are asynchronous and return specific error variants on failure.
+#[async_trait]
+pub trait InstalledModsRepository: Send + Sync {
+    /// Adds a mod to the installed mods list for a specific game variant.
+    ///
+    /// # Arguments
+    /// * `mod_id` - The unique identifier of the mod to add
+    /// * `game_variant` - The game variant this mod is installed for
+    ///
+    /// # Errors
+    /// Returns InstalledModsRepositoryError::Add if the operation fails.
+    async fn add_installed_mod(&self, mod_id: &str, game_variant: &GameVariant) -> Result<(), InstalledModsRepositoryError>;
+
+    /// Retrieves all installed mod IDs for a specific game variant.
+    ///
+    /// # Arguments
+    /// * `game_variant` - The game variant to get installed mods for
+    ///
+    /// # Errors
+    /// Returns InstalledModsRepositoryError::Get if the operation fails.
+    async fn get_all_installed_mods(&self, game_variant: &GameVariant) -> Result<Vec<String>, InstalledModsRepositoryError>;
+
+    /// Checks if a specific mod is installed for a specific game variant.
+    ///
+    /// # Arguments
+    /// * `mod_id` - The unique identifier of the mod to check
+    /// * `game_variant` - The game variant to check for
+    ///
+    /// # Errors
+    /// Returns InstalledModsRepositoryError::Check if the operation fails.
+    async fn is_mod_installed(&self, mod_id: &str, game_variant: &GameVariant) -> Result<bool, InstalledModsRepositoryError>;
+
+    /// Removes a mod from the installed mods list for a specific game variant.
+    ///
+    /// # Arguments
+    /// * `mod_id` - The unique identifier of the mod to delete
+    /// * `game_variant` - The game variant to remove the mod from
+    ///
+    /// # Errors
+    /// Returns InstalledModsRepositoryError::Delete if the operation fails.
+    async fn delete_installed_mod(&self, mod_id: &str, game_variant: &GameVariant) -> Result<(), InstalledModsRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/mods/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/mods/repository/mod.rs
@@ -1,0 +1,4 @@
+mod installed_mods_repository;
+pub mod sqlite_installed_mods_repository;
+
+pub use installed_mods_repository::{InstalledModsRepository, InstalledModsRepositoryError};

--- a/cat-launcher/src-tauri/src/mods/repository/sqlite_installed_mods_repository.rs
+++ b/cat-launcher/src-tauri/src/mods/repository/sqlite_installed_mods_repository.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use r2d2_sqlite::SqliteConnectionManager;
+use tokio::task;
+
+use crate::mods::repository::{InstalledModsRepository, InstalledModsRepositoryError};
+use crate::variants::GameVariant;
+
+type Pool = r2d2::Pool<SqliteConnectionManager>;
+
+pub struct SqliteInstalledModsRepository {
+    pool: Pool,
+}
+
+impl SqliteInstalledModsRepository {
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl InstalledModsRepository for SqliteInstalledModsRepository {
+    async fn add_installed_mod(&self, mod_id: &str, game_variant: &GameVariant) -> Result<(), InstalledModsRepositoryError> {
+        let pool = self.pool.clone();
+        let mod_id = mod_id.to_string();
+        let game_variant = game_variant.id().to_string();
+
+        task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledModsRepositoryError::Add(Box::new(e)))?;
+            conn.execute(
+                "INSERT OR IGNORE INTO installed_mods (mod_id, game_variant) VALUES (?1, ?2)",
+                rusqlite::params![mod_id, game_variant],
+            )
+            .map_err(|e| InstalledModsRepositoryError::Add(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledModsRepositoryError::Add(Box::new(e)))?
+    }
+
+    async fn get_all_installed_mods(&self, game_variant: &GameVariant) -> Result<Vec<String>, InstalledModsRepositoryError> {
+        let pool = self.pool.clone();
+        let game_variant = game_variant.id().to_string();
+
+        task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledModsRepositoryError::Get(Box::new(e)))?;
+            let mut stmt = conn
+                .prepare("SELECT mod_id FROM installed_mods WHERE game_variant = ?1")
+                .map_err(|e| InstalledModsRepositoryError::Get(Box::new(e)))?;
+            let mods = stmt
+                .query_map(rusqlite::params![game_variant], |row| row.get(0))
+                .map_err(|e| InstalledModsRepositoryError::Get(Box::new(e)))?
+                .collect::<Result<Vec<String>, _>>()
+                .map_err(|e| InstalledModsRepositoryError::Get(Box::new(e)))?;
+            Ok(mods)
+        })
+        .await
+        .map_err(|e| InstalledModsRepositoryError::Get(Box::new(e)))?
+    }
+
+    async fn is_mod_installed(&self, mod_id: &str, game_variant: &GameVariant) -> Result<bool, InstalledModsRepositoryError> {
+        let pool = self.pool.clone();
+        let mod_id = mod_id.to_string();
+        let game_variant = game_variant.id().to_string();
+
+        task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledModsRepositoryError::Check(Box::new(e)))?;
+            let mut stmt = conn
+                .prepare("SELECT 1 FROM installed_mods WHERE mod_id = ?1 AND game_variant = ?2")
+                .map_err(|e| InstalledModsRepositoryError::Check(Box::new(e)))?;
+            let exists = stmt
+                .exists(rusqlite::params![mod_id, game_variant])
+                .map_err(|e| InstalledModsRepositoryError::Check(Box::new(e)))?;
+            Ok(exists)
+        })
+        .await
+        .map_err(|e| InstalledModsRepositoryError::Check(Box::new(e)))?
+    }
+
+    async fn delete_installed_mod(&self, mod_id: &str, game_variant: &GameVariant) -> Result<(), InstalledModsRepositoryError> {
+        let pool = self.pool.clone();
+        let mod_id = mod_id.to_string();
+        let game_variant = game_variant.id().to_string();
+
+        task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledModsRepositoryError::Delete(Box::new(e)))?;
+            conn.execute(
+                "DELETE FROM installed_mods WHERE mod_id = ?1 AND game_variant = ?2",
+                rusqlite::params![mod_id, game_variant],
+            )
+            .map_err(|e| InstalledModsRepositoryError::Delete(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledModsRepositoryError::Delete(Box::new(e)))?
+    }
+}

--- a/cat-launcher/src-tauri/src/mods/uninstall_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/uninstall_mod.rs
@@ -1,0 +1,57 @@
+use std::path::Path;
+
+use thiserror::Error;
+use tokio::fs::{remove_dir_all, try_exists};
+
+use crate::filesystem::paths::{get_or_create_user_game_data_dir, GetUserGameDataDirError};
+use crate::mods::repository::{InstalledModsRepository, InstalledModsRepositoryError};
+use crate::mods::validation::{validate_mod_id, InvalidModIdError};
+use crate::variants::GameVariant;
+
+#[derive(Error, Debug)]
+pub enum UninstallModError {
+    #[error("invalid mod ID: {0}")]
+    InvalidModId(#[from] InvalidModIdError),
+
+    #[error("failed to get user game data directory: {0}")]
+    UserDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to remove mod directory: {0}")]
+    RemoveDir(std::io::Error),
+
+    #[error("failed to update repository: {0}")]
+    Repository(#[from] InstalledModsRepositoryError),
+
+    #[error("mod with ID {0} is not installed")]
+    ModNotInstalled(String),
+}
+
+pub async fn uninstall_mod_for_variant(
+    variant: &GameVariant,
+    mod_id: &str,
+    data_dir: &Path,
+    installed_mods_repository: &dyn InstalledModsRepository,
+) -> Result<(), UninstallModError> {
+    // Validate mod_id to prevent path traversal and ensure safety
+    validate_mod_id(mod_id)?;
+
+    let is_installed = installed_mods_repository.is_mod_installed(mod_id, variant).await?;
+    if !is_installed {
+        return Err(UninstallModError::ModNotInstalled(mod_id.to_string()));
+    }
+
+    let user_data_dir = get_or_create_user_game_data_dir(variant, data_dir).await?;
+    let mod_dir = user_data_dir.join("mods").join(mod_id);
+
+    if try_exists(&mod_dir).await.unwrap_or(false) {
+        remove_dir_all(&mod_dir)
+            .await
+            .map_err(UninstallModError::RemoveDir)?;
+    }
+
+    installed_mods_repository
+        .delete_installed_mod(mod_id, variant)
+        .await?;
+
+    Ok(())
+}

--- a/cat-launcher/src-tauri/src/mods/validation.rs
+++ b/cat-launcher/src-tauri/src/mods/validation.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("invalid mod ID: {mod_id}. Mod IDs must be non-empty, contain only alphanumeric characters, underscores, or hyphens, and cannot contain path separators or dots")]
+pub struct InvalidModIdError {
+    pub mod_id: String,
+}
+
+pub fn validate_mod_id(mod_id: &str) -> Result<(), InvalidModIdError> {
+    if is_valid_mod_id(mod_id) {
+        Ok(())
+    } else {
+        Err(InvalidModIdError {
+            mod_id: mod_id.to_string(),
+        })
+    }
+}
+
+fn is_valid_mod_id(mod_id: &str) -> bool {
+    !mod_id.is_empty()
+        && !mod_id.contains(['/', '\\', '.'])
+        && mod_id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+}

--- a/cat-launcher/src-tauri/src/theme/commands.rs
+++ b/cat-launcher/src-tauri/src/theme/commands.rs
@@ -18,8 +18,7 @@ pub enum GetPreferredThemeCommandError {
 pub async fn get_preferred_theme(
     repository: State<'_, SqliteThemePreferenceRepository>,
 ) -> Result<ThemePreference, GetPreferredThemeCommandError> {
-    let preference = get_theme_preference(repository.inner()).await?;
-    Ok(preference)
+    Ok(get_theme_preference(repository.inner()).await?)
 }
 
 #[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
@@ -33,6 +32,5 @@ pub async fn set_preferred_theme(
     theme: Theme,
     repository: State<'_, SqliteThemePreferenceRepository>,
 ) -> Result<(), SetPreferredThemeCommandError> {
-    update_theme_preference(theme, repository.inner()).await?;
-    Ok(())
+    Ok(update_theme_preference(theme, repository.inner()).await?)
 }

--- a/cat-launcher/src-tauri/src/theme/theme.rs
+++ b/cat-launcher/src-tauri/src/theme/theme.rs
@@ -43,10 +43,7 @@ pub enum GetThemeError {
 pub async fn get_theme_preference(
     repository: &impl ThemePreferenceRepository,
 ) -> Result<ThemePreference, GetThemeError> {
-    repository
-        .get_preferred_theme()
-        .await
-        .map_err(GetThemeError::from)
+    Ok(repository.get_preferred_theme().await?)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -59,8 +56,6 @@ pub async fn update_theme_preference(
     theme: Theme,
     repository: &impl ThemePreferenceRepository,
 ) -> Result<(), UpdateThemeError> {
-    repository
-        .set_preferred_theme(&theme)
-        .await
-        .map_err(UpdateThemeError::from)
+    repository.set_preferred_theme(&theme).await?;
+    Ok(())
 }

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -15,6 +15,7 @@ use crate::infra::repository::db_schema::InitializeSchemaError;
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
 use crate::manual_backups::repository::sqlite_manual_backup_repository::SqliteManualBackupRepository;
+use crate::mods::repository::sqlite_installed_mods_repository::SqliteInstalledModsRepository;
 use crate::play_time::sqlite_play_time_repository::SqlitePlayTimeRepository;
 use crate::settings::Settings;
 use crate::theme::sqlite_theme_preference_repository::SqliteThemePreferenceRepository;
@@ -104,6 +105,7 @@ pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
     app.manage(SqlitePlayTimeRepository::new(pool.clone()));
     app.manage(SqliteGameVariantOrderRepository::new(pool.clone()));
     app.manage(SqliteThemePreferenceRepository::new(pool.clone()));
+    app.manage(SqliteInstalledModsRepository::new(pool.clone()));
     app.manage(SqliteUsersRepository::new(pool));
 
     Ok(())

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -30,7 +30,12 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": ["releases/*.json", "schemas/schema.sql", "settings.json"],
+    "resources": [
+      "releases/*.json",
+      "schemas/schema.sql",
+      "settings.json",
+      "mods.json"
+    ],
     "createUpdaterArtifacts": true
   },
   "plugins": {

--- a/cat-launcher/src/components/SearchInput.tsx
+++ b/cat-launcher/src/components/SearchInput.tsx
@@ -1,0 +1,36 @@
+import { Search } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  "aria-label"?: string;
+}
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = "Search...",
+  className,
+  disabled,
+  "aria-label": ariaLabel,
+}: SearchInputProps) {
+  return (
+    <div className={cn("relative", className)}>
+      <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4 pointer-events-none" />
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="pl-10"
+        disabled={disabled}
+        aria-label={ariaLabel || placeholder || "Search"}
+      />
+    </div>
+  );
+}

--- a/cat-launcher/src/components/VariantSelector.tsx
+++ b/cat-launcher/src/components/VariantSelector.tsx
@@ -1,0 +1,41 @@
+import { Combobox } from "@/components/ui/combobox";
+import { GameVariantInfo } from "@/generated-types/GameVariantInfo";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { cn } from "@/lib/utils";
+
+interface VariantSelectorProps {
+  gameVariants: GameVariantInfo[];
+  selectedVariant: GameVariant | null;
+  onVariantChange: (variant: GameVariant) => void;
+  isLoading: boolean;
+  className?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export default function VariantSelector({
+  gameVariants,
+  selectedVariant,
+  onVariantChange,
+  isLoading,
+  className,
+  placeholder,
+  disabled,
+}: VariantSelectorProps) {
+  return (
+    <Combobox
+      items={gameVariants.map((v) => ({
+        value: v.id,
+        label: v.name,
+      }))}
+      value={selectedVariant ?? undefined}
+      onChange={(value) => onVariantChange(value as GameVariant)}
+      placeholder={
+        placeholder ?? (isLoading ? "Loading..." : "Select a game variant")
+      }
+      disabled={disabled ?? isLoading}
+      autoselect={true}
+      className={cn("w-72", className)}
+    />
+  );
+}

--- a/cat-launcher/src/hooks/useDebounce.ts
+++ b/cat-launcher/src/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Hook that debounces a value by delaying updates until after the specified delay
+ * @param value - The value to debounce
+ * @param delay - The delay in milliseconds
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/cat-launcher/src/hooks/useSearch.ts
+++ b/cat-launcher/src/hooks/useSearch.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useState } from "react";
+
+import { useDebounce } from "./useDebounce";
+
+export interface SearchableItem {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface UseSearchOptions<T extends SearchableItem> {
+  debounceDelay?: number;
+  searchFn?: (item: T, query: string) => boolean;
+}
+
+export function useSearch<T extends SearchableItem>(
+  items: T[],
+  options: UseSearchOptions<T> = {},
+) {
+  const { debounceDelay = 300, searchFn } = options;
+
+  const [searchInput, setSearchInput] = useState("");
+  const debouncedSearchQuery = useDebounce(searchInput, debounceDelay);
+
+  const defaultSearchFn = useCallback(
+    (item: SearchableItem, query: string): boolean => {
+      const lowerQuery = query.toLowerCase().trim();
+      return (
+        item.name.toLowerCase().includes(lowerQuery) ||
+        item.description.toLowerCase().includes(lowerQuery) ||
+        item.id.toLowerCase().includes(lowerQuery)
+      );
+    },
+    [],
+  );
+
+  const filteredItems = useMemo(() => {
+    if (!debouncedSearchQuery.trim()) {
+      return items;
+    }
+
+    const searchFunction = searchFn || defaultSearchFn;
+    return items.filter((item) => searchFunction(item, debouncedSearchQuery));
+  }, [items, debouncedSearchQuery, searchFn, defaultSearchFn]);
+
+  return {
+    searchInput,
+    setSearchInput,
+    debouncedSearchQuery,
+    filteredItems,
+    hasActiveSearch: debouncedSearchQuery.trim().length > 0,
+  };
+}

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -11,6 +11,8 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import type { GameVariantInfo } from "@/generated-types/GameVariantInfo";
 import type { InstallationProgressPayload } from "@/generated-types/InstallationProgressPayload";
 import type { InstallationProgressStatus } from "@/generated-types/InstallationProgressStatus";
+import type { Mod } from "@/generated-types/Mod";
+import type { ModInstallationStatus } from "@/generated-types/ModInstallationStatus";
 import type { ReleasesUpdatePayload } from "@/generated-types/ReleasesUpdatePayload";
 import type { Theme } from "@/generated-types/Theme";
 import type { ThemePreference } from "@/generated-types/ThemePreference";
@@ -229,5 +231,43 @@ export async function setPreferredTheme(theme: Theme): Promise<void> {
 
 export async function getUserId(): Promise<string> {
   const response = await invoke<string>("get_user_id");
+  return response;
+}
+
+export async function installMod(
+  variant: GameVariant,
+  modId: string,
+): Promise<void> {
+  await invoke("install_mod", {
+    variant,
+    modId,
+  });
+}
+
+export async function listAllMods(variant: GameVariant): Promise<Mod[]> {
+  const response = await invoke<Mod[]>("list_all_mods", {
+    variant,
+  });
+  return response;
+}
+
+export async function uninstallModForVariant(
+  variant: GameVariant,
+  modId: string,
+): Promise<void> {
+  await invoke("uninstall_mod_for_variant", {
+    variant,
+    modId,
+  });
+}
+
+export async function getModInstallationStatus(
+  variant: GameVariant,
+  modId: string,
+): Promise<ModInstallationStatus> {
+  const response = await invoke<ModInstallationStatus>("get_mod_installation_status", {
+    variant,
+    modId,
+  });
   return response;
 }

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -25,4 +25,9 @@ export const queryKeys = {
   manualBackups: (variant: GameVariant) => ["manual-backups", variant] as const,
 
   themePreference: () => ["theme_preference"] as const,
+
+  mods: (variant: GameVariant) => ["mods", variant] as const,
+
+  modInstallationStatus: (variant: GameVariant, modId: string) =>
+    ["mod_installation_status", variant, modId] as const,
 };

--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -64,3 +64,7 @@ export function setImmediateInterval(callback: () => void, timeout?: number) {
 
   return setInterval(callback, timeout);
 }
+
+export function getHumanFriendlyText(text: string): string {
+  return text.replace(/_/g, " ").replace(/\s+/g, " ").trim();
+}

--- a/cat-launcher/src/pages/BackupsPage/index.tsx
+++ b/cat-launcher/src/pages/BackupsPage/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Combobox } from "@/components/ui/combobox";
+import VariantSelector from "@/components/VariantSelector";
 import { GameVariant } from "@/generated-types/GameVariant";
 import { useCombinedBackups } from "@/hooks/useCombinedBackups";
 import { useGameVariants } from "@/hooks/useGameVariants";
@@ -80,19 +80,11 @@ function BackupsPage() {
   return (
     <div className="flex flex-col gap-4 p-2">
       <div className="flex items-center gap-4">
-        <Combobox
-          items={gameVariants.map((v) => ({
-            value: v.id,
-            label: v.name,
-          }))}
-          value={selectedVariant ?? undefined}
-          onChange={(value) => setSelectedVariant(value as GameVariant)}
-          placeholder={
-            gameVariantsLoading ? "Loading..." : "Select a game variant"
-          }
-          disabled={gameVariantsLoading}
-          autoselect={true}
-          className="w-72"
+        <VariantSelector
+          gameVariants={gameVariants}
+          selectedVariant={selectedVariant}
+          onVariantChange={setSelectedVariant}
+          isLoading={gameVariantsLoading}
         />
         <Button
           onClick={() => setNewManualDialogOpen(true)}

--- a/cat-launcher/src/pages/ModsPage/EmptyState.tsx
+++ b/cat-launcher/src/pages/ModsPage/EmptyState.tsx
@@ -1,0 +1,7 @@
+export default function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <p className="text-lg">No mods found.</p>
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/ModsPage/LoadingState.tsx
+++ b/cat-launcher/src/pages/ModsPage/LoadingState.tsx
@@ -1,0 +1,15 @@
+export default function LoadingState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="flex items-center gap-2">
+        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary" aria-hidden="true" />
+        <p className="text-lg">Loading mods...</p>
+      </div>
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -1,0 +1,202 @@
+import { Mod } from "@/generated-types/Mod";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useInstallMod } from "./hooks/useInstallMod";
+import { useUninstallMod } from "./hooks/useUninstallMod";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { getHumanFriendlyText, toastCL } from "@/lib/utils";
+import { useState } from "react";
+
+interface ModCardProps {
+  mod: Mod;
+  variant: GameVariant;
+}
+
+const DONT_SHOW_MOD_WARNING_KEY = "dontShowModInstallWarning";
+
+export default function ModCard({ mod, variant }: ModCardProps) {
+  const [showInstallConfirmation, setShowInstallConfirmation] = useState(false);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  const [isOperationInitiated, setIsOperationInitiated] = useState(false);
+
+  const { installMod, isInstalling } = useInstallMod({
+    onError: (error) => {
+      setIsOperationInitiated(false);
+      toastCL("error", "Failed to install mod", error);
+    },
+    onSuccess: () => {
+      setIsOperationInitiated(false);
+      toastCL("success", "Mod installed successfully");
+    },
+  });
+
+  const { uninstallMod, isUninstalling } = useUninstallMod({
+    onError: (error) => {
+      setIsOperationInitiated(false);
+      toastCL("error", "Failed to uninstall mod", error);
+    },
+    onSuccess: () => {
+      setIsOperationInitiated(false);
+      toastCL("success", "Mod uninstalled successfully");
+    },
+  });
+
+  const handleInstall = () => {
+    if (isOperationInitiated) return;
+
+    // Check if user has opted out of the warning
+    const dontShowWarning = localStorage.getItem(DONT_SHOW_MOD_WARNING_KEY) === "true";
+
+    if (dontShowWarning) {
+      setIsOperationInitiated(true);
+      installMod(variant, mod.id);
+    } else {
+      setShowInstallConfirmation(true);
+    }
+  };
+
+  const handleConfirmInstall = () => {
+    if (isOperationInitiated) return;
+
+    // Save the "don't show again" preference if checked
+    if (dontShowAgain) {
+      localStorage.setItem(DONT_SHOW_MOD_WARNING_KEY, "true");
+    }
+
+    setIsOperationInitiated(true);
+    installMod(variant, mod.id);
+    setShowInstallConfirmation(false);
+    setDontShowAgain(false); // Reset for next time
+  };
+
+  const handleUninstall = () => {
+    if (isOperationInitiated) return;
+    setIsOperationInitiated(true);
+    uninstallMod(variant, mod.id);
+  };
+
+  const handleReinstall = () => {
+    if (isOperationInitiated) return;
+    setIsOperationInitiated(true);
+    installMod(variant, mod.id);
+  };
+
+  const isOperationInProgress = isInstalling || isUninstalling || isOperationInitiated;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <CardTitle>{mod.name}</CardTitle>
+          <CardDescription>
+            <div className="flex gap-2 mt-1">
+              <Badge variant="secondary" className="capitalize">
+                {getHumanFriendlyText(mod.category)}
+              </Badge>
+              <Badge variant="outline" className="capitalize">
+                {mod.mod_type === "Stock" ? "Pre-Installed" : "Third-Party"}
+              </Badge>
+            </div>
+          </CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <Alert className="flex flex-col bg-secondary text-secondary-foreground">
+          <AlertDescription className="h-20 overflow-y-auto text-secondary-foreground">
+            {mod.description}
+          </AlertDescription>
+        </Alert>
+        {mod.mod_type === "ThirdParty" && (
+          <div className="space-y-2">
+            {mod.status === "NotInstalled" && (
+              <Button
+                onClick={handleInstall}
+                disabled={isOperationInProgress}
+                className="w-full"
+              >
+                {isInstalling ? "Installing..." : "Install"}
+              </Button>
+            )}
+            {mod.status === "Installed" && (
+              <div className="flex gap-2">
+                <Button
+                  onClick={handleReinstall}
+                  disabled={isOperationInProgress}
+                  variant="outline"
+                  className="flex-1"
+                >
+                  {isInstalling ? "Reinstalling..." : "Reinstall"}
+                </Button>
+                <Button
+                  onClick={handleUninstall}
+                  disabled={isOperationInProgress}
+                  variant="destructive"
+                  className="flex-1"
+                >
+                  {isUninstalling ? "Uninstalling..." : "Uninstall"}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+      <Dialog
+        open={showInstallConfirmation}
+        onOpenChange={(open) => {
+          setShowInstallConfirmation(open);
+          if (!open) {
+            setDontShowAgain(false); // Reset checkbox when dialog closes
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Install Third-Party Mod</DialogTitle>
+            <DialogDescription>
+              Third-party mods can break your game. Your saves and backups are safe. If you encounter an error, uninstall the mod.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center space-x-2 py-4">
+            <Checkbox
+              id="dont-show-again"
+              checked={dontShowAgain}
+              onCheckedChange={(checked) => setDontShowAgain(checked === true)}
+            />
+            <label
+              htmlFor="dont-show-again"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              Don't show this warning again
+            </label>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button onClick={handleConfirmInstall}>Install</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/cat-launcher/src/pages/ModsPage/ModList.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModList.tsx
@@ -1,0 +1,26 @@
+import { Mod } from "@/generated-types/Mod";
+import { GameVariant } from "@/generated-types/GameVariant";
+import ModCard from "./ModCard";
+
+interface ModListProps {
+  mods: Mod[];
+  variant: GameVariant;
+}
+
+export default function ModList({ mods, variant }: ModListProps) {
+  if (mods.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-muted-foreground">No mods available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {mods.map((modItem) => (
+        <ModCard key={`${variant}-${modItem.id}`} mod={modItem} variant={variant} />
+      ))}
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/ModsPage/hooks/useInstallMod.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useInstallMod.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/lib/queryKeys";
+import { installMod } from "@/lib/commands";
+import type { GameVariant } from "@/generated-types/GameVariant";
+
+interface UseInstallModOptions {
+  onError?: (error: unknown) => void;
+  onSuccess?: () => void;
+}
+
+export function useInstallMod({ onError, onSuccess }: UseInstallModOptions = {}) {
+  const queryClient = useQueryClient();
+
+  const { mutate: installModMutation, isPending: isInstalling } = useMutation({
+    mutationFn: async ({
+      variant,
+      modId,
+    }: {
+      variant: GameVariant;
+      modId: string;
+    }) => {
+      await installMod(variant, modId);
+    },
+    onSuccess: (_, { variant, modId }) => {
+      // Invalidate queries to refresh mod list and status
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mods(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.modInstallationStatus(variant, modId),
+      });
+
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  const installModFn = (variant: GameVariant, modId: string) => {
+    installModMutation({ variant, modId });
+  };
+
+  return {
+    isInstalling,
+    installMod: installModFn,
+  };
+}

--- a/cat-launcher/src/pages/ModsPage/hooks/useUninstallMod.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useUninstallMod.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/lib/queryKeys";
+import { uninstallModForVariant } from "@/lib/commands";
+import type { GameVariant } from "@/generated-types/GameVariant";
+
+interface UseUninstallModOptions {
+  onError?: (error: unknown) => void;
+  onSuccess?: () => void;
+}
+
+export function useUninstallMod({
+  onError,
+  onSuccess,
+}: UseUninstallModOptions = {}) {
+  const queryClient = useQueryClient();
+
+  const { mutate: uninstallModMutation, isPending: isUninstalling } =
+    useMutation({
+      mutationFn: async ({
+        variant,
+        modId,
+      }: {
+        variant: GameVariant;
+        modId: string;
+      }) => {
+        await uninstallModForVariant(variant, modId);
+      },
+      onSuccess: (_, { variant, modId }) => {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.mods(variant),
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.modInstallationStatus(variant, modId),
+        });
+
+        onSuccess?.();
+      },
+      onError,
+    });
+
+  const uninstallModFn = (variant: GameVariant, modId: string) => {
+    uninstallModMutation({ variant, modId });
+  };
+
+  return {
+    isUninstalling,
+    uninstallMod: uninstallModFn,
+  };
+}

--- a/cat-launcher/src/pages/ModsPage/index.tsx
+++ b/cat-launcher/src/pages/ModsPage/index.tsx
@@ -1,0 +1,111 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { GameVariant } from "@/generated-types/GameVariant";
+import { useGameVariants } from "@/hooks/useGameVariants";
+import { useSearch } from "@/hooks/useSearch";
+import { queryKeys } from "@/lib/queryKeys";
+import { listAllMods } from "@/lib/commands";
+import { toastCL } from "@/lib/utils";
+import VariantSelector from "@/components/VariantSelector";
+import { SearchInput } from "@/components/SearchInput";
+import ModList from "./ModList";
+import LoadingState from "./LoadingState";
+import EmptyState from "./EmptyState";
+
+function ModsPage() {
+  const { gameVariants, isLoading: gameVariantsLoading } = useGameVariants();
+  const [selectedVariant, setSelectedVariant] = useState<GameVariant | null>(
+    null,
+  );
+
+  const activeVariant = selectedVariant ?? gameVariants[0]?.id;
+
+  const {
+    data: mods,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.mods(activeVariant),
+    queryFn: () => listAllMods(activeVariant),
+    enabled: !!activeVariant,
+  });
+
+  const {
+    searchInput,
+    setSearchInput,
+    debouncedSearchQuery,
+    filteredItems: filteredMods,
+    hasActiveSearch,
+  } = useSearch(mods ?? []);
+
+  useEffect(() => {
+    if (error) {
+      toastCL("error", "Failed to load mods", error);
+    }
+  }, [error]);
+
+  // Early return if no active variant is available
+  if (!activeVariant) {
+    return <LoadingState />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!mods || mods.length === 0) {
+    return <EmptyState />;
+  }
+
+  if (hasActiveSearch && filteredMods.length === 0) {
+    return (
+      <div className="container mx-auto py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <VariantSelector
+            gameVariants={gameVariants}
+            selectedVariant={selectedVariant}
+            onVariantChange={setSelectedVariant}
+            isLoading={gameVariantsLoading}
+          />
+          <SearchInput
+            value={searchInput}
+            onChange={setSearchInput}
+            placeholder="Search mods..."
+            className="flex-1 max-w-md"
+          />
+        </div>
+        <h1 className="text-3xl font-bold mb-6">Available Mods</h1>
+        <div className="text-center py-8">
+          <p className="text-muted-foreground">
+            No mods found matching "{debouncedSearchQuery}". Try a different
+            search term.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <div className="flex items-center gap-4">
+        <VariantSelector
+          gameVariants={gameVariants}
+          selectedVariant={selectedVariant}
+          onVariantChange={setSelectedVariant}
+          isLoading={gameVariantsLoading}
+        />
+        <SearchInput
+          value={searchInput}
+          onChange={setSearchInput}
+          placeholder="Search mods..."
+          className="flex-1 max-w-md"
+        />
+      </div>
+
+      <ModList mods={filteredMods} variant={activeVariant} />
+    </div>
+  );
+}
+
+export default ModsPage;

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -1,7 +1,9 @@
+import { FileUp, Gamepad2, Info, Box } from "lucide-react";
+
 import PlayPage from "@/pages/PlayPage";
 import AboutPage from "@/pages/AboutPage";
 import BackupsPage from "@/pages/BackupsPage";
-import { FileUp, Gamepad2, Info } from "lucide-react";
+import ModsPage from "@/pages/ModsPage";
 
 export const routes = [
   {
@@ -15,6 +17,12 @@ export const routes = [
     element: <BackupsPage />,
     label: "Backups",
     icon: FileUp,
+  },
+  {
+    path: "/mods",
+    element: <ModsPage />,
+    label: "Mods",
+    icon: Box,
   },
   {
     path: "/about",

--- a/cat-launcher/src/store/store.ts
+++ b/cat-launcher/src/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+
 import gameSessionReducer from "./gameSessionSlice";
 import installationProgressReducer from "./installationProgressSlice";
 import releasesReducer from "./releasesSlice";

--- a/cat-launcher/src/theme/ThemeToggle.tsx
+++ b/cat-launcher/src/theme/ThemeToggle.tsx
@@ -16,14 +16,13 @@ export default function ThemeToggle() {
       type="button"
       variant="ghost"
       size="icon"
-      onClick={() => toggleTheme()}
+      onClick={toggleTheme}
       aria-label="Toggle theme"
       title="Toggle theme"
       disabled={isUpdating}
       className="text-muted-foreground hover:text-primary"
     >
       <Icon className="h-4 w-4" />
-      <span className="sr-only">Toggle theme</span>
     </Button>
   );
 }


### PR DESCRIPTION
### **User description**
Add core backend helpers to check and uninstall mods, plus basic
frontend list rendering for mods.

- Introduce get_mod_installation_status with ModInstallationStatus enum
  and validation to avoid path traversal. Query repository, inspect
  filesystem (offloaded with spawn_blocking) and return Installed,
  NotInstalled or Corrupted.
- Add uninstall_mod_for_variant that verifies installation in the
  repository, removes the mod directory if present, and deletes the
  record from the repository. Define UninstallModError for clear error
  cases.
- Add shared mod metadata types (ModType, ModStatus) for TS exports.
- Add ModList React component that displays a grid of ModCard items
  and shows a friendly empty state when no mods are available.

These changes enable safer mod state checks, proper uninstall flow, and
a simple UI list to surface mods to the user.


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive mod management backend with installation status checking, install/uninstall operations, and mod listing

- Implement mod repository pattern with SQLite persistence for tracking installed mods

- Create frontend ModsPage with search, filtering, and mod card UI for install/uninstall actions

- Add shared TypeScript types and React hooks for mod operations with query caching

- Include mods.json configuration with third-party mod metadata for multiple game variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Backend["Backend Mod System"]
  Commands["Tauri Commands"]
  Frontend["Frontend UI"]
  
  Backend -->|list_all_mods| Commands
  Backend -->|install_mod| Commands
  Backend -->|uninstall_mod_for_variant| Commands
  Backend -->|get_mod_installation_status| Commands
  
  Commands -->|React Hooks| Frontend
  Frontend -->|ModsPage| UI["Mod Cards & Search"]
  
  ModsJson["mods.json Config"] -->|Third-party Mods| Backend
  Repository["SQLite Repository"] -->|Track Installed| Backend
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>32 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Module structure for mod management system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-26781f3bf369c4ee6e555abe0c898b13a261f21ab1f9df11877ae0beb1d4a8c8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod_info.rs</strong><dd><code>Shared mod metadata types with TypeScript exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-64737004d87dc12eb020560bfd747db13c5f42f508130a0e9d1e11ded06fa384">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Tauri command handlers for mod operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-891589ba1757a05e0a9d08c9f8ca50ddba5f0b0cc33c33eaf54fc8096b171978">+148/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_all_mods.rs</strong><dd><code>Load and combine stock and third-party mods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-ce2da28b367858357ed0a11b6d50c8e2bed706d557bcb2d58ee78517a0a03603">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>install_mod.rs</strong><dd><code>Download, extract, and install third-party mods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-69aded3957d1b405b852872cfd4162195fce84228fd53677082e6dae36fc2b2a">+151/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>uninstall_mod.rs</strong><dd><code>Remove mod files and repository records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-06a8f90b686663327ba65b486c0d5a3359e49de90a68bf43295d8a392f7cbcb0">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_mod_installation_status.rs</strong><dd><code>Check mod installation status with path validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-020e7b988b19b194ce533cf022c9607e25d5611728ca6329d459ab0dc2b96496">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_mod_details.rs</strong><dd><code>Retrieve mod details from mods.json configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-76726dfde1633cc8050908774e99a98f89cfb2051473ef4645939e8f8833d976">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installed_mods_repository.rs</strong><dd><code>Repository trait for installed mods CRUD operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-e88cdf7b7c08be67fb7a05eb38750e0fcafeece43c941647e6c6b3b173d23926">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_installed_mods_repository.rs</strong><dd><code>SQLite implementation of installed mods repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-0bb7f7cd68393e538fab9d217491345fc79c39ec5f2fb7d615e9fc78bda14b56">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Repository module exports and trait definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-64ac37d5c4563b24437888cbf030bc97c18cf5f2c7b8d51c634fb4265bc19158">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register mods module and Tauri commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Initialize SQLite installed mods repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-b3ee322098b457e66256bbc93ebafa48258bb7677544ec6ff974981ea1915719">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Add installed_mods table and fix theme_preferences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Main mods page with variant selection and search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-e04f974b64b56ae6669d5b3e4a55fa068fdcc35f180eacc0552c2873e5c866f0">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ModCard.tsx</strong><dd><code>Mod card component with install/uninstall actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-f8d8e5c7bec36fe4784af5ed278799d4176bef37dcd22d606315cb937652cc86">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ModList.tsx</strong><dd><code>Grid layout for displaying mod cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-a91800d79eeb440b4a55ff82afa10cec17bc8f9af757829f5309560059e3883c">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoadingState.tsx</strong><dd><code>Loading state UI for mods page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-b7e8b8ed8aa9c506500f5ff2fb7cb8c4232bc59c2a8c71fab7a1455aca7b2369">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EmptyState.tsx</strong><dd><code>Empty state UI when no mods available</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-effa63039d8671b959ca422e92f025e24064985c8851c735cdd7d2fac086da3f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useInstallMod.ts</strong><dd><code>React hook for mod installation with query invalidation</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-ea543c5edd4ce6043bdd653125e44cb9591322b0fd94894cb68af4b269305f3b">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useUninstallMod.ts</strong><dd><code>React hook for mod uninstallation with query invalidation</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-3ed073f4b360701039f783e7c0aeebf4b40bf3a1a7c287b951dad66ecb6816b0">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SearchInput.tsx</strong><dd><code>Reusable search input component with icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-9cc7b0f3031995d5e15a56ad931dfd21eb79c5a1cc8e7e3cd8cd17cf63a22d27">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>VariantSelector.tsx</strong><dd><code>Reusable game variant selector component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-66ebe3a71db5030522b990ca80456663f32d7734622b8cada37e9ffa611713b3">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useDebounce.ts</strong><dd><code>Generic debounce hook for value delays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-7e9d221b7c80fb7a78dd7e164134cabeb6234eeece9f86bde9949c6660e24f77">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSearch.ts</strong><dd><code>Search hook with debouncing and filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-59586a046e11e00105df2e4c0884b21899d55ba7e218bb63e16cbf9a83cef659">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Tauri command wrappers for mod operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>React Query keys for mods and installation status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Add human-friendly text formatting utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-d1cfdf24afe367787ae798231be0ad8ce5dfda64435ed3cc781ab3201aa1b513">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>modsSlice.ts</strong><dd><code>Redux slice for mod installation status state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-1f01034007fe08f919703897ddcf6af8f19043c36b4f39e3cddbfe2d15ab13f5">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>store.ts</strong><dd><code>Register mods reducer in Redux store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-fbaf1ffc15cb80a8f46fc4fa895fcf3e9099a4a84ca0d41ece427a97be63a8f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Refactor to use reusable VariantSelector component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-21a1a501016807e7346ac1c2c6e9ccc1583b7f36e4571c5345e4981374da40e8">+6/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routes.tsx</strong><dd><code>Add mods route with Box icon to navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-1e5bca5f2ad612aadcc10f3c1749eeb1094085f3e49863d6bef96bd632673277">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mods.json</strong><dd><code>Third-party mod metadata for game variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-9499175305b9cbb752a2194e0dc12b38b1fdf5cb7a9dd898e676c9c9da7753b8">+166/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tauri.conf.json</strong><dd><code>Include mods.json in bundled resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-a129d0a394e29d198f60425580a5ef2de79dfc1717a9252f1190ec4618cfb0db">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ThemeToggle.tsx</strong><dd><code>Simplify onClick handler and remove redundant span</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-8e525222c2c12c1569ac7dfc81fc172527d4bfee6ceaacecbab95a19a909770f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Simplify error handling with question mark operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-7275b3e1d065b1966a21881f69db040790fbe60de9a400a74e13935a8eb84619">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme.rs</strong><dd><code>Simplify error handling with question mark operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/239/files#diff-1d224d67c9b833c3603f54052f86c4d7e33a9d16565ec09d08f68836cdd54d5a">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mod management across backend and UI so users can list, search, install, reinstall, and uninstall mods per game variant. Includes stock and third‑party mods with safe installation checks.

- **New Features**
  - Backend commands: list_all_mods, install_mod, uninstall_mod_for_variant, get_mod_installation_status.
  - Third‑party mods come from mods.json; stock mods are read from game resources (modinfo.json).
  - SQLite installed_mods repository and schema; validates mod IDs and flags corrupted installs.
  - Shared types exported to TS: Mod, ModType, ModStatus, ModInstallationStatus. Commands wired in Tauri and frontend (invoke helpers, query keys).
  - Mods page with VariantSelector, search, and ModCard grid. Install/uninstall/reinstall actions, confirmation dialog, and toasts. New /mods route and reusable SearchInput.

- **Migration**
  - installed_mods table is created automatically; no manual steps.
  - mods.json is bundled via tauri.conf.json resources.

<sup>Written for commit fffb1dca21ad74d71f1996fc2db14a2a6601cd9f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







