### PR TITLE
refactor(components): extract VariantSelector from BackupsPage

### DIFF
--- a/cat-launcher/src/components/VariantSelector.tsx
+++ b/cat-launcher/src/components/VariantSelector.tsx
@@ -1,0 +1,41 @@
+import { Combobox } from "@/components/ui/combobox";
+import { GameVariantInfo } from "@/generated-types/GameVariantInfo";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { cn } from "@/lib/utils";
+
+interface VariantSelectorProps {
+  gameVariants: GameVariantInfo[];
+  selectedVariant: GameVariant | null;
+  onVariantChange: (variant: GameVariant) => void;
+  isLoading: boolean;
+  className?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export default function VariantSelector({
+  gameVariants,
+  selectedVariant,
+  onVariantChange,
+  isLoading,
+  className,
+  placeholder,
+  disabled,
+}: VariantSelectorProps) {
+  return (
+    <Combobox
+      items={gameVariants.map((v) => ({
+        value: v.id,
+        label: v.name,
+      }))}
+      value={selectedVariant ?? undefined}
+      onChange={(value) => onVariantChange(value as GameVariant)}
+      placeholder={
+        placeholder ?? (isLoading ? "Loading..." : "Select a game variant")
+      }
+      disabled={disabled || isLoading}
+      autoselect={true}
+      className={cn("w-72", className)}
+    />
+  );
+}

--- a/cat-launcher/src/pages/BackupsPage/index.tsx
+++ b/cat-launcher/src/pages/BackupsPage/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Combobox } from "@/components/ui/combobox";
+import VariantSelector from "@/components/VariantSelector";
 import { GameVariant } from "@/generated-types/GameVariant";
 import { useCombinedBackups } from "@/hooks/useCombinedBackups";
 import { useGameVariants } from "@/hooks/useGameVariants";
@@ -80,19 +80,11 @@ function BackupsPage() {
   return (
     <div className="flex flex-col gap-4 p-2">
       <div className="flex items-center gap-4">
-        <Combobox
-          items={gameVariants.map((v) => ({
-            value: v.id,
-            label: v.name,
-          }))}
-          value={selectedVariant ?? undefined}
-          onChange={(value) => setSelectedVariant(value as GameVariant)}
-          placeholder={
-            gameVariantsLoading ? "Loading..." : "Select a game variant"
-          }
-          disabled={gameVariantsLoading}
-          autoselect={true}
-          className="w-72"
+        <VariantSelector
+          gameVariants={gameVariants}
+          selectedVariant={selectedVariant}
+          onVariantChange={setSelectedVariant}
+          isLoading={gameVariantsLoading}
         />
         <Button
           onClick={() => setNewManualDialogOpen(true)}


### PR DESCRIPTION
### **User description**
Extract the Combobox variant selection into a reusable VariantSelector
component and replace the inline Combobox usage in BackupsPage with the
new component.

This consolidates prop handling (gameVariants, selectedVariant,
onVariantChange, isLoading, className, placeholder, disabled) and keeps
BackupsPage leaner. It also centralizes UI logic for variant selection,
making it easier to reuse and maintain.


___

### **PR Type**
Enhancement


___

### **Description**
- Extract variant selection logic into reusable VariantSelector component

- Replace inline Combobox usage in BackupsPage with new component

- Consolidate prop handling and centralize UI logic for variant selection

- Improve code maintainability and reusability across the application


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BP["BackupsPage<br/>with inline Combobox"] -- "extract variant<br/>selection logic" --> VS["VariantSelector<br/>reusable component"]
  BP -- "replace with<br/>component import" --> BP2["BackupsPage<br/>using VariantSelector"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariantSelector.tsx</strong><dd><code>New VariantSelector component for variant selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/components/VariantSelector.tsx

<ul><li>New reusable component created to encapsulate variant selection logic<br> <li> Accepts gameVariants, selectedVariant, onVariantChange, isLoading, <br>className, placeholder, and disabled props<br> <li> Wraps Combobox with default placeholder logic and styling (w-72 width)<br> <li> Handles variant mapping and type casting internally</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/241/files#diff-66ebe3a71db5030522b990ca80456663f32d7734622b8cada37e9ffa611713b3">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Replace inline Combobox with VariantSelector component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/BackupsPage/index.tsx

<ul><li>Replace inline Combobox with VariantSelector component import<br> <li> Remove 11 lines of inline Combobox configuration code<br> <li> Pass variant selection props to VariantSelector component<br> <li> Simplify BackupsPage by delegating variant selection UI to dedicated <br>component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/241/files#diff-21a1a501016807e7346ac1c2c6e9ccc1583b7f36e4571c5345e4981374da40e8">+6/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the game variant Combobox into a reusable VariantSelector component and replaced its usage in BackupsPage. This keeps BackupsPage lean and centralizes variant selection UI for easier reuse and maintenance.

- **Refactors**
  - Added VariantSelector component that wraps Combobox and preserves autoselect, width, and loading placeholder.
  - Replaced inline Combobox in BackupsPage with VariantSelector.
  - Consolidates variant selection props and disables input while loading.

<sup>Written for commit 542b80456259936f497a9eb1efaade25c37edf34. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

