### PR TITLE
feat(downloader): add HTTP client and downloader management

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -1,3 +1,4 @@
+use reqwest::Client;
 use strum::IntoStaticStr;
 use tauri::{command, AppHandle, Emitter, Manager, State};
 
@@ -5,7 +6,6 @@ use cat_macros::CommandErrorSerialize;
 
 use crate::fetch_releases::fetch_releases::{FetchReleasesError, ReleasesUpdatePayload};
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
-use crate::infra::http_client::HTTP_CLIENT;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
@@ -22,6 +22,7 @@ pub async fn fetch_releases_for_variant(
     app_handle: AppHandle,
     variant: GameVariant,
     releases_repository: State<'_, SqliteReleasesRepository>,
+    client: State<'_, Client>,
 ) -> Result<(), FetchReleasesCommandError> {
     let resources_dir = app_handle.path().resource_dir()?;
 
@@ -32,7 +33,7 @@ pub async fn fetch_releases_for_variant(
 
     variant
         .fetch_releases(
-            &HTTP_CLIENT,
+            &client,
             &resources_dir,
             &*releases_repository,
             on_releases,

--- a/cat-launcher/src-tauri/src/infra/download.rs
+++ b/cat-launcher/src-tauri/src/infra/download.rs
@@ -1,0 +1,66 @@
+use std::num::NonZeroU16;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use downloader::progress::Reporter;
+use reqwest::Client;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DownloadFileError {
+    #[error("downloader creation failed: {0}")]
+    DownloaderCreation(#[from] downloader::Error),
+
+    #[error("no download result found")]
+    NoDownloadResult,
+}
+
+pub struct Downloader {
+    client: Client,
+    parallel_requests: NonZeroU16,
+}
+
+impl Downloader {
+    pub fn new(client: Client, parallel_requests: NonZeroU16) -> Self {
+        Self {
+            client,
+            parallel_requests,
+        }
+    }
+
+    pub async fn download_file(
+        &self,
+        url: &str,
+        download_dir: &Path,
+        reporter: Arc<dyn Reporter + Send + Sync>,
+    ) -> Result<PathBuf, DownloadFileError> {
+        let mut builder = downloader::Downloader::builder();
+        builder
+            .download_folder(download_dir)
+            .parallel_requests(self.parallel_requests.get());
+
+        let mut downloader = builder.build_with_client(self.client.clone())?;
+
+        let dl = downloader::Download::new(url).progress(reporter);
+
+        let results = downloader.async_download(&[dl]).await?;
+
+        if let Some(res) = results.into_iter().next() {
+            match res {
+                Ok(summary) => Ok(summary.file_name),
+                Err(e) => Err(DownloadFileError::DownloaderCreation(e)),
+            }
+        } else {
+            Err(DownloadFileError::NoDownloadResult)
+        }
+    }
+}
+
+pub struct NoOpReporter;
+
+impl Reporter for NoOpReporter {
+    fn setup(&self, _max_progress: Option<u64>, _message: &str) {}
+    fn progress(&self, _current: u64) {}
+    fn set_message(&self, _message: &str) {}
+    fn done(&self) {}
+}

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,26 +1,8 @@
-use std::num::NonZeroU16;
-use std::path::Path;
-use std::sync::LazyLock;
-
-use downloader::Downloader;
 use reqwest::Client;
 
-pub fn create_downloader(
-    client: Client,
-    download_folder: &Path,
-    parallel_requests: NonZeroU16,
-) -> downloader::Result<Downloader> {
-    let mut builder = Downloader::builder();
-    builder
-        .download_folder(download_folder)
-        .parallel_requests(parallel_requests.get());
-
-    builder.build_with_client(client)
-}
-
-pub static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+pub fn create_http_client() -> Client {
     Client::builder()
         .user_agent("cat-launcher")
         .build()
         .expect("Failed to build reqwest client")
-});
+}

--- a/cat-launcher/src-tauri/src/infra/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive;
 pub mod autoupdate;
+pub mod download;
 pub mod github;
 pub mod http_client;
 pub mod repository;

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -2,13 +2,13 @@ pub mod constants;
 pub mod filesystem;
 pub mod settings;
 
+pub mod active_release;
 mod backups;
 mod fetch_releases;
 mod game_release;
 mod game_tips;
 mod infra;
 mod install_release;
-pub mod active_release;
 mod launch_game;
 mod manual_backups;
 mod play_time;
@@ -17,6 +17,7 @@ mod users;
 mod utils;
 mod variants;
 
+use crate::active_release::commands::get_active_release;
 use crate::backups::commands::{
     delete_backup_by_id, list_backups_for_variant, restore_backup_by_id,
 };
@@ -24,7 +25,6 @@ use crate::fetch_releases::commands::fetch_releases_for_variant;
 use crate::game_tips::commands::get_tips;
 use crate::install_release::commands::install_release;
 use crate::install_release::installation_status::commands::get_installation_status;
-use crate::active_release::commands::get_active_release;
 use crate::launch_game::commands::launch_game;
 use crate::manual_backups::commands::{
     create_manual_backup_for_variant, delete_manual_backup_by_id, list_manual_backups_for_variant,
@@ -34,7 +34,8 @@ use crate::play_time::commands::{get_play_time_for_variant, get_play_time_for_ve
 use crate::theme::commands::{get_preferred_theme, set_preferred_theme};
 use crate::users::commands::get_user_id;
 use crate::utils::{
-    autoupdate, manage_posthog, manage_repositories, manage_settings, migrate_backups,
+    autoupdate, manage_downloader, manage_http_client, manage_posthog, manage_repositories,
+    manage_settings, migrate_backups,
 };
 use crate::variants::commands::get_game_variants_info;
 use crate::variants::commands::update_game_variant_order;
@@ -46,6 +47,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             manage_settings(app)?;
+            manage_http_client(app);
+            manage_downloader(app);
             manage_repositories(app)?;
             manage_posthog(app);
 

--- a/dev-docs/best-practices.md
+++ b/dev-docs/best-practices.md
@@ -65,6 +65,6 @@ pub enum InstallModError {
 
 The project provides shared utilities that should be reused:
 
--   **HTTP Client:** Use `HTTP_CLIENT` from `src-tauri/src/infra/http_client.rs` instead of creating new `reqwest::Client` instances.
+-   **HTTP Client:** The `reqwest::Client` is managed by Tauri. To use it in a command, add `client: State<reqwest::Client>` to the function's parameters.
 -   **Archive Extraction:** Use `extract_archive` from `src-tauri/src/infra/archive.rs` for extracting zip, tar.gz, dmg, and rar files.
 -   **Directory Copying:** Use `copy_dir_all` from `src-tauri/src/filesystem/utils.rs` for recursive directory copying.


### PR DESCRIPTION
### **User description**
Introduce a Downloader abstraction and integrate an HTTP client into the
tauri app state so background downloads can run with configured parallel
requests. Add infra/download.rs implementing Downloader with async file
download support (using downloader crate) and a NoOpReporter for simple
progress handling. Expose the module in infra/mod.rs.

Wire the new components into utils: add manage_http_client and
manage_downloader functions to create and manage a reqwest client and a
Downloader instance from app state. Reorder imports to include the new
repositories and infra modules.

Update github asset handling to use the new Downloader and its error
type instead of depending directly on downloader::Error, preparing the
codebase for centralized download management and better error mapping.


___

### **PR Type**
Enhancement, Refactoring


___

### **Description**
- Refactor HTTP client and downloader into managed Tauri state

- Create new `Downloader` abstraction wrapping downloader crate

- Replace static `HTTP_CLIENT` with dependency injection pattern

- Update commands to receive client/downloader via state parameters

- Simplify asset download logic by delegating to `Downloader`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Static HTTP_CLIENT"] -->|Remove| B["Tauri App State"]
  C["Direct downloader usage"] -->|Refactor| D["Downloader abstraction"]
  B -->|Inject| E["Commands via State"]
  D -->|Simplify| F["Asset downloads"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>download.rs</strong><dd><code>New Downloader abstraction with async file downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-d1b9041b8d409515782129636510545049b015d96de510d3230804cb90a8bd8d">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Expose new download module in public API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-461d7c8883d34c42fbfc6f8b74442bd862efd64e35b004a4f80df0ab52d27c76">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Add manage_http_client and manage_downloader setup functions</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-b3ee322098b457e66256bbc93ebafa48258bb7677544ec6ff974981ea1915719">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Wire HTTP client and downloader management into app setup</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>http_client.rs</strong><dd><code>Simplify to factory function for HTTP client creation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-7b926b94d0cc342fad5280b0b2011d7b8bfd0fd9964ee8ba22c9a06d4101fcac">+2/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>asset.rs</strong><dd><code>Use Downloader abstraction instead of direct downloader crate</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-00e245ef57c3816f19920402b2edf6cd23e7a1b55de3d97cb3619db00d373e06">+11/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Inject HTTP client via State instead of static reference</code>&nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-22e12e78248e5c9195a1a4abb391b94237f25e974790b7da0cfdb99123cf681c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Replace Settings and HTTP_CLIENT with Downloader state injection</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-9a30f7f42936aeee46df9d9e113d540a3e71e5851eaa7a9d9459312b28f5e956">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>install_release.rs</strong><dd><code>Use Downloader abstraction and remove Settings dependency</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-622ba6613a6ee5508c7e96fd54321d16adfbf604cc47bdda936440d15be7478a">+5/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>best-practices.md</strong><dd><code>Update HTTP client usage documentation for state injection</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/245/files#diff-d2bda1f7a0c4d9eed5c00b25016adcc8117bfebb69055c67c848e693ca220543">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a shared Downloader and moves the reqwest Client into Tauri app state. Centralizes downloads, enables parallel requests, and improves error handling across asset fetch and release install.

- **New Features**
  - Downloader with async file download and configurable parallel requests.
  - NoOpReporter for simple progress updates.
  - Tauri-managed reqwest Client and Downloader via manage_http_client and manage_downloader.

- **Migration**
  - Replace HTTP_CLIENT with client: State<reqwest::Client> in commands.
  - Replace create_downloader and direct settings usage with downloader: State<Downloader>.
  - Update asset downloads to use Downloader::download_file and handle DownloadFileError.

<sup>Written for commit 1ae45d0b3542386247dfcda3d020ad7fd98484fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

