### PR TITLE
feat(filter): disable release type toggles during install

### DIFF
--- a/cat-launcher/src/pages/PlayPage/ReleaseFilter.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseFilter.tsx
@@ -2,9 +2,10 @@ import { useMemo, useState } from "react";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { GameRelease } from "@/generated-types/GameRelease";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import type { ReleaseType } from "@/generated-types/ReleaseType";
-import { GameRelease } from "@/generated-types/GameRelease";
+import { useAppSelector } from "@/store/hooks";
 
 export type FilterFn = (r: GameRelease) => boolean;
 
@@ -59,6 +60,19 @@ export default function ReleaseFilter({
     filters.map((f) => f.id), // default to all filters selected
   );
 
+  const installationStatuses = useAppSelector(
+    (state) => state.installationProgress.statusByVariant[variant],
+  );
+
+  const isInProgress = useMemo(() => {
+    if (!installationStatuses) {
+      return false;
+    }
+    return Object.values(installationStatuses).some(
+      (status) => status === "Downloading" || status === "Installing",
+    );
+  }, [installationStatuses]);
+
   function handleCheckedChange(checked: boolean, filterId: ReleaseType) {
     const appliedFilterIds = new Set(selectedFilterIds);
 
@@ -93,6 +107,7 @@ export default function ReleaseFilter({
               onCheckedChange={(checked: boolean) =>
                 handleCheckedChange(checked, filter.id)
               }
+              disabled={isInProgress}
             />
             <Label htmlFor={key} className="text-sm font-medium">
               {filter.label}


### PR DESCRIPTION
### **User description**
Add installation progress awareness to ReleaseFilter so filter checkboxes
are disabled while any installation for the given variant is in progress.
Use the store hook to read installation statuses and compute an
isInProgress flag; pass it to checkbox controls to prevent changing
filters during active Downloading or Installing states.

This prevents UI state changes that could conflict with ongoing
installation actions and keeps filter behavior consistent during installs.


___

### **PR Type**
Enhancement


___

### **Description**
- Disable release filter checkboxes during active installation

- Read installation progress from Redux store for variant

- Prevent filter changes conflicting with ongoing downloads/installs

- Maintain UI consistency during installation operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Store["Redux Store<br/>installationProgress"] -- "useAppSelector" --> Hook["ReleaseFilter<br/>Component"]
  Hook -- "compute isInProgress" --> Status["Check Downloading/<br/>Installing status"]
  Status -- "pass disabled prop" --> Checkbox["Checkbox<br/>Controls"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReleaseFilter.tsx</strong><dd><code>Add installation progress awareness to filter checkboxes</code>&nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/ReleaseFilter.tsx

<ul><li>Import <code>useAppSelector</code> hook to access Redux store<br> <li> Retrieve installation statuses for current variant from store<br> <li> Compute <code>isInProgress</code> flag by checking for active <br>Downloading/Installing states<br> <li> Pass <code>disabled={isInProgress}</code> prop to Checkbox components to prevent <br>user interaction</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/246/files#diff-eb880fd3ce522f19d5e8ba48316770df00da224019d23c3e0443362c9319dbb7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable release type checkboxes while a variant is downloading or installing to prevent conflicting changes. ReleaseFilter reads installation status from the Redux store, computes an in-progress flag, and disables the toggles during active installs.

<sup>Written for commit 8f5853dad33dc0cfeb4ccc6ce7cc4b6797ad1105. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



