### PR TITLE
feat(http): add support for GITHUB_PAT to auth GitHub requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+GITHUB_PAT=
+
 TS_RS_EXPORT_DIR=../src/generated-types/
 
 TAURI_SIGNING_PRIVATE_KEY=/home/abhishek/.tauri/cat-launcher/updater.key

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,8 +1,28 @@
+use std::env;
+
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Client;
 
+fn create_github_pat_headers() -> Option<HeaderMap> {
+    if let Ok(github_pat) = env::var("GITHUB_PAT") {
+        if !github_pat.is_empty() {
+            let authorization = format!("Bearer {}", github_pat);
+            if let Ok(header_value) = HeaderValue::from_str(&authorization) {
+                let mut headers = HeaderMap::new();
+                headers.insert(AUTHORIZATION, header_value);
+                return Some(headers);
+            }
+        }
+    }
+    None
+}
+
 pub fn create_http_client() -> Client {
-    Client::builder()
-        .user_agent("cat-launcher")
-        .build()
-        .expect("Failed to build reqwest client")
+    let mut builder = Client::builder().user_agent("cat-launcher");
+
+    if let Some(headers) = create_github_pat_headers() {
+        builder = builder.default_headers(headers);
+    }
+
+    builder.build().expect("Failed to build reqwest client")
 }


### PR DESCRIPTION
### **User description**
Create helper to build Authorization headers from a GITHUB_PAT
environment variable and wire it into the reqwest client as default
headers when present. Keep existing user agent and fall back to the
previous client behavior when the variable is absent or invalid.

Also add GITHUB_PAT to .env.example so developers see how to provide the
personal access token for authenticated requests.


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub PAT authentication support via environment variable

- Create helper function to build Authorization headers from GITHUB_PAT

- Wire authentication headers into reqwest client as defaults

- Document GITHUB_PAT configuration in .env.example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GITHUB_PAT env var"] -->|read| B["create_github_pat_headers()"]
  B -->|if valid| C["Authorization header"]
  C -->|set as default| D["reqwest Client"]
  B -->|if invalid/absent| D
  E[".env.example"] -->|document| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_client.rs</strong><dd><code>Add GitHub PAT authentication header support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/infra/http_client.rs

<ul><li>Add <code>create_github_pat_headers()</code> helper function to read GITHUB_PAT <br>environment variable and build Authorization headers<br> <li> Validate PAT is non-empty and create valid HeaderValue before <br>returning<br> <li> Modify <code>create_http_client()</code> to conditionally apply default headers <br>when PAT is available<br> <li> Maintain existing user agent and fallback behavior when PAT is absent <br>or invalid</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/247/files#diff-7b926b94d0cc342fad5280b0b2011d7b8bfd0fd9964ee8ba22c9a06d4101fcac">+25/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document GITHUB_PAT environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Add GITHUB_PAT configuration variable at top of file<br> <li> Provide empty placeholder for developers to fill in their personal <br>access token</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/247/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional GitHub authentication to the HTTP client. When GITHUB_PAT is set, requests include a Bearer Authorization header; otherwise behavior is unchanged.

- **Migration**
  - Set GITHUB_PAT in your .env to enable authenticated GitHub requests.
  - .env.example now includes GITHUB_PAT for guidance.

<sup>Written for commit 0f501789e568ec37eba30858237259b52eeee5bb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

