### PR TITLE
style: tidy layout spacing and remove redundant padding

### DIFF
--- a/cat-launcher/src/App.tsx
+++ b/cat-launcher/src/App.tsx
@@ -6,11 +6,13 @@ function App() {
   return (
     <BrowserRouter>
       <NavBar />
-      <Routes>
-        {routes.map((route) => (
-          <Route key={route.path} path={route.path} element={route.element} />
-        ))}
-      </Routes>
+      <div className="p-2">
+        <Routes>
+          {routes.map((route) => (
+            <Route key={route.path} path={route.path} element={route.element} />
+          ))}
+        </Routes>
+      </div>
     </BrowserRouter>
   );
 }

--- a/cat-launcher/src/pages/BackupsPage/index.tsx
+++ b/cat-launcher/src/pages/BackupsPage/index.tsx
@@ -78,7 +78,7 @@ function BackupsPage() {
   };
 
   return (
-    <div className="flex flex-col gap-4 p-2">
+    <div className="flex flex-col gap-4">
       <div className="flex items-center gap-4">
         <VariantSelector
           gameVariants={gameVariants}

--- a/cat-launcher/src/pages/PlayPage/index.tsx
+++ b/cat-launcher/src/pages/PlayPage/index.tsx
@@ -68,7 +68,7 @@ function PlayPage() {
         items={orderedItems.map((item) => item.id)}
         strategy={verticalListSortingStrategy}
       >
-        <main className="grid grid-cols-[repeat(auto-fit,minmax(20rem,1fr))] gap-2 p-2">
+        <main className="grid grid-cols-[repeat(auto-fit,minmax(20rem,1fr))] gap-2">
           {orderedItems.map((variantInfo) => (
             <GameVariantCard key={variantInfo.id} variantInfo={variantInfo} />
           ))}


### PR DESCRIPTION
### **User description**
Wrap Routes in a padded container to separate page content from the
NavBar and ensure consistent outer spacing across routes. Remove
redundant p-2 paddings from individual pages/components so that global
container padding controls layout instead of duplicated local paddings.

- Add a div with class "p-2" around <Routes> in App.tsx to provide a
  unified outer padding.
- Remove "p-2" from BackupsPage container to avoid double padding.
- Remove "p-2" from PlayPage main grid to rely on the new outer padding.

These changes simplify spacing rules and prevent inconsistent or
excessive padding across pages.


___

### **PR Type**
Enhancement


___

### **Description**
- Wrap Routes in padded container for consistent outer spacing

- Remove redundant p-2 padding from BackupsPage and PlayPage

- Centralize layout spacing control in App.tsx


___

### Diagram Walkthrough


```mermaid
flowchart LR
  App["App.tsx<br/>Add p-2 wrapper"] --> Routes["Routes<br/>Unified padding"]
  Routes --> BackupsPage["BackupsPage<br/>Remove p-2"]
  Routes --> PlayPage["PlayPage<br/>Remove p-2"]
  BackupsPage --> Result["Consistent spacing<br/>across pages"]
  PlayPage --> Result
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Add padded container around Routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/App.tsx

<ul><li>Wrap <code><Routes></code> component with a new <code><div className="p-2"></code> container<br> <li> Provides unified outer padding for all route pages<br> <li> Centralizes spacing control at the application root level</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/248/files#diff-17d550db536b1ebb84b1fcea3ceb03d0047b6e8a7f92a8f3bcb6babebba4cb8d">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove redundant padding from container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/BackupsPage/index.tsx

<ul><li>Remove <code>p-2</code> class from main container div<br> <li> Rely on parent Routes wrapper padding instead<br> <li> Maintain flex layout and gap spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/248/files#diff-21a1a501016807e7346ac1c2c6e9ccc1583b7f36e4571c5345e4981374da40e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove redundant padding from grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/index.tsx

<ul><li>Remove <code>p-2</code> class from main grid element<br> <li> Depend on outer Routes wrapper padding<br> <li> Preserve grid layout and gap properties</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/248/files#diff-b1141b949b84d673fff5440ac3b0b61f9c6a6d80946d53e934e08eef392b3f00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized layout spacing by wrapping all routes in a padded container. Removed local p-2 padding from BackupsPage and PlayPage to avoid double padding and keep spacing consistent with the NavBar.

<sup>Written for commit 7a89e3946d5d5ce6600f02827f7d5c940e46f3b1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

