### PR TITLE
feat(ui): replace Combobox with virtualized combobox

### DIFF
--- a/cat-launcher/src/components/VariantSelector.tsx
+++ b/cat-launcher/src/components/VariantSelector.tsx
@@ -1,14 +1,15 @@
-import { Combobox } from "@/components/ui/combobox";
+import {
+  VirtualizedCombobox,
+  type ComboboxItem,
+} from "@/components/virtualized-combobox";
 import { GameVariantInfo } from "@/generated-types/GameVariantInfo";
 import { GameVariant } from "@/generated-types/GameVariant";
-import { cn } from "@/lib/utils";
 
 interface VariantSelectorProps {
   gameVariants: GameVariantInfo[];
   selectedVariant: GameVariant | null;
   onVariantChange: (variant: GameVariant) => void;
   isLoading: boolean;
-  className?: string;
   placeholder?: string;
   disabled?: boolean;
 }
@@ -18,16 +19,17 @@ export default function VariantSelector({
   selectedVariant,
   onVariantChange,
   isLoading,
-  className,
   placeholder,
   disabled,
 }: VariantSelectorProps) {
+  const comboboxItems: ComboboxItem[] = gameVariants.map((v) => ({
+    value: v.id,
+    label: v.name,
+  }));
+
   return (
-    <Combobox
-      items={gameVariants.map((v) => ({
-        value: v.id,
-        label: v.name,
-      }))}
+    <VirtualizedCombobox
+      items={comboboxItems}
       value={selectedVariant ?? undefined}
       onChange={(value) => onVariantChange(value as GameVariant)}
       placeholder={
@@ -35,7 +37,7 @@ export default function VariantSelector({
       }
       disabled={disabled || isLoading}
       autoselect={true}
-      className={cn("w-72", className)}
+      className="w-2xs"
     />
   );
 }


### PR DESCRIPTION
### **User description**
Replace the previous Combobox implementation in VariantSelector with a
VirtualizedCombobox to improve performance when rendering large lists of
game variants. Convert the incoming gameVariants into a typed
ComboboxItem[] (value/label) and pass that to the virtualized control.

Remove an unused cn import and the now-unused className prop from the
component props. Simplify styling by replacing the dynamic className
expression with a fixed "w-2xs" width. Preserve existing behavior
(placeholder, disabled, autoselect) and ensure selectedVariant maps to
the combobox value.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace Combobox with VirtualizedCombobox for improved performance

- Convert gameVariants to typed ComboboxItem array structure

- Remove unused className prop and cn utility import

- Simplify styling with fixed "w-2xs" width class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VariantSelector Component"] -->|imports| B["VirtualizedCombobox"]
  A -->|converts| C["gameVariants to ComboboxItem[]"]
  C -->|passes to| B
  D["Remove className prop"] -->|simplify| E["Fixed w-2xs styling"]
  B -->|preserves| F["Existing behavior"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VariantSelector.tsx</strong><dd><code>Replace Combobox with virtualized implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/components/VariantSelector.tsx

<ul><li>Replaced <code>Combobox</code> import with <code>VirtualizedCombobox</code> and <code>ComboboxItem</code> <br>type<br> <li> Removed unused <code>cn</code> utility import and <code>className</code> prop from component <br>interface<br> <li> Extracted gameVariants mapping to typed <code>ComboboxItem[]</code> array in <br>component body<br> <li> Simplified className from dynamic <code>cn("w-72", className)</code> to fixed <br><code>"w-2xs"</code><br> <li> Preserved all existing behavior including placeholder, disabled state, <br>and autoselect</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/249/files#diff-66ebe3a71db5030522b990ca80456663f32d7734622b8cada37e9ffa611713b3">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced VariantSelector’s Combobox with VirtualizedCombobox to improve performance with large variant lists. Converted gameVariants to typed ComboboxItem[] and preserved placeholder, disabled, and autoselect behavior.

- **Refactors**
  - Removed cn import and className prop; use fixed width className="w-2xs".
  - selectedVariant now maps directly to the combobox value.

<sup>Written for commit dca7907ba4b728b3439fa910d27cb1d54cbe09d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

