### PR TITLE
feat(mods): support third-party mod installation flow

### DIFF
--- a/cat-launcher/src-tauri/content/mods.json
+++ b/cat-launcher/src-tauri/content/mods.json
@@ -7,7 +7,7 @@
       "category": "content",
       "installation": {
         "download_url": "https://github.com/Standing-Storm/ccda-xedra-evolved-innawoods/archive/refs/heads/main.zip",
-        "modinfo": "ccda-xedra-evolved-innawoods-master/modinfo.json"
+        "modinfo": "ccda-xedra-evolved-innawoods-main/modinfo.json"
       },
       "activity": {
         "activity_type": "github_commit",
@@ -24,7 +24,7 @@
       "category": "content",
       "installation": {
         "download_url": "https://github.com/Zlorthishen/Really_Dark_Skies/archive/refs/heads/main.zip",
-        "modinfo": "Really_Dark_Skies-master/Really_Dark_Skies/modinfo.json"
+        "modinfo": "Really_Dark_Skies-main/Really_Dark_Skies/modinfo.json"
       },
       "activity": {
         "activity_type": "github_commit",
@@ -41,7 +41,7 @@
       "category": "content",
       "installation": {
         "download_url": "https://github.com/Vegetabs/MindOverMatter-CTLG/archive/refs/heads/main.zip",
-        "modinfo": "MindOverMatter-CTLG/modinfo.json"
+        "modinfo": "MindOverMatter-CTLG-main/modinfo.json"
       },
       "activity": {
         "activity_type": "github_commit",

--- a/cat-launcher/src-tauri/src/mods/commands.rs
+++ b/cat-launcher/src-tauri/src/mods/commands.rs
@@ -5,8 +5,8 @@ use tauri::{Manager, State};
 
 use cat_macros::CommandErrorSerialize;
 
-use crate::active_release::repository::active_release_repository;
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::infra::download::Downloader;
 use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::mods::install_third_party_mod::{install_third_party_mod, InstallThirdPartyModError};
 use crate::mods::list_all_mods::{list_all_mods, ListAllModsError};
@@ -54,17 +54,42 @@ pub async fn list_all_mods_command(
 
 #[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
 pub enum InstallThirdPartyModCommandError {
+    #[error("failed to get app data directory")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to get OS information")]
+    OSInfo(#[from] OSNotSupportedError),
+
     #[error("failed to install mod: {0}")]
     Install(#[from] InstallThirdPartyModError),
 }
 
 #[tauri::command]
 pub async fn install_third_party_mod_command(
-    mod_id: String,
-    game_variant: GameVariant,
+    id: String,
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    downloader: State<'_, Downloader>,
     repository: State<'_, SqliteInstalledModsRepository>,
 ) -> Result<(), InstallThirdPartyModCommandError> {
-    install_third_party_mod(&mod_id, &game_variant, repository.inner()).await?;
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+    let temp_dir = app.path().app_cache_dir()?;
+
+    let os = get_os_enum(OS)?;
+
+    install_third_party_mod(
+        &id,
+        &variant,
+        &data_dir,
+        &resource_dir,
+        &temp_dir,
+        &os,
+        downloader.inner(),
+        repository.inner(),
+    )
+    .await?;
+
     Ok(())
 }
 

--- a/cat-launcher/src-tauri/src/mods/install_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/install_third_party_mod.rs
@@ -1,21 +1,160 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::fs::{create_dir_all, read_to_string};
+
+use crate::filesystem::paths::{
+    get_or_create_directory, get_or_create_user_game_data_dir, GetOrCreateDirectoryError,
+    GetUserGameDataDirError,
+};
+use crate::filesystem::utils::{copy_dir_all, CopyDirError};
+use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::download::{DownloadFileError, Downloader, NoOpReporter};
+use crate::infra::utils::OS;
+use crate::mods::paths::get_mods_resource_path;
 use crate::mods::repository::installed_mods_repository::{
     InstalledModsRepository, InstalledModsRepositoryError,
 };
+use crate::mods::types::ThirdPartyMod;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum InstallThirdPartyModError {
-    #[error("failed to save installed mod to repository: {0}")]
-    Repository(#[from] InstalledModsRepositoryError),
+    #[error("failed to get mod from mods.json: {0}")]
+    GetModFromJson(#[from] GetModFromJsonError),
+
+    #[error("failed to create directory: {0}")]
+    CreateDirectory(#[from] io::Error),
+
+    #[error("failed to download mod: {0}")]
+    Download(#[from] DownloadFileError),
+
+    #[error("failed to extract mod: {0}")]
+    Extract(#[from] ExtractionError),
+
+    #[error("failed to get mod parent dir: {0}")]
+    GetModParentDir(#[from] GetModParentDirError),
+
+    #[error("failed to get user game data dir: {0}")]
+    GetUserGameDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to get user mod data dir: {0}")]
+    GetUserModDataDir(#[from] GetOrCreateDirectoryError),
+
+    #[error("failed to copy mod: {0}")]
+    Copy(#[from] CopyDirError),
+
+    #[error("failed to update repository: {0}")]
+    UpdateRepository(#[from] InstalledModsRepositoryError),
 }
 
 pub async fn install_third_party_mod(
     mod_id: &str,
     game_variant: &GameVariant,
+    data_dir: &Path,
+    resource_dir: &Path,
+    temp_dir: &Path,
+    os: &OS,
+    downloader: &Downloader,
     repository: &impl InstalledModsRepository,
 ) -> Result<(), InstallThirdPartyModError> {
-    repository
-        .add_installed_mod(mod_id, game_variant)
+    // Get mod details from mods.json
+    let mod_details = get_mod_from_json(game_variant, mod_id, resource_dir).await?;
+
+    // Create a temp directory for this mod download
+    let mod_temp_dir = temp_dir.join("cat-launcher-mod-install-dir").join(mod_id);
+    create_dir_all(&mod_temp_dir).await?;
+
+    // Download the mod
+    let reporter = Arc::new(NoOpReporter);
+    let downloaded_file = downloader
+        .download_file(
+            &mod_details.installation.download_url,
+            &mod_temp_dir,
+            reporter,
+        )
         .await?;
+
+    // Extract the mod to the temp directory
+    let extraction_dir = mod_temp_dir.join("extracted");
+    create_dir_all(&extraction_dir).await?;
+    extract_archive(&downloaded_file, &extraction_dir, os).await?;
+
+    // Get the mod parent directory from the modinfo path
+    let mod_parent_dir = get_mod_parent_dir(&extraction_dir, &mod_details.installation.modinfo)?;
+
+    // Get the mods directory in user game data
+    let user_game_data_dir = get_or_create_user_game_data_dir(game_variant, data_dir).await?;
+    let mods_dir = get_or_create_directory(&user_game_data_dir, "mods").await?;
+
+    // Copy the mod parent directory to the mods directory
+    let mod_install_dir = mods_dir.join(mod_id);
+    copy_dir_all(&mod_parent_dir, &mod_install_dir, os).await?;
+
+    // Mark the mod as installed in the repository
+    repository.add_installed_mod(mod_id, game_variant).await?;
+
+    // Clean up temp files, ignore any errors
+    let _ = tokio::fs::remove_dir_all(&mod_temp_dir).await;
+
     Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetModFromJsonError {
+    #[error("failed to read modinfo.json: {0}")]
+    ReadModInfoJson(#[from] std::io::Error),
+
+    #[error("failed to parse modinfo.json: {0}")]
+    ParseModInfoJson(#[from] serde_json::Error),
+
+    #[error("no mods found for variant {0}")]
+    NoModsForVariant(GameVariant),
+
+    #[error("mod with id {0} not found")]
+    ModNotFound(String),
+}
+
+async fn get_mod_from_json(
+    game_variant: &GameVariant,
+    mod_id: &str,
+    resource_dir: &Path,
+) -> Result<ThirdPartyMod, GetModFromJsonError> {
+    let mods_json_path = get_mods_resource_path(resource_dir);
+    let content = read_to_string(&mods_json_path).await?;
+
+    let mods_data: HashMap<GameVariant, HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&content)?;
+
+    let variant_mods = mods_data
+        .get(game_variant)
+        .ok_or(GetModFromJsonError::NoModsForVariant(*game_variant))?;
+
+    let mod_data = variant_mods
+        .get(mod_id)
+        .ok_or(GetModFromJsonError::ModNotFound(mod_id.to_string()))?;
+
+    let third_party_mod = serde_json::from_value::<ThirdPartyMod>(mod_data.clone())?;
+
+    Ok(third_party_mod)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetModParentDirError {
+    #[error("failed to get parent directory for modinfo path")]
+    ParentDirNotFound,
+}
+
+fn get_mod_parent_dir(
+    extracted_dir: &Path,
+    modinfo_relative_path: &str,
+) -> Result<PathBuf, GetModParentDirError> {
+    let modinfo_path = extracted_dir.join(modinfo_relative_path);
+
+    modinfo_path
+        .parent()
+        .ok_or(GetModParentDirError::ParentDirNotFound)
+        .map(|p| p.to_path_buf())
 }

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -239,3 +239,13 @@ export async function listAllMods(variant: GameVariant): Promise<Mod[]> {
   });
   return response;
 }
+
+export async function installThirdPartyMod(
+  modId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("install_third_party_mod_command", {
+    id: modId,
+    variant,
+  });
+}

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -9,9 +9,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Mod } from "@/generated-types/Mod";
-import { getHumanFriendlyText } from "@/lib/utils";
+import { getHumanFriendlyText, toastCL } from "@/lib/utils";
+import { useInstallThirdPartyMod } from "./hooks";
+import { GameVariant } from "@/generated-types/GameVariant";
 
 interface ModCardProps {
+  variant: GameVariant;
   mod: Mod;
 }
 
@@ -31,13 +34,19 @@ function getModCategory(mod: Mod): string {
   return getHumanFriendlyText(mod.content.category);
 }
 
-export default function ModCard({ mod }: ModCardProps) {
+export default function ModCard({ variant, mod }: ModCardProps) {
   const name = getModName(mod);
   const description = getModDescription(mod);
   const modType = getModType(mod);
   const category = getModCategory(mod);
 
   const isThirdParty = mod.type !== "Stock";
+
+  const { isInstalling, install } = useInstallThirdPartyMod(
+    variant,
+    () => toastCL("success", "Mod installed successfully."),
+    (error) => toastCL("error", "Failed to install mod.", error),
+  );
 
   return (
     <Card className="flex flex-col">
@@ -54,16 +63,22 @@ export default function ModCard({ mod }: ModCardProps) {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-4 flex-grow">
+      <CardContent className="flex flex-col gap-4 grow">
         <Alert className="flex flex-col bg-secondary text-secondary-foreground h-full">
-          <AlertDescription className="h-20 overflow-y-auto flex-grow items-center text-secondary-foreground">
+          <AlertDescription className="h-20 overflow-y-auto grow items-center text-secondary-foreground">
             {description}
           </AlertDescription>
         </Alert>
       </CardContent>
       {isThirdParty && (
         <CardFooter className="flex flex-col gap-4 items-stretch">
-          <Button className="w-full">Install</Button>
+          <Button
+            className="w-full"
+            onClick={() => install(mod.content.id)}
+            disabled={isInstalling}
+          >
+            {isInstalling ? "Installing..." : "Install"}
+          </Button>
         </CardFooter>
       )}
     </Card>

--- a/cat-launcher/src/pages/ModsPage/ModsList.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModsList.tsx
@@ -40,6 +40,7 @@ export default function ModsList({ variant }: ModsListProps) {
       {mods.map((mod) => (
         <ModCard
           key={`${variant}-${mod.content.id}`}
+          variant={variant}
           mod={mod}
         />
       ))}

--- a/cat-launcher/src/pages/ModsPage/hooks.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { installThirdPartyMod } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useInstallThirdPartyMod(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (modId: string) => installThirdPartyMod(modId, variant),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mods.listAll(variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isInstalling: mutation.isPending,
+    install: (modId: string) => mutation.mutate(modId),
+  };
+}


### PR DESCRIPTION
### **User description**
Update mods metadata and implement command + installer plumbing
to enable installing third-party mods from GitHub archives and local
resources. Change modinfo paths in mods.json to match '...-main/...' zip
structure so installers locate modinfo correctly.

Add a new Tauri command 'install_third_party_mod_command' that:
- renames parameters to id/variant for clarity
- accepts AppHandle and Downloader state
- resolves app directories (app data, resource, cache)
- detects OS and forwards info to the installer
- surfaces explicit errors for app dir and OS failures

Add frontend binding installThirdPartyMod to invoke the new Tauri
command.

Implement install_third_party_mod module with:
- downloading archives via Downloader
- extracting archives
- copying/extracting resources into user game data dirs
- error types for download, extraction, filesystem and manifest resolution

Refactor imports and repository usages to integrate the new flow and
provide clearer error propagation for installing third-party content.


___

### **PR Type**
Enhancement


___

### **Description**
- Implement complete third-party mod installation flow with download, extraction, and file copying

- Add Tauri command `install_third_party_mod_command` accepting app handle and downloader state

- Create frontend hook `useInstallThirdPartyMod` with React Query mutation for mod installation

- Update mods.json paths from `-master/` to `-main/` to match GitHub archive structure

- Add install button to ModCard with loading state and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frontend: Install Button"] -->|invoke| B["Tauri Command"]
  B -->|resolve paths| C["App Directories"]
  B -->|download| D["Downloader"]
  D -->|extract| E["Archive Extraction"]
  E -->|copy| F["User Game Data Dir"]
  F -->|update| G["Installed Mods Repository"]
  B -->|return| H["Frontend: Success/Error Toast"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Add Tauri command with app path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/mods/commands.rs

<ul><li>Refactored <code>install_third_party_mod_command</code> to accept <code>id</code> and <code>variant</code> <br>parameters with clearer naming<br> <li> Added <code>AppHandle</code> and <code>Downloader</code> state parameters to resolve app <br>directories and download mods<br> <li> Implemented error handling for app directory resolution and OS <br>detection via <code>InstallThirdPartyModCommandError</code><br> <li> Updated function to pass resolved paths and OS information to the <br>installer module</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-891589ba1757a05e0a9d08c9f8ca50ddba5f0b0cc33c33eaf54fc8096b171978">+29/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install_third_party_mod.rs</strong><dd><code>Implement mod download, extraction, and installation logic</code></dd></summary>
<hr>

cat-launcher/src-tauri/src/mods/install_third_party_mod.rs

<ul><li>Implemented complete installation workflow: download, extract, copy, <br>and repository update<br> <li> Added <code>get_mod_from_json</code> function to parse mods.json and retrieve mod <br>metadata<br> <li> Added <code>get_mod_parent_dir</code> helper to locate mod directory from modinfo <br>path in extracted archive<br> <li> Introduced comprehensive error types for download, extraction, <br>filesystem, and manifest resolution failures<br> <li> Integrated with <code>Downloader</code>, archive extraction, and directory <br>utilities for full installation pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-230c18d872137277ad958548218a0525fca8b05383197c3868f955c01f6fd521">+143/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commands.ts</strong><dd><code>Add frontend binding for mod installation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/lib/commands.ts

<ul><li>Added <code>installThirdPartyMod</code> frontend binding to invoke the Tauri <br>command<br> <li> Function accepts <code>modId</code> and <code>variant</code> parameters and invokes <br><code>install_third_party_mod_command</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Create React Query hook for mod installation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/hooks.ts

<ul><li>Created <code>useInstallThirdPartyMod</code> custom hook using React Query mutation<br> <li> Implements optimistic UI updates by invalidating mod list query on <br>success<br> <li> Provides <code>isInstalling</code> state and <code>install</code> function for component <br>integration<br> <li> Supports optional <code>onSuccess</code> and <code>onError</code> callbacks for custom handling</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-b74a1a3a9b230def6db81382e304133ca66b7a1b75e136ee9e40b4714ee9a3f6">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModCard.tsx</strong><dd><code>Add install button with loading state and toasts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/ModCard.tsx

<ul><li>Added <code>variant</code> prop to ModCard component for passing game variant <br>context<br> <li> Integrated <code>useInstallThirdPartyMod</code> hook to handle installation state <br>and logic<br> <li> Updated Install button with click handler, disabled state during <br>installation, and dynamic text<br> <li> Added success and error toast notifications via <code>toastCL</code> utility<br> <li> Fixed CSS class from <code>flex-grow</code> to <code>grow</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-f8d8e5c7bec36fe4784af5ed278799d4176bef37dcd22d606315cb937652cc86">+20/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModsList.tsx</strong><dd><code>Pass variant prop to ModCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/ModsList.tsx

<ul><li>Passed <code>variant</code> prop to ModCard component to enable variant-aware <br>installation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-eeaddda99ed7f83376c48918b821c922a74200573114d3f045f1d4eebb820508">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mods.json</strong><dd><code>Update modinfo paths to main branch structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/content/mods.json

<ul><li>Updated modinfo paths from <code>-master/</code> to <code>-main/</code> branch naming convention<br> <li> Changed three mod entries: <code>xedra_evolved_innawoods</code>, <code>realdarkskies</code>, and <br><code>mindovermatter</code><br> <li> Ensures paths match GitHub archive structure when downloading from <br>main branch</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/251/files#diff-a00e7302e49b649209c2edec325ce483f4ff97dba2bd8f3d1cb28d94d3f16dae">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables installing third-party mods from GitHub zip archives end-to-end, with extraction, copy to the user mods folder, and install tracking. Adds a new Tauri command and UI hook/button, and fixes mods.json paths to match -main archives.

- **New Features**
  - New Tauri command install_third_party_mod_command (id, variant) that resolves app dirs, detects OS, uses Downloader, and returns clear errors.
  - Installer reads mods.json, downloads and extracts the archive, copies the mod into the user game data mods dir, updates the repository, and cleans up temp files.
  - Frontend adds installThirdPartyMod binding, a useInstallThirdPartyMod hook (invalidates list), and an Install button with loading state and toasts.

- **Bug Fixes**
  - Updated mods.json modinfo paths from ...-master/... to ...-main/... to match GitHub archive structure.

<sup>Written for commit eb538edd6bae730574f760f06fc7854cc6938778. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #253 
- <kbd>&nbsp;3&nbsp;</kbd> #252 
- <kbd>&nbsp;2&nbsp;</kbd> #251 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #250 
<!-- GitButler Footer Boundary Bottom -->

