### PR TITLE
feat(mods): add installation status

### DIFF
--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -32,7 +32,8 @@ use crate::manual_backups::commands::{
     restore_manual_backup_by_id,
 };
 use crate::mods::commands::{
-    install_third_party_mod_command, list_all_mods_command, uninstall_third_party_mod_command,
+    get_third_party_mod_installation_status_command, install_third_party_mod_command,
+    list_all_mods_command, uninstall_third_party_mod_command,
 };
 use crate::play_time::commands::{get_play_time_for_variant, get_play_time_for_version};
 use crate::theme::commands::{get_preferred_theme, set_preferred_theme};
@@ -83,6 +84,7 @@ pub fn run() {
             list_all_mods_command,
             install_third_party_mod_command,
             uninstall_third_party_mod_command,
+            get_third_party_mod_installation_status_command,
             get_user_id,
             get_preferred_theme,
             set_preferred_theme,

--- a/cat-launcher/src-tauri/src/mods/get_third_party_mod_installation_status.rs
+++ b/cat-launcher/src-tauri/src/mods/get_third_party_mod_installation_status.rs
@@ -1,0 +1,25 @@
+use crate::mods::repository::installed_mods_repository::{
+    InstalledModsRepository, InstalledModsRepositoryError,
+};
+use crate::mods::types::ModInstallationStatus;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetThirdPartyModInstallationStatusError {
+    #[error("failed to check mod installation status: {0}")]
+    Repository(#[from] InstalledModsRepositoryError),
+}
+
+pub async fn get_third_party_mod_installation_status(
+    mod_id: &str,
+    variant: &GameVariant,
+    repository: &dyn InstalledModsRepository,
+) -> Result<ModInstallationStatus, GetThirdPartyModInstallationStatusError> {
+    let is_installed = repository.is_mod_installed(mod_id, variant).await?;
+
+    Ok(if is_installed {
+        ModInstallationStatus::Installed
+    } else {
+        ModInstallationStatus::NotInstalled
+    })
+}

--- a/cat-launcher/src-tauri/src/mods/mod.rs
+++ b/cat-launcher/src-tauri/src/mods/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod get_third_party_mod_installation_status;
 pub mod install_third_party_mod;
 pub mod list_all_mods;
 pub mod paths;

--- a/cat-launcher/src-tauri/src/mods/repository/installed_mods_repository.rs
+++ b/cat-launcher/src-tauri/src/mods/repository/installed_mods_repository.rs
@@ -29,4 +29,10 @@ pub trait InstalledModsRepository: Send + Sync {
         mod_id: &str,
         game_variant: &GameVariant,
     ) -> Result<(), InstalledModsRepositoryError>;
+
+    async fn is_mod_installed(
+        &self,
+        mod_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<bool, InstalledModsRepositoryError>;
 }

--- a/cat-launcher/src-tauri/src/mods/types.rs
+++ b/cat-launcher/src-tauri/src/mods/types.rs
@@ -38,3 +38,10 @@ pub enum Mod {
     Stock(StockMod),
     ThirdParty(ThirdPartyMod),
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum ModInstallationStatus {
+    Installed,
+    NotInstalled,
+}

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -12,6 +12,7 @@ import type { InstallationProgressPayload } from "@/generated-types/Installation
 import type { InstallationProgressStatus } from "@/generated-types/InstallationProgressStatus";
 import type { ManualBackupEntry } from "@/generated-types/ManualBackupEntry";
 import type { Mod } from "@/generated-types/Mod";
+import type { ModInstallationStatus } from "@/generated-types/ModInstallationStatus";
 import type { ReleasesUpdatePayload } from "@/generated-types/ReleasesUpdatePayload";
 import type { Theme } from "@/generated-types/Theme";
 import type { ThemePreference } from "@/generated-types/ThemePreference";
@@ -247,5 +248,29 @@ export async function installThirdPartyMod(
   await invoke("install_third_party_mod_command", {
     id: modId,
     variant,
+  });
+}
+
+export async function getThirdPartyModInstallationStatus(
+  modId: string,
+  variant: GameVariant,
+): Promise<ModInstallationStatus> {
+  const response = await invoke<ModInstallationStatus>(
+    "get_third_party_mod_installation_status_command",
+    {
+      id: modId,
+      variant,
+    },
+  );
+  return response;
+}
+
+export async function uninstallThirdPartyMod(
+  modId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("uninstall_third_party_mod_command", {
+    mod_id: modId,
+    game_variant: variant,
   });
 }

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -28,5 +28,7 @@ export const queryKeys = {
 
   mods: {
     listAll: (variant: GameVariant) => ["mods", variant] as const,
+    installationStatus: (modId: string, variant: GameVariant) =>
+      ["mods", "installation_status", modId, variant] as const,
   },
 };

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -8,10 +8,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { GameVariant } from "@/generated-types/GameVariant";
 import type { Mod } from "@/generated-types/Mod";
 import { getHumanFriendlyText, toastCL } from "@/lib/utils";
-import { useInstallThirdPartyMod } from "./hooks";
-import { GameVariant } from "@/generated-types/GameVariant";
+import {
+  useGetThirdPartyModInstallationStatus,
+  useInstallThirdPartyMod,
+  useUninstallThirdPartyMod,
+} from "./hooks";
 
 interface ModCardProps {
   variant: GameVariant;
@@ -41,11 +45,25 @@ export default function ModCard({ variant, mod }: ModCardProps) {
   const category = getModCategory(mod);
 
   const isThirdParty = mod.type !== "Stock";
+  const modId = mod.content.id;
+
+  const { installationStatus } = useGetThirdPartyModInstallationStatus(
+    modId,
+    variant,
+  );
+
+  const isInstalled = installationStatus === "Installed";
 
   const { isInstalling, install } = useInstallThirdPartyMod(
     variant,
     () => toastCL("success", "Mod installed successfully."),
     (error) => toastCL("error", "Failed to install mod.", error),
+  );
+
+  const { isUninstalling, uninstall } = useUninstallThirdPartyMod(
+    variant,
+    () => toastCL("success", "Mod uninstalled successfully."),
+    (error) => toastCL("error", "Failed to uninstall mod.", error),
   );
 
   return (
@@ -72,13 +90,24 @@ export default function ModCard({ variant, mod }: ModCardProps) {
       </CardContent>
       {isThirdParty && (
         <CardFooter className="flex flex-col gap-4 items-stretch">
-          <Button
-            className="w-full"
-            onClick={() => install(mod.content.id)}
-            disabled={isInstalling}
-          >
-            {isInstalling ? "Installing..." : "Install"}
-          </Button>
+          {isInstalled ? (
+            <Button
+              className="w-full"
+              variant="destructive"
+              onClick={() => uninstall(modId)}
+              disabled={isUninstalling}
+            >
+              {isUninstalling ? "Uninstalling..." : "Uninstall"}
+            </Button>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={() => install(modId)}
+              disabled={isInstalling}
+            >
+              {isInstalling ? "Installing..." : "Install"}
+            </Button>
+          )}
         </CardFooter>
       )}
     </Card>

--- a/cat-launcher/src/pages/ModsPage/hooks.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks.ts
@@ -1,7 +1,11 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
-import { installThirdPartyMod } from "@/lib/commands";
+import {
+  getThirdPartyModInstallationStatus,
+  installThirdPartyMod,
+  uninstallThirdPartyMod,
+} from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function useInstallThirdPartyMod(
@@ -13,9 +17,12 @@ export function useInstallThirdPartyMod(
 
   const mutation = useMutation({
     mutationFn: (modId: string) => installThirdPartyMod(modId, variant),
-    onSuccess: () => {
+    onSuccess: (_data, modId) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mods.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mods.installationStatus(modId, variant),
       });
       onSuccess?.();
     },
@@ -25,5 +32,47 @@ export function useInstallThirdPartyMod(
   return {
     isInstalling: mutation.isPending,
     install: (modId: string) => mutation.mutate(modId),
+  };
+}
+
+export function useGetThirdPartyModInstallationStatus(
+  modId: string,
+  variant: GameVariant,
+) {
+  const query = useQuery({
+    queryKey: queryKeys.mods.installationStatus(modId, variant),
+    queryFn: () => getThirdPartyModInstallationStatus(modId, variant),
+  });
+
+  return {
+    installationStatus: query.data,
+    isLoading: query.isLoading,
+  };
+}
+
+export function useUninstallThirdPartyMod(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (modId: string) => uninstallThirdPartyMod(modId, variant),
+    onSuccess: (_data, modId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mods.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mods.installationStatus(modId, variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isUninstalling: mutation.isPending,
+    uninstall: (modId: string) => mutation.mutate(modId),
   };
 }


### PR DESCRIPTION
### **User description**
Introduce a command and UI hooks to check and manage third-party
mod installation status.

- Add backend function get_third_party_mod_installation_status that
  queries the InstalledModsRepository and returns Installed or
  NotInstalled. Add corresponding error mapping.
- Expose new Tauri command get_third_party_mod_installation_status_command
  in the Rust lib to allow frontend invocation.
- Extend frontend commands with getThirdPartyModInstallationStatus and
  adjust uninstallThirdPartyMod to pass expected param names.
- Add React hooks:
  - useGetThirdPartyModInstallationStatus to fetch and cache installation
    status via react-query.
  - useUninstallThirdPartyMod to uninstall a mod and invalidate related
    queries.
- Update install hook to invalidate the installation status query after
  successful install, ensuring UI stays in sync.

These changes enable the app to show accurate mod installation state and
allow uninstall operations to update the UI reliably.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #253 
- <kbd>&nbsp;3&nbsp;</kbd> #252 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #251 
- <kbd>&nbsp;1&nbsp;</kbd> #250 
<!-- GitButler Footer Boundary Bottom -->

___

### **PR Type**
Enhancement


___

### **Description**
- Add backend function to query mod installation status from repository

- Expose new Tauri command for frontend to check installation status

- Create React hooks for fetching and managing mod installation state

- Update ModCard UI to show install/uninstall button based on status

- Invalidate installation status queries after install/uninstall operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Repository"] -->|is_mod_installed| B["get_third_party_mod_installation_status"]
  B -->|ModInstallationStatus| C["Tauri Command"]
  C -->|invoke| D["Frontend Command"]
  D -->|useQuery| E["useGetThirdPartyModInstallationStatus Hook"]
  E -->|status| F["ModCard Component"]
  F -->|install/uninstall| G["useInstallThirdPartyMod/useUninstallThirdPartyMod"]
  G -->|invalidate| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Register new installation status command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Export new installation status module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-26781f3bf369c4ee6e555abe0c898b13a261f21ab1f9df11877ae0beb1d4a8c8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>commands.rs</strong><dd><code>Add Tauri command for installation status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-891589ba1757a05e0a9d08c9f8ca50ddba5f0b0cc33c33eaf54fc8096b171978">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_third_party_mod_installation_status.rs</strong><dd><code>New backend function to check mod status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-a59ee9dd43f109b6cdfad50652f30c828ae7a823511dbf217dc99b7ba818c836">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installed_mods_repository.rs</strong><dd><code>Add is_mod_installed trait method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-e88cdf7b7c08be67fb7a05eb38750e0fcafeece43c941647e6c6b3b173d23926">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_installed_mods_repository.rs</strong><dd><code>Implement is_mod_installed database query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-0bb7f7cd68393e538fab9d217491345fc79c39ec5f2fb7d615e9fc78bda14b56">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Define ModInstallationStatus enum type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-eb39b1de5c0cb6901a21699f23eadb80704c32b0752f57f23879c786973d76e4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Add frontend commands for installation status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add query key for installation status caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hooks.ts</strong><dd><code>Create hooks for mod installation management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-b74a1a3a9b230def6db81382e304133ca66b7a1b75e136ee9e40b4714ee9a3f6">+52/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ModCard.tsx</strong><dd><code>Display install/uninstall button based on status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/252/files#diff-f8d8e5c7bec36fe4784af5ed278799d4176bef37dcd22d606315cb937652cc86">+38/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mod installation status API and UI so the Mods page can show Install or Uninstall accurately. Status updates immediately after install/uninstall to keep the UI in sync.

- **New Features**
  - Backend: Added ModInstallationStatus enum, repository is_mod_installed, status service, and Tauri command get_third_party_mod_installation_status_command.
  - Frontend: Added getThirdPartyModInstallationStatus, new query key for status, and fixed uninstall command param names.
  - Hooks: Added useGetThirdPartyModInstallationStatus and useUninstallThirdPartyMod; install and uninstall hooks invalidate list and status queries.
  - UI: ModCard toggles Install/Uninstall buttons and shows installing/uninstalling states based on real status.

<sup>Written for commit 9e405dc801936b5eb90b1fdad4fb98f16f254cc0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





