### PR TITLE
feat(tilesets): add tilesets repositories, paths, hooks, route and schema

### DIFF
--- a/cat-launcher/src-tauri/content/tilesets.json
+++ b/cat-launcher/src-tauri/content/tilesets.json
@@ -1,0 +1,46 @@
+{
+  "DarkDaysAhead": {
+    "UNDEAD_PEOPLE_BASE_v2": {
+      "id": "UNDEAD_PEOPLE_BASE_v2",
+      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
+      "installation": {
+        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
+        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
+      }
+    }
+  },
+
+  "BrightNights": {
+    "UNDEAD_PEOPLE_BASE_v2": {
+      "id": "UNDEAD_PEOPLE_BASE_v2",
+      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
+      "installation": {
+        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
+        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
+      }
+    }
+  },
+
+  "TheLastGeneration": {
+    "UNDEAD_PEOPLE_BASE_v2": {
+      "id": "UNDEAD_PEOPLE_BASE_v2",
+      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
+      "installation": {
+        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
+        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
+      }
+    }
+  }
+}

--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -117,3 +117,13 @@ CREATE TABLE IF NOT EXISTS installed_mods (
 );
 
 CREATE INDEX IF NOT EXISTS idx_installed_mods_game_variant ON installed_mods (game_variant);
+
+-- This table stores installed tilesets for each game variant.
+CREATE TABLE IF NOT EXISTS installed_tilesets (
+    tileset_id TEXT NOT NULL,
+    game_variant TEXT NOT NULL,
+    PRIMARY KEY (tileset_id, game_variant),
+    FOREIGN KEY (game_variant) REFERENCES variants (name) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_installed_tilesets_game_variant ON installed_mods (game_variant);

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod manual_backups;
 mod mods;
 mod play_time;
 mod theme;
+mod tilesets;
 mod users;
 mod utils;
 mod variants;
@@ -37,6 +38,10 @@ use crate::mods::commands::{
 };
 use crate::play_time::commands::{get_play_time_for_variant, get_play_time_for_version};
 use crate::theme::commands::{get_preferred_theme, set_preferred_theme};
+use crate::tilesets::commands::{
+    get_third_party_tileset_installation_status_command, install_third_party_tileset_command,
+    list_all_tilesets_command, uninstall_third_party_tileset_command,
+};
 use crate::users::commands::get_user_id;
 use crate::utils::{
     autoupdate, manage_downloader, manage_http_client, manage_posthog, manage_repositories,
@@ -85,6 +90,10 @@ pub fn run() {
             install_third_party_mod_command,
             uninstall_third_party_mod_command,
             get_third_party_mod_installation_status_command,
+            list_all_tilesets_command,
+            install_third_party_tileset_command,
+            uninstall_third_party_tileset_command,
+            get_third_party_tileset_installation_status_command,
             get_user_id,
             get_preferred_theme,
             set_preferred_theme,

--- a/cat-launcher/src-tauri/src/tilesets/commands.rs
+++ b/cat-launcher/src-tauri/src/tilesets/commands.rs
@@ -1,0 +1,138 @@
+use std::env::consts::OS;
+
+use strum::IntoStaticStr;
+use tauri::{Manager, State};
+
+use cat_macros::CommandErrorSerialize;
+
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::infra::download::Downloader;
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::tilesets::get_third_party_tileset_installation_status::{
+    get_third_party_tileset_installation_status, GetThirdPartyTilesetInstallationStatusError,
+};
+use crate::tilesets::install_third_party_tileset::{
+    install_third_party_tileset, InstallThirdPartyTilesetError,
+};
+use crate::tilesets::list_all_tilesets::{list_all_tilesets, ListAllTilesetsError};
+use crate::tilesets::repository::sqlite_installed_tilesets_repository::SqliteInstalledTilesetsRepository;
+use crate::tilesets::types::{Tileset, TilesetInstallationStatus};
+use crate::tilesets::uninstall_third_party_tileset::{
+    uninstall_third_party_tileset, UninstallThirdPartyTilesetError,
+};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum ListAllTilesetsCommandError {
+    #[error("failed to get app data directory")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to get OS information")]
+    OSInfo(#[from] OSNotSupportedError),
+
+    #[error("failed to list tilesets: {0}")]
+    ListTilesets(#[from] ListAllTilesetsError),
+}
+
+#[tauri::command]
+pub async fn list_all_tilesets_command(
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    active_release_repository: State<'_, SqliteActiveReleaseRepository>,
+) -> Result<Vec<Tileset>, ListAllTilesetsCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+
+    let os = get_os_enum(OS)?;
+
+    let tilesets = list_all_tilesets(
+        &variant,
+        &data_dir,
+        &resource_dir,
+        &os,
+        active_release_repository.inner(),
+    )
+    .await?;
+
+    Ok(tilesets)
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum InstallThirdPartyTilesetCommandError {
+    #[error("failed to get app data directory")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to get OS information")]
+    OSInfo(#[from] OSNotSupportedError),
+
+    #[error("failed to install tileset: {0}")]
+    Install(#[from] InstallThirdPartyTilesetError),
+}
+
+#[tauri::command]
+pub async fn install_third_party_tileset_command(
+    id: String,
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    downloader: State<'_, Downloader>,
+    repository: State<'_, SqliteInstalledTilesetsRepository>,
+) -> Result<(), InstallThirdPartyTilesetCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+    let temp_dir = app.path().app_cache_dir()?;
+
+    let os = get_os_enum(OS)?;
+
+    install_third_party_tileset(
+        &id,
+        &variant,
+        &data_dir,
+        &resource_dir,
+        &temp_dir,
+        &os,
+        downloader.inner(),
+        repository.inner(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum UninstallThirdPartyTilesetCommandError {
+    #[error("failed to get app data directory: {0}")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to uninstall tileset: {0}")]
+    Uninstall(#[from] UninstallThirdPartyTilesetError),
+}
+
+#[tauri::command]
+pub async fn uninstall_third_party_tileset_command(
+    id: String,
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    repository: State<'_, SqliteInstalledTilesetsRepository>,
+) -> Result<(), UninstallThirdPartyTilesetCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+
+    uninstall_third_party_tileset(&id, &variant, &data_dir, repository.inner()).await?;
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum GetThirdPartyTilesetInstallationStatusCommandError {
+    #[error("failed to get tileset installation status: {0}")]
+    GetStatus(#[from] GetThirdPartyTilesetInstallationStatusError),
+}
+
+#[tauri::command]
+pub async fn get_third_party_tileset_installation_status_command(
+    id: String,
+    variant: GameVariant,
+    repository: State<'_, SqliteInstalledTilesetsRepository>,
+) -> Result<TilesetInstallationStatus, GetThirdPartyTilesetInstallationStatusCommandError> {
+    let status =
+        get_third_party_tileset_installation_status(&id, &variant, repository.inner()).await?;
+    Ok(status)
+}

--- a/cat-launcher/src-tauri/src/tilesets/get_third_party_tileset_installation_status.rs
+++ b/cat-launcher/src-tauri/src/tilesets/get_third_party_tileset_installation_status.rs
@@ -1,0 +1,25 @@
+use crate::tilesets::repository::installed_tilesets_repository::{
+    InstalledTilesetsRepository, InstalledTilesetsRepositoryError,
+};
+use crate::tilesets::types::TilesetInstallationStatus;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetThirdPartyTilesetInstallationStatusError {
+    #[error("failed to check tileset installation status: {0}")]
+    Repository(#[from] InstalledTilesetsRepositoryError),
+}
+
+pub async fn get_third_party_tileset_installation_status(
+    tileset_id: &str,
+    variant: &GameVariant,
+    repository: &dyn InstalledTilesetsRepository,
+) -> Result<TilesetInstallationStatus, GetThirdPartyTilesetInstallationStatusError> {
+    let is_installed = repository.is_tileset_installed(tileset_id, variant).await?;
+
+    Ok(if is_installed {
+        TilesetInstallationStatus::Installed
+    } else {
+        TilesetInstallationStatus::NotInstalled
+    })
+}

--- a/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::fs::{create_dir_all, read_to_string};
+
+use crate::filesystem::paths::{
+    get_or_create_directory, get_or_create_user_game_data_dir, GetOrCreateDirectoryError,
+    GetUserGameDataDirError,
+};
+use crate::filesystem::utils::{copy_dir_all, CopyDirError};
+use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::download::{DownloadFileError, Downloader, NoOpReporter};
+use crate::infra::utils::OS;
+use crate::tilesets::paths::get_tilesets_resource_path;
+use crate::tilesets::repository::installed_tilesets_repository::{
+    InstalledTilesetsRepository, InstalledTilesetsRepositoryError,
+};
+use crate::tilesets::types::ThirdPartyTileset;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InstallThirdPartyTilesetError {
+    #[error("failed to get tileset from tilesets.json: {0}")]
+    GetTilesetFromJson(#[from] GetTilesetFromJsonError),
+
+    #[error("failed to create directory: {0}")]
+    CreateDirectory(#[from] io::Error),
+
+    #[error("failed to download tileset: {0}")]
+    Download(#[from] DownloadFileError),
+
+    #[error("failed to extract tileset: {0}")]
+    Extract(#[from] ExtractionError),
+
+    #[error("failed to get tileset parent dir: {0}")]
+    GetTilesetParentDir(#[from] GetTilesetParentDirError),
+
+    #[error("failed to get user game data dir: {0}")]
+    GetUserGameDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to get user tileset data dir: {0}")]
+    GetUserTilesetDataDir(#[from] GetOrCreateDirectoryError),
+
+    #[error("failed to copy tileset: {0}")]
+    Copy(#[from] CopyDirError),
+
+    #[error("failed to update repository: {0}")]
+    UpdateRepository(#[from] InstalledTilesetsRepositoryError),
+}
+
+pub async fn install_third_party_tileset(
+    tileset_id: &str,
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    resource_dir: &Path,
+    temp_dir: &Path,
+    os: &OS,
+    downloader: &Downloader,
+    repository: &impl InstalledTilesetsRepository,
+) -> Result<(), InstallThirdPartyTilesetError> {
+    // Get tileset details from tilesets.json
+    let tileset_details = get_tileset_from_json(game_variant, tileset_id, resource_dir).await?;
+
+    // Create a temp directory for this tileset download
+    let tileset_temp_dir = temp_dir.join("cat-launcher-tileset-install-dir").join(tileset_id);
+    create_dir_all(&tileset_temp_dir).await?;
+
+    // Download the tileset
+    let reporter = Arc::new(NoOpReporter);
+    let downloaded_file = downloader
+        .download_file(
+            &tileset_details.installation.download_url,
+            &tileset_temp_dir,
+            reporter,
+        )
+        .await?;
+
+    // Extract the tileset to the temp directory
+    let extraction_dir = tileset_temp_dir.join("extracted");
+    create_dir_all(&extraction_dir).await?;
+    extract_archive(&downloaded_file, &extraction_dir, os).await?;
+
+    // Get the tileset parent directory from the tileset path
+    let tileset_parent_dir = get_tileset_parent_dir(&extraction_dir, &tileset_details.installation.tileset)?;
+
+    // Get the gfx directory in user game data
+    let user_game_data_dir = get_or_create_user_game_data_dir(game_variant, data_dir).await?;
+    let gfx_dir = get_or_create_directory(&user_game_data_dir, "gfx").await?;
+
+    // Copy the tileset parent directory to the gfx directory
+    let tileset_install_dir = gfx_dir.join(tileset_id);
+    copy_dir_all(&tileset_parent_dir, &tileset_install_dir, os).await?;
+
+    // Mark the tileset as installed in the repository
+    repository.add_installed_tileset(tileset_id, game_variant).await?;
+
+    // Clean up temp files, ignore any errors
+    let _ = tokio::fs::remove_dir_all(&tileset_temp_dir).await;
+
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetTilesetFromJsonError {
+    #[error("failed to read tilesets.json: {0}")]
+    ReadTilesetsJson(#[from] std::io::Error),
+
+    #[error("failed to parse tilesets.json: {0}")]
+    ParseTilesetsJson(#[from] serde_json::Error),
+
+    #[error("no tilesets found for variant {0}")]
+    NoTilesetsForVariant(GameVariant),
+
+    #[error("tileset with id {0} not found")]
+    TilesetNotFound(String),
+}
+
+async fn get_tileset_from_json(
+    game_variant: &GameVariant,
+    tileset_id: &str,
+    resource_dir: &Path,
+) -> Result<ThirdPartyTileset, GetTilesetFromJsonError> {
+    let tilesets_json_path = get_tilesets_resource_path(resource_dir);
+    let content = read_to_string(&tilesets_json_path).await?;
+
+    let tilesets_data: HashMap<GameVariant, HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&content)?;
+
+    let variant_tilesets = tilesets_data
+        .get(game_variant)
+        .ok_or(GetTilesetFromJsonError::NoTilesetsForVariant(*game_variant))?;
+
+    let tileset_data = variant_tilesets
+        .get(tileset_id)
+        .ok_or(GetTilesetFromJsonError::TilesetNotFound(tileset_id.to_string()))?;
+
+    let third_party_tileset = serde_json::from_value::<ThirdPartyTileset>(tileset_data.clone())?;
+
+    Ok(third_party_tileset)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetTilesetParentDirError {
+    #[error("failed to get parent directory for tileset path")]
+    ParentDirNotFound,
+}
+
+fn get_tileset_parent_dir(
+    extracted_dir: &Path,
+    tileset_relative_path: &str,
+) -> Result<PathBuf, GetTilesetParentDirError> {
+    let tileset_path = extracted_dir.join(tileset_relative_path);
+
+    tileset_path
+        .parent()
+        .ok_or(GetTilesetParentDirError::ParentDirNotFound)
+        .map(|p| p.to_path_buf())
+}

--- a/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
+++ b/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+
+use tokio::fs::{read_dir, read_to_string};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::fs::File;
+
+
+use crate::active_release::repository::{ActiveReleaseRepository, ActiveReleaseRepositoryError};
+use crate::infra::utils::OS;
+use crate::tilesets::paths::{get_stock_tilesets_dir, get_tilesets_resource_path, GetStockTilesetsDirError};
+use crate::tilesets::types::{Tileset, StockTileset, ThirdPartyTileset};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListAllTilesetsError {
+    #[error("failed to get stock tilesets dir: {0}")]
+    GetStockTilesetsDir(#[from] GetStockTilesetsDirError),
+
+    #[error("failed to read stock tileset dir: {0}")]
+    ExtractStockTileset(#[from] ListAllStockTilesetsError),
+
+    #[error("failed to get active release: {0}")]
+    GetActiveRelease(#[from] ActiveReleaseRepositoryError),
+
+    #[error("failed to list third-party tilesets: {0}")]
+    ListThirdPartyTilesets(#[from] ListThirdPartyTilesetsError),
+}
+
+pub async fn list_all_tilesets(
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    resource_dir: &Path,
+    os: &OS,
+    active_release_repository: &impl ActiveReleaseRepository,
+) -> Result<Vec<Tileset>, ListAllTilesetsError> {
+    let mut tilesets = Vec::new();
+
+    // Add third-party tilesets
+    let third_party_tilesets = list_all_third_party_tilesets(game_variant, resource_dir).await?;
+    tilesets.extend(third_party_tilesets);
+
+    // Add stock tilesets
+    let release_version = active_release_repository
+        .get_active_release(game_variant)
+        .await?;
+
+    if let Some(release_version) = release_version {
+        let stock_tilesets_dir =
+            get_stock_tilesets_dir(game_variant, &release_version, data_dir, os).await?;
+        let stock_tilesets = list_all_stock_tilesets(&stock_tilesets_dir).await?;
+        tilesets.extend(stock_tilesets);
+    }
+
+    Ok(tilesets)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExtractStockTilesetError {
+    #[error("failed to read tileset.txt: {0}")]
+    ReadTilesetTxt(#[from] io::Error),
+    #[error("missing field in tileset.txt: {0}")]
+    MissingField(String),
+}
+
+async fn extract_stock_tileset_from_tileset_txt(
+    tileset_txt_path: &Path,
+) -> Result<StockTileset, ExtractStockTilesetError> {
+    let file = File::open(tileset_txt_path).await?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    let mut name = None;
+    let mut view = None;
+
+    while let Some(line) = lines.next_line().await? {
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+
+        if let Some(captures) = line.split_once(':') {
+            let key = captures.0.trim();
+            let value = captures.1.trim().to_string();
+
+            if key == "NAME" {
+                name = Some(value);
+            } else if key == "VIEW" {
+                view = Some(value);
+            }
+        }
+    }
+
+    let id = name.ok_or_else(|| ExtractStockTilesetError::MissingField("NAME".to_string()))?;
+    let name = view.ok_or_else(|| ExtractStockTilesetError::MissingField("VIEW".to_string()))?;
+
+    Ok(StockTileset { id, name })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ListAllStockTilesetsError {
+    #[error("failed to read stock tilesets directory: {0}")]
+    ReadDir(#[from] io::Error),
+}
+
+async fn list_all_stock_tilesets(stock_tilesets_dir: &Path) -> Result<Vec<Tileset>, ListAllStockTilesetsError> {
+    let mut tilesets = Vec::new();
+    if !stock_tilesets_dir.exists() {
+        return Ok(tilesets);
+    }
+    let mut dir_entries = read_dir(stock_tilesets_dir).await?;
+
+    while let Some(entry) = dir_entries.next_entry().await? {
+        let path = entry.path();
+
+        if !entry.file_type().await?.is_dir() {
+            continue;
+        }
+
+        let tileset_txt_path = path.join("tileset.txt");
+
+        if tileset_txt_path.exists() {
+            match extract_stock_tileset_from_tileset_txt(&tileset_txt_path).await {
+                Ok(stock_tileset) => {
+                    tilesets.push(Tileset::Stock(stock_tileset));
+                }
+                Err(_) => {
+                    // Failed to parse, skip
+                    continue;
+                }
+            }
+        }
+    }
+
+    Ok(tilesets)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListThirdPartyTilesetsError {
+    #[error("failed to read tilesets.json: {0}")]
+    ReadTilesetsJson(#[from] io::Error),
+
+    #[error("failed to parse tilesets.json: {0}")]
+    ParseTilesetsJson(#[from] serde_json::Error),
+}
+
+async fn list_all_third_party_tilesets(
+    game_variant: &GameVariant,
+    resource_dir: &Path,
+) -> Result<Vec<Tileset>, ListThirdPartyTilesetsError> {
+    // Construct the path to tilesets.json
+    let tilesets_json_path = get_tilesets_resource_path(resource_dir);
+
+    // Try to read the tilesets.json file
+    let content = match read_to_string(&tilesets_json_path).await {
+        Ok(content) => content,
+        Err(e) => return Err(ListThirdPartyTilesetsError::ReadTilesetsJson(e)),
+    };
+
+    let tilesets_data: HashMap<GameVariant, HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&content)?;
+
+    let variant_tilesets = match tilesets_data.get(game_variant) {
+        Some(tilesets) => tilesets,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut tilesets = Vec::new();
+    for (_, tileset_data) in variant_tilesets {
+        let third_party_tileset = serde_json::from_value::<ThirdPartyTileset>(tileset_data.clone());
+        match third_party_tileset {
+            Ok(third_party_tileset) => tilesets.push(Tileset::ThirdParty(third_party_tileset)),
+            Err(e) => return Err(ListThirdPartyTilesetsError::ParseTilesetsJson(e)),
+        }
+    }
+
+    Ok(tilesets)
+}
+

--- a/cat-launcher/src-tauri/src/tilesets/mod.rs
+++ b/cat-launcher/src-tauri/src/tilesets/mod.rs
@@ -1,0 +1,8 @@
+pub mod commands;
+pub mod get_third_party_tileset_installation_status;
+pub mod install_third_party_tileset;
+pub mod list_all_tilesets;
+pub mod paths;
+pub mod repository;
+pub mod types;
+pub mod uninstall_third_party_tileset;

--- a/cat-launcher/src-tauri/src/tilesets/paths.rs
+++ b/cat-launcher/src-tauri/src/tilesets/paths.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+
+use crate::filesystem::paths::{get_game_resources_dir, GetGameExecutableDirError};
+use crate::infra::utils::OS;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetStockTilesetsDirError {
+    #[error("failed to get game resources directory: {0}")]
+    GameResourcesDir(#[from] GetGameExecutableDirError),
+}
+
+pub async fn get_stock_tilesets_dir(
+    variant: &GameVariant,
+    release_version: &str,
+    data_dir: &Path,
+    os: &OS,
+) -> Result<PathBuf, GetStockTilesetsDirError> {
+    let game_resources_dir = get_game_resources_dir(variant, release_version, data_dir, os).await?;
+
+    Ok(game_resources_dir.join("gfx"))
+}
+
+pub fn get_tilesets_resource_path(resource_dir: &Path) -> PathBuf {
+    resource_dir.join("content").join("tilesets.json")
+}

--- a/cat-launcher/src-tauri/src/tilesets/repository/installed_tilesets_repository.rs
+++ b/cat-launcher/src-tauri/src/tilesets/repository/installed_tilesets_repository.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InstalledTilesetsRepositoryError {
+    #[error("database error: {0}")]
+    Database(String),
+
+    #[error("installed tileset with id {0} not found for variant {1}")]
+    NotFound(String, String),
+}
+
+#[async_trait]
+pub trait InstalledTilesetsRepository: Send + Sync {
+    async fn add_installed_tileset(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledTilesetsRepositoryError>;
+
+    async fn get_installed_tilesets_for_variant(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<String>, InstalledTilesetsRepositoryError>;
+
+    async fn delete_installed_tileset(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledTilesetsRepositoryError>;
+
+    async fn is_tileset_installed(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<bool, InstalledTilesetsRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/tilesets/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/tilesets/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod installed_tilesets_repository;
+pub mod sqlite_installed_tilesets_repository;

--- a/cat-launcher/src-tauri/src/tilesets/repository/sqlite_installed_tilesets_repository.rs
+++ b/cat-launcher/src-tauri/src/tilesets/repository/sqlite_installed_tilesets_repository.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use r2d2_sqlite::SqliteConnectionManager;
+
+use crate::tilesets::repository::installed_tilesets_repository::{
+    InstalledTilesetsRepository, InstalledTilesetsRepositoryError,
+};
+use crate::variants::GameVariant;
+
+pub struct SqliteInstalledTilesetsRepository {
+    pool: r2d2::Pool<SqliteConnectionManager>,
+}
+
+impl SqliteInstalledTilesetsRepository {
+    pub fn new(pool: r2d2::Pool<SqliteConnectionManager>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl InstalledTilesetsRepository for SqliteInstalledTilesetsRepository {
+    async fn add_installed_tileset(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledTilesetsRepositoryError> {
+        let pool = self.pool.clone();
+        let tileset_id = tileset_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            conn.execute(
+                "INSERT OR IGNORE INTO installed_tilesets (tileset_id, game_variant) VALUES (?1, ?2)",
+                [&tileset_id, &variant_name],
+            )
+            .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn get_installed_tilesets_for_variant(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<String>, InstalledTilesetsRepositoryError> {
+        let pool = self.pool.clone();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            let mut stmt = conn
+                .prepare("SELECT tileset_id FROM installed_tilesets WHERE game_variant = ?1")
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            let tileset_ids = stmt
+                .query_map([&variant_name], |row| row.get::<_, String>(0))
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            Ok(tileset_ids)
+        })
+        .await
+        .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn delete_installed_tileset(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledTilesetsRepositoryError> {
+        let pool = self.pool.clone();
+        let tileset_id = tileset_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            let rows_affected = conn
+                .execute(
+                    "DELETE FROM installed_tilesets WHERE tileset_id = ?1 AND game_variant = ?2",
+                    [&tileset_id, &variant_name],
+                )
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            if rows_affected == 0 {
+                return Err(InstalledTilesetsRepositoryError::NotFound(tileset_id, variant_name));
+            }
+
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn is_tileset_installed(
+        &self,
+        tileset_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<bool, InstalledTilesetsRepositoryError> {
+        let pool = self.pool.clone();
+        let tileset_id = tileset_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            let mut stmt = conn
+                .prepare("SELECT 1 FROM installed_tilesets WHERE tileset_id = ?1 AND game_variant = ?2")
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            let exists = stmt
+                .exists([&tileset_id, &variant_name])
+                .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?;
+
+            Ok(exists)
+        })
+        .await
+        .map_err(|e| InstalledTilesetsRepositoryError::Database(e.to_string()))?
+    }
+}

--- a/cat-launcher/src-tauri/src/tilesets/types.rs
+++ b/cat-launcher/src-tauri/src/tilesets/types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct TilesetInstallation {
+    pub download_url: String,
+    pub tileset: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct TilesetActivity {
+    pub activity_type: String,
+    pub github: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ThirdPartyTileset {
+    pub id: String,
+    pub name: String,
+    pub installation: TilesetInstallation,
+    pub activity: TilesetActivity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct StockTileset {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(tag = "type", content = "content")]
+pub enum Tileset {
+    Stock(StockTileset),
+    ThirdParty(ThirdPartyTileset),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum TilesetInstallationStatus {
+    Installed,
+    NotInstalled,
+}

--- a/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::path::Path;
+
+use crate::filesystem::paths::{get_or_create_user_game_data_dir, GetUserGameDataDirError};
+use crate::tilesets::repository::installed_tilesets_repository::{
+    InstalledTilesetsRepository, InstalledTilesetsRepositoryError,
+};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum UninstallThirdPartyTilesetError {
+    #[error("failed to remove installed tileset from repository: {0}")]
+    Repository(#[from] InstalledTilesetsRepositoryError),
+    #[error("failed to get user game data directory: {0}")]
+    UserGameDataDir(#[from] GetUserGameDataDirError),
+    #[error("failed to delete tileset directory: {0}")]
+    DeleteTilesetDirectory(#[from] io::Error),
+}
+
+pub async fn uninstall_third_party_tileset(
+    tileset_id: &str,
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    repository: &impl InstalledTilesetsRepository,
+) -> Result<(), UninstallThirdPartyTilesetError> {
+    // Remove from repository
+    repository
+        .delete_installed_tileset(tileset_id, game_variant)
+        .await?;
+
+    // Delete tileset directory
+    let user_game_data_dir = get_or_create_user_game_data_dir(game_variant, data_dir).await?;
+    let tileset_dir = user_game_data_dir.join("gfx").join(tileset_id);
+    tokio::fs::remove_dir_all(&tileset_dir).await?;
+
+    Ok(())
+}

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -21,6 +21,7 @@ use crate::mods::repository::sqlite_installed_mods_repository::SqliteInstalledMo
 use crate::play_time::sqlite_play_time_repository::SqlitePlayTimeRepository;
 use crate::settings::Settings;
 use crate::theme::sqlite_theme_preference_repository::SqliteThemePreferenceRepository;
+use crate::tilesets::repository::sqlite_installed_tilesets_repository::SqliteInstalledTilesetsRepository;
 use crate::users::repository::sqlite_users_repository::SqliteUsersRepository;
 use crate::users::service::get_or_create_user_id;
 use crate::variants::repository::sqlite_game_variant_order_repository::SqliteGameVariantOrderRepository;
@@ -108,6 +109,7 @@ pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
     app.manage(SqliteGameVariantOrderRepository::new(pool.clone()));
     app.manage(SqliteThemePreferenceRepository::new(pool.clone()));
     app.manage(SqliteInstalledModsRepository::new(pool.clone()));
+    app.manage(SqliteInstalledTilesetsRepository::new(pool.clone()));
     app.manage(SqliteUsersRepository::new(pool));
 
     Ok(())

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -16,6 +16,8 @@ import type { ModInstallationStatus } from "@/generated-types/ModInstallationSta
 import type { ReleasesUpdatePayload } from "@/generated-types/ReleasesUpdatePayload";
 import type { Theme } from "@/generated-types/Theme";
 import type { ThemePreference } from "@/generated-types/ThemePreference";
+import type { Tileset } from "@/generated-types/Tileset";
+import type { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
 import type { UpdateStatus } from "@/generated-types/UpdateStatus";
 
 export async function listenToReleasesUpdate(
@@ -271,6 +273,49 @@ export async function uninstallThirdPartyMod(
 ): Promise<void> {
   await invoke("uninstall_third_party_mod_command", {
     id: modId,
+    variant: variant,
+  });
+}
+
+export async function listAllTilesets(
+  variant: GameVariant,
+): Promise<Tileset[]> {
+  const response = await invoke<Tileset[]>("list_all_tilesets_command", {
+    variant,
+  });
+  return response;
+}
+
+export async function installThirdPartyTileset(
+  tilesetId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("install_third_party_tileset_command", {
+    id: tilesetId,
+    variant,
+  });
+}
+
+export async function getThirdPartyTilesetInstallationStatus(
+  tilesetId: string,
+  variant: GameVariant,
+): Promise<TilesetInstallationStatus> {
+  const response = await invoke<TilesetInstallationStatus>(
+    "get_third_party_tileset_installation_status_command",
+    {
+      id: tilesetId,
+      variant,
+    },
+  );
+  return response;
+}
+
+export async function uninstallThirdPartyTileset(
+  tilesetId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("uninstall_third_party_tileset_command", {
+    id: tilesetId,
     variant: variant,
   });
 }

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -31,4 +31,10 @@ export const queryKeys = {
     installationStatus: (modId: string, variant: GameVariant) =>
       ["mods", "installation_status", modId, variant] as const,
   },
+
+  tilesets: {
+    listAll: (variant: GameVariant) => ["tilesets", variant] as const,
+    installationStatus: (tilesetId: string, variant: GameVariant) =>
+      ["tilesets", "installation_status", tilesetId, variant] as const,
+  },
 };

--- a/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
@@ -1,0 +1,95 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { GameVariant } from "@/generated-types/GameVariant";
+import type { Tileset } from "@/generated-types/Tileset";
+import { toastCL } from "@/lib/utils";
+import {
+  useGetThirdPartyTilesetInstallationStatus,
+  useInstallThirdPartyTileset,
+  useUninstallThirdPartyTileset,
+} from "./hooks";
+
+interface TilesetCardProps {
+  variant: GameVariant;
+  tileset: Tileset;
+}
+
+function getTilesetName(tileset: Tileset): string {
+  return tileset.content.name;
+}
+
+function getTilesetType(tileset: Tileset): string {
+  return tileset.type === "Stock" ? "Pre-Installed" : "Third-Party";
+}
+
+export default function TilesetCard({ variant, tileset }: TilesetCardProps) {
+  const name = getTilesetName(tileset);
+  const tilesetType = getTilesetType(tileset);
+
+  const isThirdParty = tileset.type !== "Stock";
+  const tilesetId = tileset.content.id;
+
+  const { installationStatus } = useGetThirdPartyTilesetInstallationStatus(
+    tilesetId,
+    variant,
+  );
+
+  const isInstalled = installationStatus === "Installed";
+
+  const { isInstalling, install } = useInstallThirdPartyTileset(
+    variant,
+    () => toastCL("success", "Tileset installed successfully."),
+    (error) => toastCL("error", "Failed to install tileset.", error),
+  );
+
+  const { isUninstalling, uninstall } = useUninstallThirdPartyTileset(
+    variant,
+    () => toastCL("success", "Tileset uninstalled successfully."),
+    (error) => toastCL("error", "Failed to uninstall tileset.", error),
+  );
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex justify-between items-start">
+          <div className="flex-1">
+            <CardTitle>{name}</CardTitle>
+            <div className="flex gap-2 mt-2">
+              <Badge variant="secondary">{tilesetType}</Badge>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {isThirdParty && (
+        <CardFooter className="flex flex-col gap-4 items-stretch">
+          {isInstalled ? (
+            <Button
+              className="w-full"
+              variant="destructive"
+              onClick={() => uninstall(tilesetId)}
+              disabled={isUninstalling}
+            >
+              {isUninstalling ? "Uninstalling..." : "Uninstall"}
+            </Button>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={() => install(tilesetId)}
+              disabled={isInstalling}
+            >
+              {isInstalling ? "Installing..." : "Install"}
+            </Button>
+          )}
+        </CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { toastCL } from "@/lib/utils";
+import TilesetCard from "./TilesetCard";
+import { useListAllTilesets } from "./hooks";
+
+interface TilesetsListProps {
+  variant: GameVariant;
+}
+
+export default function TilesetsList({ variant }: TilesetsListProps) {
+  const {
+    tilesets,
+    isLoading,
+    error,
+  } = useListAllTilesets(variant);
+
+  useEffect(() => {
+    if (error) {
+      toastCL("error", "Failed to load tilesets.", error);
+    }
+  }, [error]);
+
+  if (isLoading) {
+    return <p className="text-muted-foreground">Loading tilesets...</p>;
+  }
+
+  if (!tilesets || tilesets.length === 0) {
+    return <p className="text-muted-foreground">No tilesets available.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {tilesets.map((tileset) => (
+        <TilesetCard
+          key={`${variant}-${tileset.content.id}`}
+          variant={variant}
+          tileset={tileset}
+        />
+      ))}
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/TilesetsPage/hooks.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import {
+  getThirdPartyTilesetInstallationStatus,
+  installThirdPartyTileset,
+  listAllTilesets,
+  uninstallThirdPartyTileset,
+} from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useInstallThirdPartyTileset(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (tilesetId: string) => installThirdPartyTileset(tilesetId, variant),
+    onSuccess: (_data, tilesetId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tilesets.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tilesets.installationStatus(tilesetId, variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isInstalling: mutation.isPending,
+    install: (tilesetId: string) => mutation.mutate(tilesetId),
+  };
+}
+
+export function useGetThirdPartyTilesetInstallationStatus(
+  tilesetId: string,
+  variant: GameVariant,
+) {
+  const query = useQuery({
+    queryKey: queryKeys.tilesets.installationStatus(tilesetId, variant),
+    queryFn: () => getThirdPartyTilesetInstallationStatus(tilesetId, variant),
+  });
+
+  return {
+    installationStatus: query.data,
+    isLoading: query.isLoading,
+  };
+}
+
+export function useUninstallThirdPartyTileset(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (tilesetId: string) => uninstallThirdPartyTileset(tilesetId, variant),
+    onSuccess: (_data, tilesetId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tilesets.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tilesets.installationStatus(tilesetId, variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isUninstalling: mutation.isPending,
+    uninstall: (tilesetId: string) => mutation.mutate(tilesetId),
+  };
+}
+
+export function useListAllTilesets(variant: GameVariant) {
+    const query = useQuery({
+        queryKey: queryKeys.tilesets.listAll(variant),
+        queryFn: () => listAllTilesets(variant),
+    });
+
+    return {
+        tilesets: query.data,
+        isLoading: query.isLoading,
+        error: query.error,
+    };
+}

--- a/cat-launcher/src/pages/TilesetsPage/index.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/index.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+import VariantSelector from "@/components/VariantSelector";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { useGameVariants } from "@/hooks/useGameVariants";
+import TilesetsList from "./TilesetsList";
+
+function TilesetsPage() {
+  const { gameVariants, isLoading: gameVariantsLoading } = useGameVariants();
+  const [selectedVariant, setSelectedVariant] = useState<GameVariant | null>(
+    null,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <VariantSelector
+        gameVariants={gameVariants}
+        selectedVariant={selectedVariant}
+        onVariantChange={setSelectedVariant}
+        isLoading={gameVariantsLoading}
+      />
+      {selectedVariant && <TilesetsList variant={selectedVariant} />}
+    </div>
+  );
+}
+
+export default TilesetsPage;

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -2,7 +2,8 @@ import AboutPage from "@/pages/AboutPage";
 import BackupsPage from "@/pages/BackupsPage";
 import ModsPage from "@/pages/ModsPage";
 import PlayPage from "@/pages/PlayPage";
-import { FileUp, Gamepad2, Info, Package } from "lucide-react";
+import TilesetsPage from "@/pages/TilesetsPage";
+import { FileUp, Gamepad2, Info, Package, Palette } from "lucide-react";
 
 export const routes = [
   {
@@ -22,6 +23,12 @@ export const routes = [
     element: <ModsPage />,
     label: "Mods",
     icon: Package,
+  },
+  {
+    path: "/tilesets",
+    element: <TilesetsPage />,
+    label: "Tilesets",
+    icon: Palette,
   },
   {
     path: "/about",


### PR DESCRIPTION
### **User description**
Add installed_tilesets repository module declarations and a SQLite
implementation placeholder to the tilesets repository mod to prepare the
codebase for multiple repository backends.

Introduce tilesets path utilities:
- get_stock_tilesets_dir: resolve the game's gfx resources dir for a
  given variant/release/data dir/OS.
- get_tilesets_resource_path: compute content/tilesets.json path inside a
  resource directory.
These helpers centralize filesystem logic for locating stock tileset
resources.

Add React Query hooks for tilesets management on the Tilesets page:
- useInstallThirdPartyTileset: mutation to install a third-party tileset
  and invalidate relevant queries.
- useUninstallThirdPartyTileset: mutation to uninstall and invalidate.
- useGetThirdPartyTilesetInstallationStatus: query for a tileset's
  installation status.
- useListAllTilesets: query to list available tilesets.
These hooks wrap IPC/command calls and keep UI data synchronized.

Wire up UI and navigation:
- Add a Tilesets page route and Palette icon to the main routes list so
  the tilesets UI is reachable from the app navigation.

Database migration:
- Add installed_tilesets table to the schema to persist installed
  tilesets per game variant.

Overall this change lays the groundwork for managing third-party and
stock tilesets end-to-end (filesystem, DB, UI hooks, and routing).


___

### **PR Type**
Enhancement


___

### **Description**
- Add tilesets management system with repository pattern for database persistence

- Implement tileset listing, installation, and uninstallation functionality

- Create React Query hooks and UI components for tileset management

- Add tilesets route and navigation with Palette icon

- Introduce filesystem utilities for stock and third-party tileset resolution

- Add `installed_tilesets` database table to persist installation state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tauri Commands"] -->|invoke| B["Tileset Operations"]
  B -->|list| C["List All Tilesets"]
  B -->|install| D["Install Third-Party"]
  B -->|uninstall| E["Uninstall Tileset"]
  B -->|check| F["Get Installation Status"]
  C -->|read| G["tilesets.json"]
  C -->|scan| H["Stock Tilesets Dir"]
  D -->|download| I["Archive File"]
  D -->|extract| J["Temp Directory"]
  D -->|persist| K["SQLite Repository"]
  E -->|remove| K
  F -->|query| K
  K -->|store| L["installed_tilesets Table"]
  M["React Query Hooks"] -->|call| A
  N["UI Components"] -->|use| M
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Register tilesets module and commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Create tilesets module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-5bde1de1b1a9535fa22df754a19fd200e905dee4f95e69c552429ddddceb6588">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Implement Tauri commands for tileset operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-449e788340ed39fa396d692703189f8979286d21b6e06152ce0b6dabc5e75b00">+135/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Define tileset data structures and enums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-0c2274b60eaa85d36942c5169e6d3363aa374449a14724c2a340db854541e6cc">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paths.rs</strong><dd><code>Add filesystem path utilities for tilesets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-de130d1c726db04d62ce062137669e9e52a2d6574fa78230725e1149ad917011">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_all_tilesets.rs</strong><dd><code>Implement tileset listing from JSON and filesystem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-b7af594b4f0e2808d9951fa05b1331dcedb3cf42673810dc842359c2492df5fb">+179/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>install_third_party_tileset.rs</strong><dd><code>Implement third-party tileset download and installation</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-735a97f6e387f3a93c32c0c3659065fe23052be4b06ef4dddc09b418ea92b69a">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>uninstall_third_party_tileset.rs</strong><dd><code>Implement third-party tileset uninstallation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-b41dfc930f26f4cd8dda612915af1337d844939b58507a5ff16c50e91109b95c">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_third_party_tileset_installation_status.rs</strong><dd><code>Implement tileset installation status checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-0e04eadc594c7a93273fcb24ff640e2bd87fc81d37699896ba941f30aba864f2">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Create repository module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-a982f23f4719d7974bf9653f6c1e9ca85e33d39e822bc51f1e7a4edf5dd61b70">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installed_tilesets_repository.rs</strong><dd><code>Define installed tilesets repository trait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-61ee51b86102a01934b418656b45cd210d11f3b1c85f2767169e87078d3e6d7c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_installed_tilesets_repository.rs</strong><dd><code>Implement SQLite repository for installed tilesets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-7862aa125e9805fc9639d6d47a9aa9cd84ba2d5f8f715e8e92b829516e5acd59">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Add installed_tilesets database table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Register tilesets repository in dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-b3ee322098b457e66256bbc93ebafa48258bb7677544ec6ff974981ea1915719">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Export tileset command wrappers for frontend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add React Query keys for tileset queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hooks.ts</strong><dd><code>Create React Query hooks for tileset management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-6c0f3793863f874235c11f3c8caf40dc569cfd05bdf7506ae68d60f46fbd3ccd">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TilesetCard.tsx</strong><dd><code>Create tileset card UI component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-23778ded4b8b3334a3fed14a98fd573777021cdf33a255c0e63d978400dbdb29">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TilesetsList.tsx</strong><dd><code>Create tileset list display component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-11122e82d20401f805b19a8317329d7a3a255978db42df5ce57db9c633dd1c76">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Create tilesets page with variant selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-429e4544aa9290b4589a7095438828e47029ce6721e52226e3eb6596a41dfe1b">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routes.tsx</strong><dd><code>Add tilesets route and Palette navigation icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-1e5bca5f2ad612aadcc10f3c1749eeb1094085f3e49863d6bef96bd632673277">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tilesets.json</strong><dd><code>Add third-party tileset configuration data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/254/files#diff-b741ff4ee2c80f51c72fdee6ee1363d4709c187cc66e5100f04a8cf5f7ed869c">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end tileset management: list stock and third-party tilesets, install/uninstall third-party sets, and a new Tilesets page. Persists installations in SQLite and adds filesystem helpers to locate resources.

- **New Features**
  - New Tilesets page and route (Palette icon) with install/uninstall actions and live status via React Query hooks.
  - Tauri commands to list tilesets, install, uninstall, and check installation status; fully wired in the app.
  - Stock tilesets auto-discovered from the active release’s gfx directory by parsing tileset.txt.
  - Third-party tilesets sourced from content/tilesets.json; install flow downloads, extracts, copies to user gfx, and records in DB (cleanup included).
  - Repository abstraction for installed tilesets with a SQLite implementation, plus path utilities for stock and resource files.

- **Migration**
  - Adds installed_tilesets table (tileset_id, game_variant) to track installations per variant.

<sup>Written for commit 857f48c4e4800691454e2d6f50f47f0ae867aff6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







