### PR TITLE
feat(soundpacks): add types and Tauri command handlers

### DIFF
--- a/cat-launcher/src-tauri/content/soundpacks.json
+++ b/cat-launcher/src-tauri/content/soundpacks.json
@@ -1,0 +1,46 @@
+{
+  "DarkDaysAhead": {
+    "otopack": {
+      "id": "otopack",
+      "name": "Otopack",
+      "installation": {
+        "download_url": "https://github.com/Kenan2000/Otopack-Mods-Updates/archive/refs/heads/master.zip",
+        "soundpack": "Otopack-Mods-Updates-master/Otopack+ModsUpdates/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
+      }
+    }
+  },
+
+  "BrightNights": {
+    "otopack": {
+      "id": "otopack",
+      "name": "Otopack",
+      "installation": {
+        "download_url": "https://github.com/Kenan2000/Otopack-Mods-Updates/archive/refs/heads/master.zip",
+        "soundpack": "Otopack-Mods-Updates-master/Otopack+ModsUpdates/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
+      }
+    }
+  },
+
+  "TheLastGeneration": {
+    "otopack": {
+      "id": "otopack",
+      "name": "Otopack",
+      "installation": {
+        "download_url": "https://github.com/Kenan2000/Otopack-Mods-Updates/archive/refs/heads/master.zip",
+        "soundpack": "Otopack-Mods-Updates-master/Otopack+ModsUpdates/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
+      }
+    }
+  }
+}

--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -127,3 +127,13 @@ CREATE TABLE IF NOT EXISTS installed_tilesets (
 );
 
 CREATE INDEX IF NOT EXISTS idx_installed_tilesets_game_variant ON installed_mods (game_variant);
+
+-- This table stores installed soundpacks for each game variant.
+CREATE TABLE IF NOT EXISTS installed_soundpacks (
+    soundpack_id TEXT NOT NULL,
+    game_variant TEXT NOT NULL,
+    PRIMARY KEY (soundpack_id, game_variant),
+    FOREIGN KEY (game_variant) REFERENCES variants (name) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_installed_soundpacks_game_variant ON installed_mods (game_variant);

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod launch_game;
 mod manual_backups;
 mod mods;
 mod play_time;
+mod soundpacks;
 mod theme;
 mod tilesets;
 mod users;
@@ -37,6 +38,10 @@ use crate::mods::commands::{
     list_all_mods_command, uninstall_third_party_mod_command,
 };
 use crate::play_time::commands::{get_play_time_for_variant, get_play_time_for_version};
+use crate::soundpacks::commands::{
+    get_third_party_soundpack_installation_status_command, install_third_party_soundpack_command,
+    list_all_soundpacks_command, uninstall_third_party_soundpack_command,
+};
 use crate::theme::commands::{get_preferred_theme, set_preferred_theme};
 use crate::tilesets::commands::{
     get_third_party_tileset_installation_status_command, install_third_party_tileset_command,
@@ -94,6 +99,10 @@ pub fn run() {
             install_third_party_tileset_command,
             uninstall_third_party_tileset_command,
             get_third_party_tileset_installation_status_command,
+            list_all_soundpacks_command,
+            install_third_party_soundpack_command,
+            uninstall_third_party_soundpack_command,
+            get_third_party_soundpack_installation_status_command,
             get_user_id,
             get_preferred_theme,
             set_preferred_theme,

--- a/cat-launcher/src-tauri/src/soundpacks/commands.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/commands.rs
@@ -1,0 +1,138 @@
+use std::env::consts::OS;
+
+use strum::IntoStaticStr;
+use tauri::{Manager, State};
+
+use cat_macros::CommandErrorSerialize;
+
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::infra::download::Downloader;
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::soundpacks::get_third_party_soundpack_installation_status::{
+    get_third_party_soundpack_installation_status, GetThirdPartySoundpackInstallationStatusError,
+};
+use crate::soundpacks::install_third_party_soundpack::{
+    install_third_party_soundpack, InstallThirdPartySoundpackError,
+};
+use crate::soundpacks::list_all_soundpacks::{list_all_soundpacks, ListAllSoundpacksError};
+use crate::soundpacks::repository::sqlite_installed_soundpacks_repository::SqliteInstalledSoundpacksRepository;
+use crate::soundpacks::types::{Soundpack, SoundpackInstallationStatus};
+use crate::soundpacks::uninstall_third_party_soundpack::{
+    uninstall_third_party_soundpack, UninstallThirdPartySoundpackError,
+};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum ListAllSoundpacksCommandError {
+    #[error("failed to get app data directory")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to get OS information")]
+    OSInfo(#[from] OSNotSupportedError),
+
+    #[error("failed to list soundpacks: {0}")]
+    ListSoundpacks(#[from] ListAllSoundpacksError),
+}
+
+#[tauri::command]
+pub async fn list_all_soundpacks_command(
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    active_release_repository: State<'_, SqliteActiveReleaseRepository>,
+) -> Result<Vec<Soundpack>, ListAllSoundpacksCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+
+    let os = get_os_enum(OS)?;
+
+    let soundpacks = list_all_soundpacks(
+        &variant,
+        &data_dir,
+        &resource_dir,
+        &os,
+        active_release_repository.inner(),
+    )
+    .await?;
+
+    Ok(soundpacks)
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum InstallThirdPartySoundpackCommandError {
+    #[error("failed to get app data directory")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to get OS information")]
+    OSInfo(#[from] OSNotSupportedError),
+
+    #[error("failed to install soundpack: {0}")]
+    Install(#[from] InstallThirdPartySoundpackError),
+}
+
+#[tauri::command]
+pub async fn install_third_party_soundpack_command(
+    id: String,
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    downloader: State<'_, Downloader>,
+    repository: State<'_, SqliteInstalledSoundpacksRepository>,
+) -> Result<(), InstallThirdPartySoundpackCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+    let resource_dir = app.path().resource_dir()?;
+    let temp_dir = app.path().app_cache_dir()?;
+
+    let os = get_os_enum(OS)?;
+
+    install_third_party_soundpack(
+        &id,
+        &variant,
+        &data_dir,
+        &resource_dir,
+        &temp_dir,
+        &os,
+        downloader.inner(),
+        repository.inner(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum UninstallThirdPartySoundpackCommandError {
+    #[error("failed to get app data directory: {0}")]
+    AppDataDir(#[from] tauri::Error),
+
+    #[error("failed to uninstall soundpack: {0}")]
+    Uninstall(#[from] UninstallThirdPartySoundpackError),
+}
+
+#[tauri::command]
+pub async fn uninstall_third_party_soundpack_command(
+    id: String,
+    variant: GameVariant,
+    app: tauri::AppHandle,
+    repository: State<'_, SqliteInstalledSoundpacksRepository>,
+) -> Result<(), UninstallThirdPartySoundpackCommandError> {
+    let data_dir = app.path().app_local_data_dir()?;
+
+    uninstall_third_party_soundpack(&id, &variant, &data_dir, repository.inner()).await?;
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
+pub enum GetThirdPartySoundpackInstallationStatusCommandError {
+    #[error("failed to get soundpack installation status: {0}")]
+    GetStatus(#[from] GetThirdPartySoundpackInstallationStatusError),
+}
+
+#[tauri::command]
+pub async fn get_third_party_soundpack_installation_status_command(
+    id: String,
+    variant: GameVariant,
+    repository: State<'_, SqliteInstalledSoundpacksRepository>,
+) -> Result<SoundpackInstallationStatus, GetThirdPartySoundpackInstallationStatusCommandError> {
+    let status =
+        get_third_party_soundpack_installation_status(&id, &variant, repository.inner()).await?;
+    Ok(status)
+}

--- a/cat-launcher/src-tauri/src/soundpacks/get_third_party_soundpack_installation_status.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/get_third_party_soundpack_installation_status.rs
@@ -1,0 +1,25 @@
+use crate::soundpacks::repository::installed_soundpacks_repository::{
+    InstalledSoundpacksRepository, InstalledSoundpacksRepositoryError,
+};
+use crate::soundpacks::types::SoundpackInstallationStatus;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetThirdPartySoundpackInstallationStatusError {
+    #[error("failed to check soundpack installation status: {0}")]
+    Repository(#[from] InstalledSoundpacksRepositoryError),
+}
+
+pub async fn get_third_party_soundpack_installation_status(
+    soundpack_id: &str,
+    variant: &GameVariant,
+    repository: &dyn InstalledSoundpacksRepository,
+) -> Result<SoundpackInstallationStatus, GetThirdPartySoundpackInstallationStatusError> {
+    let is_installed = repository.is_soundpack_installed(soundpack_id, variant).await?;
+
+    Ok(if is_installed {
+        SoundpackInstallationStatus::Installed
+    } else {
+        SoundpackInstallationStatus::NotInstalled
+    })
+}

--- a/cat-launcher/src-tauri/src/soundpacks/install_third_party_soundpack.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/install_third_party_soundpack.rs
@@ -1,0 +1,167 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::fs::{create_dir_all, read_to_string};
+
+use crate::filesystem::paths::{
+    get_or_create_directory, get_or_create_user_game_data_dir, GetOrCreateDirectoryError,
+    GetUserGameDataDirError,
+};
+use crate::filesystem::utils::{copy_dir_all, CopyDirError};
+use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::download::{DownloadFileError, Downloader, NoOpReporter};
+use crate::infra::utils::OS;
+use crate::soundpacks::paths::get_soundpacks_resource_path;
+use crate::soundpacks::repository::installed_soundpacks_repository::{
+    InstalledSoundpacksRepository, InstalledSoundpacksRepositoryError,
+};
+use crate::soundpacks::types::ThirdPartySoundpack;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InstallThirdPartySoundpackError {
+    #[error("failed to get soundpack from soundpacks.json: {0}")]
+    GetSoundpackFromJson(#[from] GetSoundpackFromJsonError),
+
+    #[error("failed to create directory: {0}")]
+    CreateDirectory(#[from] io::Error),
+
+    #[error("failed to download soundpack: {0}")]
+    Download(#[from] DownloadFileError),
+
+    #[error("failed to extract soundpack: {0}")]
+    Extract(#[from] ExtractionError),
+
+    #[error("failed to get soundpack parent dir: {0}")]
+    GetSoundpackParentDir(#[from] GetSoundpackParentDirError),
+
+    #[error("failed to get user game data dir: {0}")]
+    GetUserGameDataDir(#[from] GetUserGameDataDirError),
+
+    #[error("failed to get user soundpack data dir: {0}")]
+    GetUserSoundpackDataDir(#[from] GetOrCreateDirectoryError),
+
+    #[error("failed to copy soundpack: {0}")]
+    Copy(#[from] CopyDirError),
+
+    #[error("failed to update repository: {0}")]
+    UpdateRepository(#[from] InstalledSoundpacksRepositoryError),
+}
+
+pub async fn install_third_party_soundpack(
+    soundpack_id: &str,
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    resource_dir: &Path,
+    temp_dir: &Path,
+    os: &OS,
+    downloader: &Downloader,
+    repository: &impl InstalledSoundpacksRepository,
+) -> Result<(), InstallThirdPartySoundpackError> {
+    // Get soundpack details from soundpacks.json
+    let soundpack_details =
+        get_soundpack_from_json(game_variant, soundpack_id, resource_dir).await?;
+
+    // Create a temp directory for this soundpack download
+    let soundpack_temp_dir = temp_dir
+        .join("cat-launcher-soundpack-install-dir")
+        .join(soundpack_id);
+    create_dir_all(&soundpack_temp_dir).await?;
+
+    // Download the soundpack
+    let reporter = Arc::new(NoOpReporter);
+    let downloaded_file = downloader
+        .download_file(
+            &soundpack_details.installation.download_url,
+            &soundpack_temp_dir,
+            reporter,
+        )
+        .await?;
+
+    // Extract the soundpack to the temp directory
+    let extraction_dir = soundpack_temp_dir.join("extracted");
+    create_dir_all(&extraction_dir).await?;
+    extract_archive(&downloaded_file, &extraction_dir, os).await?;
+
+    // Get the soundpack parent directory from the soundpack path
+    let soundpack_parent_dir =
+        get_soundpack_parent_dir(&extraction_dir, &soundpack_details.installation.soundpack)?;
+
+    // Get the sounds directory in user game data
+    let user_game_data_dir = get_or_create_user_game_data_dir(game_variant, data_dir).await?;
+    let sounds_dir = get_or_create_directory(&user_game_data_dir, "sound").await?;
+
+    // Copy the soundpack parent directory to the sounds directory
+    let soundpack_install_dir = sounds_dir.join(soundpack_id);
+    copy_dir_all(&soundpack_parent_dir, &soundpack_install_dir, os).await?;
+
+    // Mark the soundpack as installed in the repository
+    repository
+        .add_installed_soundpack(soundpack_id, game_variant)
+        .await?;
+
+    // Clean up temp files, ignore any errors
+    let _ = tokio::fs::remove_dir_all(&soundpack_temp_dir).await;
+
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetSoundpackFromJsonError {
+    #[error("failed to read soundpacks.json: {0}")]
+    ReadSoundpacksJson(#[from] std::io::Error),
+
+    #[error("failed to parse soundpacks.json: {0}")]
+    ParseSoundpacksJson(#[from] serde_json::Error),
+
+    #[error("no soundpacks found for variant {0}")]
+    NoSoundpacksForVariant(GameVariant),
+
+    #[error("soundpack with id {0} not found")]
+    SoundpackNotFound(String),
+}
+
+async fn get_soundpack_from_json(
+    game_variant: &GameVariant,
+    soundpack_id: &str,
+    resource_dir: &Path,
+) -> Result<ThirdPartySoundpack, GetSoundpackFromJsonError> {
+    let soundpacks_json_path = get_soundpacks_resource_path(resource_dir);
+    let content = read_to_string(&soundpacks_json_path).await?;
+
+    let soundpacks_data: HashMap<GameVariant, HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&content)?;
+
+    let variant_soundpacks = soundpacks_data.get(game_variant).ok_or(
+        GetSoundpackFromJsonError::NoSoundpacksForVariant(*game_variant),
+    )?;
+
+    let soundpack_data = variant_soundpacks.get(soundpack_id).ok_or(
+        GetSoundpackFromJsonError::SoundpackNotFound(soundpack_id.to_string()),
+    )?;
+
+    let third_party_soundpack =
+        serde_json::from_value::<ThirdPartySoundpack>(soundpack_data.clone())?;
+
+    Ok(third_party_soundpack)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetSoundpackParentDirError {
+    #[error("failed to get parent directory for soundpack path")]
+    ParentDirNotFound,
+}
+
+fn get_soundpack_parent_dir(
+    extracted_dir: &Path,
+    soundpack_relative_path: &str,
+) -> Result<PathBuf, GetSoundpackParentDirError> {
+    let soundpack_path = extracted_dir.join(soundpack_relative_path);
+
+    soundpack_path
+        .parent()
+        .ok_or(GetSoundpackParentDirError::ParentDirNotFound)
+        .map(|p| p.to_path_buf())
+}

--- a/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
@@ -1,0 +1,185 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+
+use tokio::fs::File;
+use tokio::fs::{read_dir, read_to_string};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::active_release::repository::{ActiveReleaseRepository, ActiveReleaseRepositoryError};
+use crate::infra::utils::OS;
+use crate::soundpacks::paths::{
+    get_soundpacks_resource_path, get_stock_soundpacks_dir, GetStockSoundpacksDirError,
+};
+use crate::soundpacks::types::{Soundpack, StockSoundpack, ThirdPartySoundpack};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListAllSoundpacksError {
+    #[error("failed to get stock soundpacks dir: {0}")]
+    GetStockSoundpacksDir(#[from] GetStockSoundpacksDirError),
+
+    #[error("failed to read stock soundpack dir: {0}")]
+    ExtractStockSoundpack(#[from] ListAllStockSoundpacksError),
+
+    #[error("failed to get active release: {0}")]
+    GetActiveRelease(#[from] ActiveReleaseRepositoryError),
+
+    #[error("failed to list third-party soundpacks: {0}")]
+    ListThirdPartySoundpacks(#[from] ListThirdPartySoundpacksError),
+}
+
+pub async fn list_all_soundpacks(
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    resource_dir: &Path,
+    os: &OS,
+    active_release_repository: &impl ActiveReleaseRepository,
+) -> Result<Vec<Soundpack>, ListAllSoundpacksError> {
+    let mut soundpacks = Vec::new();
+
+    // Add third-party soundpacks
+    let third_party_soundpacks =
+        list_all_third_party_soundpacks(game_variant, resource_dir).await?;
+    soundpacks.extend(third_party_soundpacks);
+
+    // Add stock soundpacks
+    let release_version = active_release_repository
+        .get_active_release(game_variant)
+        .await?;
+
+    if let Some(release_version) = release_version {
+        let stock_soundpacks_dir =
+            get_stock_soundpacks_dir(game_variant, &release_version, data_dir, os).await?;
+        let stock_soundpacks = list_all_stock_soundpacks(&stock_soundpacks_dir).await?;
+        soundpacks.extend(stock_soundpacks);
+    }
+
+    Ok(soundpacks)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExtractStockSoundpackError {
+    #[error("failed to read soundpack.txt: {0}")]
+    ReadSoundpackTxt(#[from] io::Error),
+    #[error("missing field in soundpack.txt: {0}")]
+    MissingField(String),
+}
+
+async fn extract_stock_soundpack_from_soundpack_txt(
+    soundpack_txt_path: &Path,
+) -> Result<StockSoundpack, ExtractStockSoundpackError> {
+    let file = File::open(soundpack_txt_path).await?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    let mut name = None;
+    let mut view = None;
+
+    while let Some(line) = lines.next_line().await? {
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+
+        if let Some(captures) = line.split_once(':') {
+            let key = captures.0.trim();
+            let value = captures.1.trim().to_string();
+
+            if key == "NAME" {
+                name = Some(value);
+            } else if key == "VIEW" {
+                view = Some(value);
+            }
+        }
+    }
+
+    let id = name.ok_or_else(|| ExtractStockSoundpackError::MissingField("NAME".to_string()))?;
+    let name = view.ok_or_else(|| ExtractStockSoundpackError::MissingField("VIEW".to_string()))?;
+
+    Ok(StockSoundpack { id, name })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ListAllStockSoundpacksError {
+    #[error("failed to read stock soundpacks directory: {0}")]
+    ReadDir(#[from] io::Error),
+}
+
+async fn list_all_stock_soundpacks(
+    stock_soundpacks_dir: &Path,
+) -> Result<Vec<Soundpack>, ListAllStockSoundpacksError> {
+    let mut soundpacks = Vec::new();
+    if !stock_soundpacks_dir.exists() {
+        return Ok(soundpacks);
+    }
+    let mut dir_entries = read_dir(stock_soundpacks_dir).await?;
+
+    while let Some(entry) = dir_entries.next_entry().await? {
+        let path = entry.path();
+
+        if !entry.file_type().await?.is_dir() {
+            continue;
+        }
+
+        let soundpack_txt_path = path.join("soundpack.txt");
+
+        if soundpack_txt_path.exists() {
+            match extract_stock_soundpack_from_soundpack_txt(&soundpack_txt_path).await {
+                Ok(stock_soundpack) => {
+                    soundpacks.push(Soundpack::Stock(stock_soundpack));
+                }
+                Err(_) => {
+                    // Failed to parse, skip
+                    continue;
+                }
+            }
+        }
+    }
+
+    Ok(soundpacks)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListThirdPartySoundpacksError {
+    #[error("failed to read soundpacks.json: {0}")]
+    ReadSoundpacksJson(#[from] io::Error),
+
+    #[error("failed to parse soundpacks.json: {0}")]
+    ParseSoundpacksJson(#[from] serde_json::Error),
+}
+
+async fn list_all_third_party_soundpacks(
+    game_variant: &GameVariant,
+    resource_dir: &Path,
+) -> Result<Vec<Soundpack>, ListThirdPartySoundpacksError> {
+    // Construct the path to soundpacks.json
+    let soundpacks_json_path = get_soundpacks_resource_path(resource_dir);
+
+    // Try to read the soundpacks.json file
+    let content = match read_to_string(&soundpacks_json_path).await {
+        Ok(content) => content,
+        Err(e) => return Err(ListThirdPartySoundpacksError::ReadSoundpacksJson(e)),
+    };
+
+    let soundpacks_data: HashMap<GameVariant, HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&content)?;
+
+    let variant_soundpacks = match soundpacks_data.get(game_variant) {
+        Some(soundpacks) => soundpacks,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut soundpacks = Vec::new();
+    for (_, soundpack_data) in variant_soundpacks {
+        let third_party_soundpack =
+            serde_json::from_value::<ThirdPartySoundpack>(soundpack_data.clone());
+        match third_party_soundpack {
+            Ok(third_party_soundpack) => {
+                soundpacks.push(Soundpack::ThirdParty(third_party_soundpack))
+            }
+            Err(e) => return Err(ListThirdPartySoundpacksError::ParseSoundpacksJson(e)),
+        }
+    }
+
+    Ok(soundpacks)
+}

--- a/cat-launcher/src-tauri/src/soundpacks/mod.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/mod.rs
@@ -1,0 +1,8 @@
+pub mod commands;
+pub mod get_third_party_soundpack_installation_status;
+pub mod install_third_party_soundpack;
+pub mod list_all_soundpacks;
+pub mod paths;
+pub mod repository;
+pub mod types;
+pub mod uninstall_third_party_soundpack;

--- a/cat-launcher/src-tauri/src/soundpacks/paths.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/paths.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+
+use crate::filesystem::paths::{get_game_resources_dir, GetGameExecutableDirError};
+use crate::infra::utils::OS;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetStockSoundpacksDirError {
+    #[error("failed to get game resources directory: {0}")]
+    GameResourcesDir(#[from] GetGameExecutableDirError),
+}
+
+pub async fn get_stock_soundpacks_dir(
+    variant: &GameVariant,
+    release_version: &str,
+    data_dir: &Path,
+    os: &OS,
+) -> Result<PathBuf, GetStockSoundpacksDirError> {
+    let game_resources_dir = get_game_resources_dir(variant, release_version, data_dir, os).await?;
+
+    Ok(game_resources_dir.join("data").join("sound"))
+}
+
+pub fn get_soundpacks_resource_path(resource_dir: &Path) -> PathBuf {
+    resource_dir.join("content").join("soundpacks.json")
+}

--- a/cat-launcher/src-tauri/src/soundpacks/repository/installed_soundpacks_repository.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/repository/installed_soundpacks_repository.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InstalledSoundpacksRepositoryError {
+    #[error("database error: {0}")]
+    Database(String),
+
+    #[error("installed soundpack with id {0} not found for variant {1}")]
+    NotFound(String, String),
+}
+
+#[async_trait]
+pub trait InstalledSoundpacksRepository: Send + Sync {
+    async fn add_installed_soundpack(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledSoundpacksRepositoryError>;
+
+    async fn get_installed_soundpacks_for_variant(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<String>, InstalledSoundpacksRepositoryError>;
+
+    async fn delete_installed_soundpack(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledSoundpacksRepositoryError>;
+
+    async fn is_soundpack_installed(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<bool, InstalledSoundpacksRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/soundpacks/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod installed_soundpacks_repository;
+pub mod sqlite_installed_soundpacks_repository;

--- a/cat-launcher/src-tauri/src/soundpacks/repository/sqlite_installed_soundpacks_repository.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/repository/sqlite_installed_soundpacks_repository.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use r2d2_sqlite::SqliteConnectionManager;
+
+use crate::soundpacks::repository::installed_soundpacks_repository::{
+    InstalledSoundpacksRepository, InstalledSoundpacksRepositoryError,
+};
+use crate::variants::GameVariant;
+
+pub struct SqliteInstalledSoundpacksRepository {
+    pool: r2d2::Pool<SqliteConnectionManager>,
+}
+
+impl SqliteInstalledSoundpacksRepository {
+    pub fn new(pool: r2d2::Pool<SqliteConnectionManager>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl InstalledSoundpacksRepository for SqliteInstalledSoundpacksRepository {
+    async fn add_installed_soundpack(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledSoundpacksRepositoryError> {
+        let pool = self.pool.clone();
+        let soundpack_id = soundpack_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            conn.execute(
+                "INSERT OR IGNORE INTO installed_soundpacks (soundpack_id, game_variant) VALUES (?1, ?2)",
+                [&soundpack_id, &variant_name],
+            )
+            .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn get_installed_soundpacks_for_variant(
+        &self,
+        game_variant: &GameVariant,
+    ) -> Result<Vec<String>, InstalledSoundpacksRepositoryError> {
+        let pool = self.pool.clone();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            let mut stmt = conn
+                .prepare("SELECT soundpack_id FROM installed_soundpacks WHERE game_variant = ?1")
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            let soundpack_ids = stmt
+                .query_map([&variant_name], |row| row.get::<_, String>(0))
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            Ok(soundpack_ids)
+        })
+        .await
+        .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn delete_installed_soundpack(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<(), InstalledSoundpacksRepositoryError> {
+        let pool = self.pool.clone();
+        let soundpack_id = soundpack_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            let rows_affected = conn
+                .execute(
+                    "DELETE FROM installed_soundpacks WHERE soundpack_id = ?1 AND game_variant = ?2",
+                    [&soundpack_id, &variant_name],
+                )
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            if rows_affected == 0 {
+                return Err(InstalledSoundpacksRepositoryError::NotFound(soundpack_id, variant_name));
+            }
+
+            Ok(())
+        })
+        .await
+        .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?
+    }
+
+    async fn is_soundpack_installed(
+        &self,
+        soundpack_id: &str,
+        game_variant: &GameVariant,
+    ) -> Result<bool, InstalledSoundpacksRepositoryError> {
+        let pool = self.pool.clone();
+        let soundpack_id = soundpack_id.to_string();
+        let variant_name = game_variant.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool
+                .get()
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            let mut stmt = conn
+                .prepare("SELECT 1 FROM installed_soundpacks WHERE soundpack_id = ?1 AND game_variant = ?2")
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            let exists = stmt
+                .exists([&soundpack_id, &variant_name])
+                .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?;
+
+            Ok(exists)
+        })
+        .await
+        .map_err(|e| InstalledSoundpacksRepositoryError::Database(e.to_string()))?
+    }
+}

--- a/cat-launcher/src-tauri/src/soundpacks/types.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct SoundpackInstallation {
+    pub download_url: String,
+    pub soundpack: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct SoundpackActivity {
+    pub activity_type: String,
+    pub github: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ThirdPartySoundpack {
+    pub id: String,
+    pub name: String,
+    pub installation: SoundpackInstallation,
+    pub activity: SoundpackActivity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct StockSoundpack {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(tag = "type", content = "content")]
+pub enum Soundpack {
+    Stock(StockSoundpack),
+    ThirdParty(ThirdPartySoundpack),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum SoundpackInstallationStatus {
+    Installed,
+    NotInstalled,
+}

--- a/cat-launcher/src-tauri/src/soundpacks/uninstall_third_party_soundpack.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/uninstall_third_party_soundpack.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::path::Path;
+
+use crate::filesystem::paths::{get_or_create_user_game_data_dir, GetUserGameDataDirError};
+use crate::soundpacks::repository::installed_soundpacks_repository::{
+    InstalledSoundpacksRepository, InstalledSoundpacksRepositoryError,
+};
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum UninstallThirdPartySoundpackError {
+    #[error("failed to remove installed soundpack from repository: {0}")]
+    Repository(#[from] InstalledSoundpacksRepositoryError),
+    #[error("failed to get user game data directory: {0}")]
+    UserGameDataDir(#[from] GetUserGameDataDirError),
+    #[error("failed to delete soundpack directory: {0}")]
+    DeleteSoundpackDirectory(#[from] io::Error),
+}
+
+pub async fn uninstall_third_party_soundpack(
+    soundpack_id: &str,
+    game_variant: &GameVariant,
+    data_dir: &Path,
+    repository: &impl InstalledSoundpacksRepository,
+) -> Result<(), UninstallThirdPartySoundpackError> {
+    // Remove from repository
+    repository
+        .delete_installed_soundpack(soundpack_id, game_variant)
+        .await?;
+
+    // Delete soundpack directory
+    let user_game_data_dir = get_or_create_user_game_data_dir(game_variant, data_dir).await?;
+    let soundpack_dir = user_game_data_dir.join("sound").join(soundpack_id);
+    tokio::fs::remove_dir_all(&soundpack_dir).await?;
+
+    Ok(())
+}

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -20,6 +20,7 @@ use crate::manual_backups::repository::sqlite_manual_backup_repository::SqliteMa
 use crate::mods::repository::sqlite_installed_mods_repository::SqliteInstalledModsRepository;
 use crate::play_time::sqlite_play_time_repository::SqlitePlayTimeRepository;
 use crate::settings::Settings;
+use crate::soundpacks::repository::sqlite_installed_soundpacks_repository::SqliteInstalledSoundpacksRepository;
 use crate::theme::sqlite_theme_preference_repository::SqliteThemePreferenceRepository;
 use crate::tilesets::repository::sqlite_installed_tilesets_repository::SqliteInstalledTilesetsRepository;
 use crate::users::repository::sqlite_users_repository::SqliteUsersRepository;
@@ -110,6 +111,7 @@ pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
     app.manage(SqliteThemePreferenceRepository::new(pool.clone()));
     app.manage(SqliteInstalledModsRepository::new(pool.clone()));
     app.manage(SqliteInstalledTilesetsRepository::new(pool.clone()));
+    app.manage(SqliteInstalledSoundpacksRepository::new(pool.clone()));
     app.manage(SqliteUsersRepository::new(pool));
 
     Ok(())

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -18,6 +18,8 @@ import type { Theme } from "@/generated-types/Theme";
 import type { ThemePreference } from "@/generated-types/ThemePreference";
 import type { Tileset } from "@/generated-types/Tileset";
 import type { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
+import type { Soundpack } from "@/generated-types/Soundpack";
+import type { SoundpackInstallationStatus } from "@/generated-types/SoundpackInstallationStatus";
 import type { UpdateStatus } from "@/generated-types/UpdateStatus";
 
 export async function listenToReleasesUpdate(
@@ -316,6 +318,49 @@ export async function uninstallThirdPartyTileset(
 ): Promise<void> {
   await invoke("uninstall_third_party_tileset_command", {
     id: tilesetId,
+    variant: variant,
+  });
+}
+
+export async function listAllSoundpacks(
+  variant: GameVariant,
+): Promise<Soundpack[]> {
+  const response = await invoke<Soundpack[]>("list_all_soundpacks_command", {
+    variant,
+  });
+  return response;
+}
+
+export async function installThirdPartySoundpack(
+  soundpackId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("install_third_party_soundpack_command", {
+    id: soundpackId,
+    variant,
+  });
+}
+
+export async function getThirdPartySoundpackInstallationStatus(
+  soundpackId: string,
+  variant: GameVariant,
+): Promise<SoundpackInstallationStatus> {
+  const response = await invoke<SoundpackInstallationStatus>(
+    "get_third_party_soundpack_installation_status_command",
+    {
+      id: soundpackId,
+      variant,
+    },
+  );
+  return response;
+}
+
+export async function uninstallThirdPartySoundpack(
+  soundpackId: string,
+  variant: GameVariant,
+): Promise<void> {
+  await invoke("uninstall_third_party_soundpack_command", {
+    id: soundpackId,
     variant: variant,
   });
 }

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -37,4 +37,10 @@ export const queryKeys = {
     installationStatus: (tilesetId: string, variant: GameVariant) =>
       ["tilesets", "installation_status", tilesetId, variant] as const,
   },
+
+  soundpacks: {
+    listAll: (variant: GameVariant) => ["soundpacks", variant] as const,
+    installationStatus: (soundpackId: string, variant: GameVariant) =>
+      ["soundpacks", "installation_status", soundpackId, variant] as const,
+  },
 };

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
@@ -1,0 +1,94 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { GameVariant } from "@/generated-types/GameVariant";
+import type { Soundpack } from "@/generated-types/Soundpack";
+import { toastCL } from "@/lib/utils";
+import {
+  useGetThirdPartySoundpackInstallationStatus,
+  useInstallThirdPartySoundpack,
+  useUninstallThirdPartySoundpack,
+} from "./hooks";
+
+interface SoundpackCardProps {
+  variant: GameVariant;
+  soundpack: Soundpack;
+}
+
+function getSoundpackName(soundpack: Soundpack): string {
+  return soundpack.content.name;
+}
+
+function getSoundpackType(soundpack: Soundpack): string {
+  return soundpack.type === "Stock" ? "Pre-Installed" : "Third-Party";
+}
+
+export default function SoundpackCard({ variant, soundpack }: SoundpackCardProps) {
+  const name = getSoundpackName(soundpack);
+  const soundpackType = getSoundpackType(soundpack);
+
+  const isThirdParty = soundpack.type !== "Stock";
+  const soundpackId = soundpack.content.id;
+
+  const { installationStatus } = useGetThirdPartySoundpackInstallationStatus(
+    soundpackId,
+    variant,
+  );
+
+  const isInstalled = installationStatus === "Installed";
+
+  const { isInstalling, install } = useInstallThirdPartySoundpack(
+    variant,
+    () => toastCL("success", "Soundpack installed successfully."),
+    (error) => toastCL("error", "Failed to install soundpack.", error),
+  );
+
+  const { isUninstalling, uninstall } = useUninstallThirdPartySoundpack(
+    variant,
+    () => toastCL("success", "Soundpack uninstalled successfully."),
+    (error) => toastCL("error", "Failed to uninstall soundpack.", error),
+  );
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex justify-between items-start">
+          <div className="flex-1">
+            <CardTitle>{name}</CardTitle>
+            <div className="flex gap-2 mt-2">
+              <Badge variant="secondary">{soundpackType}</Badge>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {isThirdParty && (
+        <CardFooter className="flex flex-col gap-4 items-stretch">
+          {isInstalled ? (
+            <Button
+              className="w-full"
+              variant="destructive"
+              onClick={() => uninstall(soundpackId)}
+              disabled={isUninstalling}
+            >
+              {isUninstalling ? "Uninstalling..." : "Uninstall"}
+            </Button>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={() => install(soundpackId)}
+              disabled={isInstalling}
+            >
+              {isInstalling ? "Installing..." : "Install"}
+            </Button>
+          )}
+        </CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { toastCL } from "@/lib/utils";
+import SoundpackCard from "./SoundpackCard";
+import { useListAllSoundpacks } from "./hooks";
+
+interface SoundpacksListProps {
+  variant: GameVariant;
+}
+
+export default function SoundpacksList({ variant }: SoundpacksListProps) {
+  const {
+    soundpacks,
+    isLoading,
+    error,
+  } = useListAllSoundpacks(variant);
+
+  useEffect(() => {
+    if (error) {
+      toastCL("error", "Failed to load soundpacks.", error);
+    }
+  }, [error]);
+
+  if (isLoading) {
+    return <p className="text-muted-foreground">Loading soundpacks...</p>;
+  }
+
+  if (!soundpacks || soundpacks.length === 0) {
+    return <p className="text-muted-foreground">No soundpacks available.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {soundpacks.map((soundpack) => (
+        <SoundpackCard
+          key={`${variant}-${soundpack.content.id}`}
+          variant={variant}
+          soundpack={soundpack}
+        />
+      ))}
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/SoundpacksPage/hooks.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import {
+  getThirdPartySoundpackInstallationStatus,
+  installThirdPartySoundpack,
+  listAllSoundpacks,
+  uninstallThirdPartySoundpack,
+} from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useInstallThirdPartySoundpack(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (soundpackId: string) => installThirdPartySoundpack(soundpackId, variant),
+    onSuccess: (_data, soundpackId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.soundpacks.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.soundpacks.installationStatus(soundpackId, variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isInstalling: mutation.isPending,
+    install: (soundpackId: string) => mutation.mutate(soundpackId),
+  };
+}
+
+export function useGetThirdPartySoundpackInstallationStatus(
+  soundpackId: string,
+  variant: GameVariant,
+) {
+  const query = useQuery({
+    queryKey: queryKeys.soundpacks.installationStatus(soundpackId, variant),
+    queryFn: () => getThirdPartySoundpackInstallationStatus(soundpackId, variant),
+  });
+
+  return {
+    installationStatus: query.data,
+    isLoading: query.isLoading,
+  };
+}
+
+export function useUninstallThirdPartySoundpack(
+  variant: GameVariant,
+  onSuccess?: () => void,
+  onError?: (error: unknown) => void,
+) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (soundpackId: string) => uninstallThirdPartySoundpack(soundpackId, variant),
+    onSuccess: (_data, soundpackId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.soundpacks.listAll(variant),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.soundpacks.installationStatus(soundpackId, variant),
+      });
+      onSuccess?.();
+    },
+    onError,
+  });
+
+  return {
+    isUninstalling: mutation.isPending,
+    uninstall: (soundpackId: string) => mutation.mutate(soundpackId),
+  };
+}
+
+export function useListAllSoundpacks(variant: GameVariant) {
+    const query = useQuery({
+        queryKey: queryKeys.soundpacks.listAll(variant),
+        queryFn: () => listAllSoundpacks(variant),
+    });
+
+    return {
+        soundpacks: query.data,
+        isLoading: query.isLoading,
+        error: query.error,
+    };
+}

--- a/cat-launcher/src/pages/SoundpacksPage/index.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/index.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+import VariantSelector from "@/components/VariantSelector";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { useGameVariants } from "@/hooks/useGameVariants";
+import SoundpacksList from "./SoundpacksList";
+
+function SoundpacksPage() {
+  const { gameVariants, isLoading: gameVariantsLoading } = useGameVariants();
+  const [selectedVariant, setSelectedVariant] = useState<GameVariant | null>(
+    null,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <VariantSelector
+        gameVariants={gameVariants}
+        selectedVariant={selectedVariant}
+        onVariantChange={setSelectedVariant}
+        isLoading={gameVariantsLoading}
+      />
+      {selectedVariant && <SoundpacksList variant={selectedVariant} />}
+    </div>
+  );
+}
+
+export default SoundpacksPage;

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -3,7 +3,8 @@ import BackupsPage from "@/pages/BackupsPage";
 import ModsPage from "@/pages/ModsPage";
 import PlayPage from "@/pages/PlayPage";
 import TilesetsPage from "@/pages/TilesetsPage";
-import { FileUp, Gamepad2, Info, Package, Palette } from "lucide-react";
+import { FileUp, Gamepad2, Info, Package, Palette, Drum } from "lucide-react";
+import SoundpacksPage from "@/pages/SoundpacksPage";
 
 export const routes = [
   {
@@ -23,6 +24,12 @@ export const routes = [
     element: <ModsPage />,
     label: "Mods",
     icon: Package,
+  },
+  {
+    path: "/soundpacks",
+    element: <SoundpacksPage />,
+    label: "Soundpacks",
+    icon: Drum,
   },
   {
     path: "/tilesets",


### PR DESCRIPTION
### **User description**
Add Rust types for soundpacks and implement Tauri command handlers
for listing, installing and uninstalling third-party soundpacks.

- Introduce serializable Soundpack-related types (Stock, ThirdParty,
  Installation, Activity) with TS bindings for TypeScript interop.
- Add Soundpack and SoundpackInstallationStatus enums with serde tagging
  and ts export annotations.
- Implement Tauri commands:
  - list_all_soundpacks_command: fetches app/resource dirs, detects OS,
    and returns available soundpacks via list_all_soundpacks.
  - install_third_party_soundpack_command: retrieves local, resource,
    and cache dirs, resolves OS, and delegates to installer using the
    Downloader and repository state.
  - uninstall_third_party_soundpack_command: wraps uninstall logic and
    maps errors into command-level error types.
- Define detailed error enums for each command with serialization via
  CommandErrorSerialize and conversion from underlying errors.

These changes enable backend soundpack management and expose them to the
frontend via Tauri commands, improving integration between the Rust
core and the TypeScript UI.


___

### **PR Type**
Enhancement


___

### **Description**
- Add complete soundpack management system with Tauri commands for listing, installing, and uninstalling soundpacks

- Implement Rust types and SQLite repository for tracking installed third-party soundpacks

- Create React hooks and UI components for soundpack discovery and management

- Add soundpacks database table and JSON configuration file with soundpack metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Soundpacks JSON<br/>Configuration"] -->|"Read metadata"| B["List Soundpacks<br/>Command"]
  B -->|"Return stock +<br/>third-party"| C["Frontend<br/>SoundpacksList"]
  C -->|"Display cards"| D["SoundpackCard<br/>Component"]
  D -->|"Install/Uninstall"| E["Install/Uninstall<br/>Commands"]
  E -->|"Download & Extract"| F["Downloader<br/>Archive Utils"]
  E -->|"Track installation"| G["SQLite<br/>Repository"]
  G -->|"Query status"| H["Installation Status<br/>Command"]
  H -->|"Return status"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Register soundpacks module and Tauri commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Implement four Tauri command handlers for soundpack operations</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-5ece8690da78bf84cfa0edf37d3259ffff61a21e459c046ecaea6b4250b7077b">+135/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Define serializable soundpack types with TypeScript bindings</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-2736c9dcb61fcbb6b5e2a6397bb0049f8e7f79e82dcebcbd9a04bf9cc098d7c0">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_all_soundpacks.rs</strong><dd><code>List stock and third-party soundpacks from resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-6e73224644cb6289040295da04f3f4fc5b687f062b2f106c6b7ce587cd851718">+178/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>install_third_party_soundpack.rs</strong><dd><code>Download, extract, and install third-party soundpacks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-20976970524dda3a782c99f8f155c6f5f09b98b7946fccd87d799a35b2142780">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>uninstall_third_party_soundpack.rs</strong><dd><code>Remove installed soundpacks and update repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-6103ec82110ac9411d38aee3dd8c6be3231b3de9d8ffca610b8bccd56d180122">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_third_party_soundpack_installation_status.rs</strong><dd><code>Check if soundpack is installed for variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-b4900e5da6763eb33b474c3081e3271d1d963f34bc235351f206d2cc4a708743">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paths.rs</strong><dd><code>Utility functions for soundpack directory paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-e420d38145ebce7e1c3f7e58768dc6d5db16e6865f75a4cc9d16c7091c0b6ace">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Module declarations for soundpacks subsystem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-8f7bb8e917f429e887b2f5fba1ca9a6124015f37ebbb0bdb45a74342f852a8e0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installed_soundpacks_repository.rs</strong><dd><code>Define trait for installed soundpacks repository operations</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-8d46fa1b3b2f17485655839f28385af7ad14ebd88e41d79deb1d0db78a5b3c5a">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_installed_soundpacks_repository.rs</strong><dd><code>SQLite implementation of installed soundpacks repository</code>&nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-b7282ba12be6341002be2cf5acbb64fa7917e80630a67764457b501519e0034f">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Register SQLite soundpacks repository in dependency injection</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-b3ee322098b457e66256bbc93ebafa48258bb7677544ec6ff974981ea1915719">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Add installed_soundpacks table to track installations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Add TypeScript command wrappers for soundpack operations</code>&nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add React Query keys for soundpack queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hooks.ts</strong><dd><code>React hooks for soundpack installation and status queries</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-ccc9dbeb425a08de3c77580018f2ccc765ea139dfe4d7b626d04b37ac3485040">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SoundpackCard.tsx</strong><dd><code>UI component displaying individual soundpack with install/uninstall</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-b11994dc89075c9a1bc4ec2bccd764c4a2ca58ff24e2fba6284f94e4ffaf2973">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SoundpacksList.tsx</strong><dd><code>Grid layout component listing all soundpacks for variant</code>&nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-7b576da67c599b388f2bcdc20d567bb445eb9cb9cdcbf9aaf2a68bd8a3c27507">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Main soundpacks page with variant selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-94b03b5d2c4ff9357f3d200b8a9ae02c9b099e5df4f4fccd70d7722e95220f7f">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routes.tsx</strong><dd><code>Add soundpacks route and navigation icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-1e5bca5f2ad612aadcc10f3c1749eeb1094085f3e49863d6bef96bd632673277">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>soundpacks.json</strong><dd><code>Configuration file with third-party soundpack metadata</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-8309b5368ff4f49fe02e75b6770616d09839160dd13235a28a9841b73d244024">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/255/files#diff-55b5ee7756d660b655c0053880ecdc9bf93aa526f45299636348dc3712f09d94">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___













<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add backend and UI support for soundpacks. You can list stock and third‑party packs, install/uninstall third‑party packs, and see installation status in the app.

- **New Features**
  - Backend: added soundpack types with TS bindings and a soundpacks.json catalog.
  - Tauri commands: list, install, uninstall, and check installation status.
  - Persistence: SQLite repository and installed_soundpacks table to track installs.

- **UI Improvements**
  - New Soundpacks page to browse packs with install/uninstall actions and status.
  - Added commands.ts bindings and React Query hooks for listing, install/uninstall, and status updates.

<sup>Written for commit d805e8c206306bffbd40708f4549ee41b3cbc9de. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











