### PR TITLE
fix: use app_local_data_dir for app data path

### DIFF
--- a/cat-launcher/src-tauri/src/mods/commands.rs
+++ b/cat-launcher/src-tauri/src/mods/commands.rs
@@ -38,7 +38,7 @@ pub async fn list_all_mods_command(
     app: tauri::AppHandle,
     active_release_repository: State<'_, SqliteActiveReleaseRepository>,
 ) -> Result<Vec<Mod>, ListAllModsCommandError> {
-    let data_dir = app.path().app_data_dir()?;
+    let data_dir = app.path().app_local_data_dir()?;
     let resource_dir = app.path().resource_dir()?;
 
     let os = get_os_enum(OS)?;


### PR DESCRIPTION
### **User description**
Change the data directory lookup in the list-all-mods command from
app_data_dir to app_local_data_dir. This ensures the application reads
and writes mod data from the local per-user application data location
expected on modern platforms and by Tauri, avoiding potential issues
with non-writable or legacy global app data directories.

This change fixes incorrect path resolution when listing mods and
aligns behavior with application-local storage conventions.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `app_data_dir()` with `app_local_data_dir()` in list-all-mods command

- Ensures mod data reads from local per-user application directory

- Aligns with Tauri conventions and modern platform expectations

- Avoids issues with non-writable or legacy global directories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["list_all_mods_command"] -- "data directory lookup" --> B["app_local_data_dir"]
  B -- "returns" --> C["Local per-user app data"]
  C -- "avoids" --> D["Non-writable global directories"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Replace app_data_dir with app_local_data_dir</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/mods/commands.rs

<ul><li>Changed <code>app.path().app_data_dir()</code> to <code>app.path().app_local_data_dir()</code> <br>in <code>list_all_mods_command</code> function<br> <li> Ensures mod data is read from local per-user application data location<br> <li> Aligns with Tauri framework conventions and modern platform storage <br>expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/256/files#diff-891589ba1757a05e0a9d08c9f8ca50ddba5f0b0cc33c33eaf54fc8096b171978">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched list-all-mods to use app_local_data_dir for resolving the mod data path. This reads from the per-user local app directory, fixing path issues on systems with non-writable global dirs and aligning with Tauri defaults.

<sup>Written for commit 85557f2c1980da73125c6fa285e192fdba3137e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

