### PR TITLE
feat(search): add shared search hook and integrate into pages

### DIFF
--- a/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 
+import { SearchInput } from "@/components/SearchInput";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { toastCL } from "@/lib/utils";
 import SoundpackCard from "./SoundpackCard";
 import { useListAllSoundpacks } from "./hooks";
+import { useSearch } from "@/hooks/useSearch";
 
 interface SoundpacksListProps {
   variant: GameVariant;
@@ -14,6 +16,20 @@ export default function SoundpacksList({
 }: SoundpacksListProps) {
   const { soundpacks, isLoading, error } =
     useListAllSoundpacks(variant);
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    filteredItems: filteredSoundpacks,
+    hasActiveSearch,
+  } = useSearch(soundpacks || [], {
+    searchFn: (soundpack, query) => {
+      return (
+        soundpack.content.name.toLowerCase().includes(query) ||
+        soundpack.content.id.toLowerCase().includes(query)
+      );
+    },
+  });
 
   useEffect(() => {
     if (error) {
@@ -27,23 +43,31 @@ export default function SoundpacksList({
     );
   }
 
-  if (!soundpacks || soundpacks.length === 0) {
-    return (
-      <p className="text-muted-foreground">
-        No soundpacks available.
-      </p>
-    );
-  }
-
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {soundpacks.map((soundpack) => (
-        <SoundpackCard
-          key={`${variant}-${soundpack.content.id}`}
-          variant={variant}
-          soundpack={soundpack}
-        />
-      ))}
+    <div className="flex flex-col gap-4">
+      <SearchInput
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder="Search soundpacks..."
+        className="mb-4 mt-2"
+      />
+      {!filteredSoundpacks || filteredSoundpacks.length === 0 ? (
+        <p className="text-muted-foreground">
+          {hasActiveSearch
+            ? "No soundpacks match your search."
+            : "No soundpacks available."}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredSoundpacks.map((soundpack) => (
+            <SoundpackCard
+              key={`${variant}-${soundpack.content.id}`}
+              variant={variant}
+              soundpack={soundpack}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 
+import { SearchInput } from "@/components/SearchInput";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { toastCL } from "@/lib/utils";
 import TilesetCard from "./TilesetCard";
 import { useListAllTilesets } from "./hooks";
+import { useSearch } from "@/hooks/useSearch";
 
 interface TilesetsListProps {
   variant: GameVariant;
@@ -11,6 +13,20 @@ interface TilesetsListProps {
 
 export default function TilesetsList({ variant }: TilesetsListProps) {
   const { tilesets, isLoading, error } = useListAllTilesets(variant);
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    filteredItems: filteredTilesets,
+    hasActiveSearch,
+  } = useSearch(tilesets || [], {
+    searchFn: (tileset, query) => {
+      return (
+        tileset.content.name.toLowerCase().includes(query) ||
+        tileset.content.id.toLowerCase().includes(query)
+      );
+    },
+  });
 
   useEffect(() => {
     if (error) {
@@ -24,21 +40,31 @@ export default function TilesetsList({ variant }: TilesetsListProps) {
     );
   }
 
-  if (!tilesets || tilesets.length === 0) {
-    return (
-      <p className="text-muted-foreground">No tilesets available.</p>
-    );
-  }
-
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {tilesets.map((tileset) => (
-        <TilesetCard
-          key={`${variant}-${tileset.content.id}`}
-          variant={variant}
-          tileset={tileset}
-        />
-      ))}
+    <div className="flex flex-col gap-4">
+      <SearchInput
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder="Search tilesets..."
+        className="mb-4 mt-2"
+      />
+      {!filteredTilesets || filteredTilesets.length === 0 ? (
+        <p className="text-muted-foreground">
+          {hasActiveSearch
+            ? "No tilesets match your search."
+            : "No tilesets available."}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredTilesets.map((tileset) => (
+            <TilesetCard
+              key={`${variant}-${tileset.content.id}`}
+              variant={variant}
+              tileset={tileset}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### **User description**
Introduce a reusable useSearch hook and wire it into Mods and
Tilesets pages to provide client-side filtering and a search input.

- Add SearchInput and useSearch usage to ModsPage, exposing search
  state and debounce behavior at page level.
- Update ModsList to accept searchInput and setSearchInput props,
  use useSearch to filter mods, and show contextual empty messages
  ("No mods match your search." vs "No mods available.").
- Apply same pattern to TilesetsList: accept search props, filter
  tilesets with useSearch, and show contextual empty messages.
- Implement searchFn callbacks that match name, id, and description
  (for mods) or name and id (for tilesets), normalizing query to
  lowercase and trimmed string.
- Preserve existing loading/error handling; keep keys and layout.

This adds user-facing search with debouncing and consistent UX when
no results are found.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor `useSearch` hook to support external state management
  - Remove `SearchableItem` interface constraint for generic flexibility
  - Add optional `searchInput` and `setSearchInput` props for controlled components
  - Remove default search function; require explicit `searchFn` implementation

- Integrate search functionality across four content pages
  - ModsPage, SoundpacksPage, TilesetsPage, BackupsPage now include SearchInput component
  - Each page passes search state to child list components via props

- Implement contextual empty state messages
  - Display "No [items] match your search." when search is active with no results
  - Display "No [items] available." when no items exist or search is inactive

- Add custom search functions for each content type
  - Mods: search by name, id, and description
  - Soundpacks and Tilesets: search by name and id
  - Backups: search by name, notes, and timestamp


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useSearch Hook<br/>Generic & Flexible"] -->|"Controlled State"| B["ModsPage<br/>SoundpacksPage<br/>TilesetsPage<br/>BackupsPage"]
  B -->|"Pass searchInput<br/>& setSearchInput"| C["ModsList<br/>SoundpacksList<br/>TilesetsList<br/>BackupsTable"]
  C -->|"Filter & Display<br/>Contextual Messages"| D["Filtered Results<br/>with Empty States"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSearch.ts</strong><dd><code>Make useSearch generic and support controlled state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useSearch.ts

<ul><li>Remove <code>SearchableItem</code> interface constraint; make hook fully generic <br>with <code><T></code><br> <li> Add optional <code>searchInput</code> and <code>setSearchInput</code> props for controlled <br>component pattern<br> <li> Support both internal state (when props undefined) and external state <br>management<br> <li> Remove <code>defaultSearchFn</code>; require explicit <code>searchFn</code> in options<br> <li> Simplify filtering logic to check for <code>searchFn</code> existence before <br>filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-59586a046e11e00105df2e4c0884b21899d55ba7e218bb63e16cbf9a83cef659">+22/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add search input and state to ModsPage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/index.tsx

<ul><li>Import <code>SearchInput</code> component and <code>useSearch</code> hook<br> <li> Initialize <code>useSearch</code> hook at page level with empty items array<br> <li> Add <code>SearchInput</code> component with search state management<br> <li> Pass <code>searchInput</code> and <code>setSearchInput</code> props to <code>ModsList</code> component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-e04f974b64b56ae6669d5b3e4a55fa068fdcc35f180eacc0552c2873e5c866f0">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModsList.tsx</strong><dd><code>Integrate search filtering into ModsList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/ModsList.tsx

<ul><li>Add <code>searchInput</code> and <code>setSearchInput</code> props to component interface<br> <li> Implement <code>useSearch</code> hook with custom search function for mods<br> <li> Search across mod name, id, and description fields<br> <li> Update empty state message to show contextual text based on active <br>search<br> <li> Filter rendered mods using <code>filteredMods</code> from hook</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-eeaddda99ed7f83376c48918b821c922a74200573114d3f045f1d4eebb820508">+31/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add search input and state to SoundpacksPage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SoundpacksPage/index.tsx

<ul><li>Import <code>SearchInput</code> component and <code>useSearch</code> hook<br> <li> Initialize <code>useSearch</code> hook at page level with empty items array<br> <li> Add <code>SearchInput</code> component with search state management<br> <li> Pass <code>searchInput</code> and <code>setSearchInput</code> props to <code>SoundpacksList</code> component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-94b03b5d2c4ff9357f3d200b8a9ae02c9b099e5df4f4fccd70d7722e95220f7f">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SoundpacksList.tsx</strong><dd><code>Integrate search filtering into SoundpacksList component</code>&nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx

<ul><li>Add <code>searchInput</code> and <code>setSearchInput</code> props to component interface<br> <li> Implement <code>useSearch</code> hook with custom search function for soundpacks<br> <li> Search across soundpack name and id fields<br> <li> Update empty state message to show contextual text based on active <br>search<br> <li> Filter rendered soundpacks using <code>filteredSoundpacks</code> from hook</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-7b576da67c599b388f2bcdc20d567bb445eb9cb9cdcbf9aaf2a68bd8a3c27507">+23/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add search input and state to TilesetsPage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/TilesetsPage/index.tsx

<ul><li>Import <code>SearchInput</code> component and <code>useSearch</code> hook<br> <li> Initialize <code>useSearch</code> hook at page level with empty items array<br> <li> Add <code>SearchInput</code> component with search state management<br> <li> Pass <code>searchInput</code> and <code>setSearchInput</code> props to <code>TilesetsList</code> component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-429e4544aa9290b4589a7095438828e47029ce6721e52226e3eb6596a41dfe1b">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TilesetsList.tsx</strong><dd><code>Integrate search filtering into TilesetsList component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx

<ul><li>Add <code>searchInput</code> and <code>setSearchInput</code> props to component interface<br> <li> Implement <code>useSearch</code> hook with custom search function for tilesets<br> <li> Search across tileset name and id fields<br> <li> Update empty state message to show contextual text based on active <br>search<br> <li> Filter rendered tilesets using <code>filteredTilesets</code> from hook</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-11122e82d20401f805b19a8317329d7a3a255978db42df5ce57db9c633dd1c76">+28/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add search functionality to BackupsPage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/BackupsPage/index.tsx

<ul><li>Import <code>SearchInput</code> component and <code>useSearch</code> hook<br> <li> Implement <code>useSearch</code> hook with custom search function for backups<br> <li> Search across backup name, notes, and timestamp fields<br> <li> Add <code>SearchInput</code> component to page UI<br> <li> Chain search results with existing filter logic using <code>useMemo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/260/files#diff-21a1a501016807e7346ac1c2c6e9ccc1583b7f36e4571c5345e4981374da40e8">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared useSearch hook and debounced client-side search across Mods, Tilesets, Soundpacks, and Backups. Users can quickly filter lists and see contextual empty states.

- **New Features**
  - Reusable useSearch with debounce; requires an explicit searchFn per type.
  - SearchInput added to Mods/Tilesets/Soundpacks lists and the Backups page; lists filter client-side.
  - Fields matched:
    - Mods: name, id, description.
    - Tilesets/Soundpacks: name, id.
    - Backups: name, notes, formatted timestamp.
  - Contextual empty messages when no results; existing loading/error handling preserved.

<sup>Written for commit de205973d39ee03751e6002ce14c43a047074fd1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







