### PR TITLE
chore(re): bump version to 0.9.0

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.9.0",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cat-macros",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.8.1"
+version = "0.9.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
### **User description**
Update project version from 0.8.1 to 0.9.0 across Tauri and package
manifests. Change versions in:
- src-tauri/Cargo.toml
- src-tauri/Cargo.lock
- src-tauri/tauri.conf.json
- package.json

This the repository for the 0.9.0 release and keeps Rust,
Tauri and frontend metadata in sync.


___

### **PR Type**
Other


___

### **Description**
- Bump project version from 0.8.1 to 0.9.0

- Update version across package.json, Cargo.toml, and tauri.conf.json

- Synchronize Rust, Tauri, and frontend metadata versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 0.8.1"] -- "Update to" --> B["Version 0.9.0"]
  B --> C["package.json"]
  B --> D["Cargo.toml"]
  B --> E["tauri.conf.json"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update npm package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/package.json

- Update version field from 0.8.1 to 0.9.0


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/275/files#diff-0f82b8d2b9f21dbc61745f560e387f5e77c43354f5107fcb2547d156eded0f24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update Rust package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/Cargo.toml

- Update version field from 0.8.1 to 0.9.0


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/275/files#diff-2b3d88798673dc02d1dc670095173dd88479151362c6e11fab9cbc66502c2f29">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Update Tauri app version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/tauri.conf.json

- Update version field from 0.8.1 to 0.9.0


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/275/files#diff-a129d0a394e29d198f60425580a5ef2de79dfc1717a9252f1190ec4618cfb0db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped project version from 0.8.1 to 0.9.0 across Tauri and frontend manifests to prepare the 0.9.0 release and keep metadata in sync. Updated version in package.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock, and src-tauri/tauri.conf.json.

<sup>Written for commit 3499eb6b683a4cf83d58f6dd61bf8ae13c20d0d7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

