### PR TITLE
feat(mods): add many new DarkDaysAhead & BrightNights mods

### DIFF
--- a/cat-launcher/src-tauri/content/mods.json
+++ b/cat-launcher/src-tauri/content/mods.json
@@ -1,22 +1,162 @@
 {
   "DarkDaysAhead": {
-    "xedra_evolved_innawoods": {
-      "id": "xedra_evolved_innawoods",
-      "name": "XedraWood: Stone and Sorcery",
-      "description": "Better blending for Xedra Evolved and Innawoods.  Also forms the core for a number of optional supplemental mods.",
+    "Arcana": {
+      "id": "Arcana",
+      "name": "Arcana and Magic Items",
+      "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
       "category": "content",
       "installation": {
-        "download_url": "https://github.com/Standing-Storm/ccda-xedra-evolved-innawoods/archive/refs/heads/main.zip",
-        "modinfo": "ccda-xedra-evolved-innawoods-main/modinfo.json"
+        "download_url": "https://github.com/chaosvolt/cdda-arcana-mod/archive/refs/heads/master.zip",
+        "modinfo": "cdda-arcana-mod-master/Arcana/modinfo.json"
       },
       "activity": {
         "activity_type": "github_commit",
-        "github": "https://github.com/Standing-Storm/ccda-xedra-evolved-innawoods"
+        "github": "https://github.com/chaosvolt/cdda-arcana-mod"
+      }
+    },
+    "Cata++": {
+      "id": "Cata++",
+      "name": "Cataclysm++",
+      "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.\n\nThe gigantic jabberwock of a mod that adds a lot of content to the game: new items, buildings, scenarios, monsters, etc. It also reworks and adds alternatives to many things from recipes to scenarios. It also adds a pseudo-story and lore on the works.\n\nThe Bio-Weapon, Super Soldier, Commandeers, Slave Fighters and the Old World Prepper NPC factions join the world.\n\nSeek the Bio-weapons, find loot, take down new monsters and invest in skills for new craftable items.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/refs/heads/master.zip",
+        "modinfo": "nocts_cata_mod-master/nocts_cata_mod_DDA/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod"
+      }
+    },
+    "fallout_rework": {
+      "id": "fallout_rework",
+      "name": "Fallout New England Remastered",
+      "description": "Brings a little bit of that retro-futuristic class to the Cataclysm. Guns, beasts, and more. Stuff from the Core Region, all the way to the Commonwealth. Remade from scratch.",
+      "category": "items",
+      "installation": {
+        "download_url": "https://github.com/Tefnut/Fallout-New-England-Remastered/archive/refs/heads/main.zip",
+        "modinfo": "Fallout-New-England-Remastered-main/FNE-Remastered/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Tefnut/Fallout-New-England-Remastered"
+      }
+    },
+    "Dorf_Life": {
+      "id": "Dorf_Life",
+      "name": "Dorf Life",
+      "description": "Adds multi-level caverns hidden away in the underground, breaching the subways to add various strange sights to explore.",
+      "category": "buildings",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/Dorf-Life-CDDA/archive/refs/heads/master.zip",
+        "modinfo": "Dorf-Life-CDDA-master/Dorf_Life/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/Dorf-Life-CDDA"
+      }
+    },
+    "MST_Extra": {
+      "id": "MST_Extra",
+      "name": "MST Extra",
+      "description": "The sequel to CDDA's old More Survival Tools mod, adding additional useful innawoods content.",
+      "category": "items",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/MST_Extra_Mod/archive/refs/heads/master.zip",
+        "modinfo": "MST_Extra_Mod-master/MST_Extra/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/MST_Extra_Mod"
+      }
+    },
+    "Tankmod_Revived": {
+      "id": "Tankmod_Revived",
+      "name": "Tankmod: Revived",
+      "description": "The intended successor of my older, obsoleted Tanks and Other Vehicles mod.",
+      "category": "vehicles",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/cdda-tankmod-revived-mod/archive/refs/heads/master.zip",
+        "modinfo": "cdda-tankmod-revived-mod-master/Tankmod_Revived/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/cdda-tankmod-revived-mod"
       }
     }
   },
 
   "BrightNights": {
+    "Arcana": {
+      "id": "Arcana",
+      "name": "Arcana and Magic Items",
+      "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/cdda-arcana-mod/archive/refs/heads/master.zip",
+        "modinfo": "cdda-arcana-mod-master/Arcana_BN/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/cdda-arcana-mod"
+      }
+    },
+    "Cata++": {
+      "id": "Cata++",
+      "name": "Cataclysm++",
+      "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.\n\nThe gigantic jabberwock of a mod that adds a lot of content to the game: new items, buildings, scenarios, monsters, etc. It also reworks and adds alternatives to many things from recipes to scenarios. It also adds a pseudo-story and lore on the works.\n\nThe Bio-Weapon, Super Soldier, Commandeers, Slave Fighters and the Old World Prepper NPC factions join the world.\n\nSeek the Bio-weapons, find loot, take down new monsters and invest in skills for new craftable items.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/refs/heads/master.zip",
+        "modinfo": "nocts_cata_mod-master/nocts_cata_mod_BN/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod"
+      }
+    },
+    "Dorf_Life": {
+      "id": "Dorf_Life",
+      "name": "Dorf Life",
+      "description": "Adds multi-level caverns hidden away in the underground, breaching the subways to add various strange sights to explore.",
+      "category": "buildings",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/Dorf-Life-CDDA/archive/refs/heads/master.zip",
+        "modinfo": "Dorf-Life-CDDA-master/Dorf_Life_BN/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/Dorf-Life-CDDA"
+      }
+    },
+    "fallout_combined": {
+      "id": "fallout_combined",
+      "name": "Fallout: New England Combined",
+      "description": "Brings the retro-futuristic feel of Fallout series to the Cataclysm. Guns, factions, monsters, craftable items, mutations, food, drinks, locations and even more. Stuff from the Core Region, all the way to the Commonwealth. Fusion of the two fallout mods by tefnut and Jolmar7.",
+      "category": "content",
+      "installation": {
+        "download_url": "https://github.com/WarriorKingBob/Fallout_BrightNights/archive/refs/heads/main.zip",
+        "modinfo": "Fallout_BrightNights-main/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/WarriorKingBob/Fallout_BrightNights"
+      }
+    },
+    "MST_Extra": {
+      "id": "MST_Extra",
+      "name": "MST Extra",
+      "description": "The sequel to CDDA's old More Survival Tools mod, adding additional useful innawoods content.",
+      "category": "items",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/MST_Extra_Mod/archive/refs/heads/master.zip",
+        "modinfo": "MST_Extra_Mod-master/MST_Extra_BN/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/MST_Extra_Mod"
+      }
+    },
     "realdarkskies": {
       "id": "realdarkskies",
       "name": "Really Dark Skies",
@@ -30,10 +170,38 @@
         "activity_type": "github_commit",
         "github": "https://github.com/Zlorthishen/Really_Dark_Skies"
       }
+    },
+    "Tankmod_Revived": {
+      "id": "Tankmod_Revived",
+      "name": "Tankmod: Revived",
+      "description": "The intended successor of my older, obsoleted Tanks and Other Vehicles mod.",
+      "category": "vehicles",
+      "installation": {
+        "download_url": "https://github.com/chaosvolt/cdda-tankmod-revived-mod/archive/refs/heads/master.zip",
+        "modinfo": "cdda-tankmod-revived-mod-master/Tankmod_Revived_BN/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chaosvolt/cdda-tankmod-revived-mod"
+      }
     }
   },
 
   "TheLastGeneration": {
+    "bionics_expanded": {
+      "id": "bionics_expanded",
+      "name": "Bionics Expanded",
+      "description": "A collection of various (hopefully) interesting CBMs.",
+      "category": "misc_additions",
+      "installation": {
+        "download_url": "https://github.com/Vegetabs/BionicsExpanded-CTLG/archive/refs/heads/main.zip",
+        "modinfo": "BionicsExpanded-CTLG-main/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Vegetabs/BionicsExpanded-CTLG"
+      }
+    },
     "mindovermatter": {
       "id": "mindovermatter",
       "name": "Mind Over Matter",
@@ -46,6 +214,20 @@
       "activity": {
         "activity_type": "github_commit",
         "github": "https://github.com/Vegetabs/MindOverMatter-CTLG"
+      }
+    },
+    "MMA": {
+      "id": "MMA",
+      "name": "Mythical Martial Arts",
+      "description": "A collection of fictional, mythologically inspired or otherwise unrealistic martial arts.",
+      "category": "misc_additions",
+      "installation": {
+        "download_url": "https://github.com/Vegetabs/MythicalMartialArts-CTLG/archive/refs/heads/main.zip",
+        "modinfo": "MythicalMartialArts-CTLG-main/modinfo.json"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/Vegetabs/MythicalMartialArts-CTLG"
       }
     }
   }


### PR DESCRIPTION
### **User description**
Add multiple new mod entries to content/mods.json under the
DarkDaysAhead and BrightNights groups and replace a previous
xedra_evolved_innawoods entry with a curated collection of mods.

Major changes:
- Replace xedra_evolved_innawoods with Arcana mod and metadata,
  including download URL, modinfo path, and GitHub activity link.
- Add new DarkDaysAhead mods: Cata++, fallout_rework, Dorf_Life,
  MST_Extra, and Tankmod_Revived with categories, installation
  URLs, modinfo paths, and activity metadata.
- Mirror Arcana entry into BrightNights group (partial diff shown).

Why:
- Expand the launcher mod catalog for Dark Days Ahead and BrightNights
  with popular community mods and correct installation metadata so
  the launcher can download, install, and track activity for them.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace xedra_evolved_innawoods with Arcana mod in DarkDaysAhead

- Add 5 new DarkDaysAhead mods: Cata++, fallout_rework, Dorf_Life, MST_Extra, Tankmod_Revived

- Add 6 new BrightNights mods: Arcana, Cata++, Dorf_Life, fallout_combined, MST_Extra, Tankmod_Revived

- Add 2 new TheLastGeneration mods: bionics_expanded, MMA

- Update realdarkskies description formatting in BrightNights


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mods.json"] -->|Replace| B["xedra_evolved_innawoods"]
  A -->|Add to DarkDaysAhead| C["5 new mods"]
  A -->|Add to BrightNights| D["6 new mods"]
  A -->|Add to TheLastGeneration| E["2 new mods"]
  C --> F["Arcana, Cata++, fallout_rework, Dorf_Life, MST_Extra, Tankmod_Revived"]
  D --> G["Arcana, Cata++, Dorf_Life, fallout_combined, MST_Extra, Tankmod_Revived"]
  E --> H["bionics_expanded, MMA"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mods.json</strong><dd><code>Expand mod catalog across all game variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/content/mods.json

<ul><li>Replaced <code>xedra_evolved_innawoods</code> with <code>Arcana</code> mod in DarkDaysAhead <br>group<br> <li> Added 5 new mods to DarkDaysAhead: Cata++, fallout_rework, Dorf_Life, <br>MST_Extra, Tankmod_Revived<br> <li> Added 6 new mods to BrightNights: Arcana, Cata++, Dorf_Life, <br>fallout_combined, MST_Extra, Tankmod_Revived<br> <li> Added 2 new mods to TheLastGeneration: bionics_expanded, MMA<br> <li> Updated realdarkskies description formatting with color tags and line <br>breaks</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/279/files#diff-a00e7302e49b649209c2edec325ce483f4ff97dba2bd8f3d1cb28d94d3f16dae">+190/-8</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the launcher mod catalog with popular DarkDaysAhead and BrightNights mods, and replace xedra_evolved_innawoods with Arcana for better metadata and install support. Updates content/mods.json so the launcher can download, install, and track activity for these mods.

- **New Features**
  - Replace xedra_evolved_innawoods with Arcana (DDA + BN).
  - DarkDaysAhead additions: Cata++, Fallout New England Remastered, Dorf Life, MST Extra, Tankmod: Revived.
  - BrightNights additions: Arcana, Cata++, Dorf Life, Fallout: New England Combined, MST Extra, Tankmod: Revived.
  - TheLastGeneration additions: Bionics Expanded, Mythical Martial Arts, Mind Over Matter. All entries include category, download URL, modinfo path, and GitHub activity metadata.

<sup>Written for commit ff448dee5761bdebbf65c1680b4d5b701ac0edac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





