### PR TITLE
refactor: remove UnDeadPeople tileset entries from tilesets.json

### DIFF
--- a/cat-launcher/src-tauri/content/tilesets.json
+++ b/cat-launcher/src-tauri/content/tilesets.json
@@ -1,46 +1,5 @@
 {
-  "DarkDaysAhead": {
-    "UNDEAD_PEOPLE_BASE_v2": {
-      "id": "UNDEAD_PEOPLE_BASE_v2",
-      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
-      "installation": {
-        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
-        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
-      },
-      "activity": {
-        "activity_type": "github_commit",
-        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
-      }
-    }
-  },
-
-  "BrightNights": {
-    "UNDEAD_PEOPLE_BASE_v2": {
-      "id": "UNDEAD_PEOPLE_BASE_v2",
-      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
-      "installation": {
-        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
-        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
-      },
-      "activity": {
-        "activity_type": "github_commit",
-        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
-      }
-    }
-  },
-
-  "TheLastGeneration": {
-    "UNDEAD_PEOPLE_BASE_v2": {
-      "id": "UNDEAD_PEOPLE_BASE_v2",
-      "name": "UNDEAD_PEOPLE (by Goodgulf_PL)",
-      "installation": {
-        "download_url": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version/archive/refs/heads/main.zip",
-        "tileset": "UndeadPeopleTileset_Unpacked_New_Version-main/dda/gfx/MSX++UnDeadPeopleEdition_v2/tileset.txt"
-      },
-      "activity": {
-        "activity_type": "github_commit",
-        "github": "https://github.com/Goodgulf-PL/UndeadPeopleTileset_Unpacked_New_Version"
-      }
-    }
-  }
+  "DarkDaysAhead": {},
+  "BrightNights": {},
+  "TheLastGeneration": {}
 }


### PR DESCRIPTION
### **User description**
Remove detailed UNDEAD_PEOPLE_BASE_v2 definitions for the three
build profiles (DarkDaysAhead, BrightNights, TheLastGeneration) and
replace them with empty objects. This simplifies the tilesets file
by removing duplicated external tileset configuration and prevents
the launcher from referencing a hardcoded third-party download and
tileset path. The change prepares the codebase for a centralized or
dynamic tileset registration approach and avoids shipping external
URLs in the repository.


___

### **PR Type**
Enhancement


___

### **Description**
- Removes hardcoded UnDeadPeople tileset entries from tilesets.json

- Replaces detailed configurations with empty objects for three build profiles

- Eliminates external URLs and third-party download references from repository

- Prepares codebase for centralized or dynamic tileset registration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tilesets.json<br/>with detailed configs"] -- "remove hardcoded<br/>UnDeadPeople entries" --> B["tilesets.json<br/>with empty objects"]
  B -- "enables" --> C["centralized tileset<br/>registration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tilesets.json</strong><dd><code>Simplify tilesets.json by removing UnDeadPeople configs</code>&nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/content/tilesets.json

<ul><li>Removes 41 lines of detailed UNDEAD_PEOPLE_BASE_v2 configuration for <br>DarkDaysAhead, BrightNights, and TheLastGeneration profiles<br> <li> Replaces each profile's tileset definition with an empty object<br> <li> Eliminates hardcoded GitHub download URLs and tileset paths<br> <li> Reduces file from 46 lines to 5 lines</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/280/files#diff-b741ff4ee2c80f51c72fdee6ee1363d4709c187cc66e5100f04a8cf5f7ed869c">+3/-44</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the UNDEAD_PEOPLE_BASE_v2 tileset entries from tilesets.json for DarkDaysAhead, BrightNights, and TheLastGeneration, leaving empty objects. This removes hardcoded third‑party URLs/paths, reduces duplication, and prepares for centralized or dynamic tileset registration.

<sup>Written for commit faacb294da3ed6507256056e43d32697b6eb315a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

