### PR TITLE
fix(query-keys): normalize query key parameter order

### DIFF
--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -34,32 +34,32 @@ export const queryKeys = {
 
   mods: {
     listAll: (variant: GameVariant) => ["mods", variant] as const,
-    installationStatus: (modId: string, variant: GameVariant) =>
-      ["mods", "installation_status", modId, variant] as const,
-    lastActivity: (modId: string, variant: GameVariant) =>
-      ["mods", "last_activity", modId, variant] as const,
+    installationStatus: (variant: GameVariant, modId: string) =>
+      ["mods", "installation_status", variant, modId] as const,
+    lastActivity: (variant: GameVariant, modId: string) =>
+      ["mods", "last_activity", variant, modId] as const,
   },
 
   tilesets: {
     listAll: (variant: GameVariant) => ["tilesets", variant] as const,
-    installationStatus: (tilesetId: string, variant: GameVariant) =>
+    installationStatus: (variant: GameVariant, tilesetId: string) =>
       [
         "tilesets",
         "installation_status",
-        tilesetId,
         variant,
+        tilesetId,
       ] as const,
   },
 
   soundpacks: {
     listAll: (variant: GameVariant) =>
       ["soundpacks", variant] as const,
-    installationStatus: (soundpackId: string, variant: GameVariant) =>
+    installationStatus: (variant: GameVariant, soundpackId: string) =>
       [
         "soundpacks",
         "installation_status",
-        soundpackId,
         variant,
+        soundpackId,
       ] as const,
   },
 

--- a/cat-launcher/src/pages/ModsPage/hooks.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks.ts
@@ -35,7 +35,7 @@ export function useInstallThirdPartyMod(
         queryKey: queryKeys.mods.listAll(variant),
       });
       queryClient.invalidateQueries({
-        queryKey: queryKeys.mods.installationStatus(id, variant),
+        queryKey: queryKeys.mods.installationStatus(variant, id),
       });
       onSuccess?.();
     },
@@ -57,7 +57,7 @@ export function useGetThirdPartyModInstallationStatus(
   variant: GameVariant,
 ) {
   const query = useQuery({
-    queryKey: queryKeys.mods.installationStatus(modId, variant),
+    queryKey: queryKeys.mods.installationStatus(variant, modId),
     queryFn: () => getThirdPartyModInstallationStatus(modId, variant),
   });
 
@@ -82,7 +82,7 @@ export function useUninstallThirdPartyMod(
         queryKey: queryKeys.mods.listAll(variant),
       });
       queryClient.invalidateQueries({
-        queryKey: queryKeys.mods.installationStatus(modId, variant),
+        queryKey: queryKeys.mods.installationStatus(variant, modId),
       });
       onSuccess?.();
     },
@@ -102,7 +102,7 @@ export function useGetLastModActivity(
   onError?: (error: unknown) => void,
 ) {
   const query = useQuery({
-    queryKey: queryKeys.mods.lastActivity(modId, variant),
+    queryKey: queryKeys.mods.lastActivity(variant, modId),
     queryFn: () => getLastModActivity(modId, variant),
     enabled,
   });

--- a/cat-launcher/src/pages/SoundpacksPage/hooks.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks.ts
@@ -38,8 +38,8 @@ export function useInstallThirdPartySoundpack(
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.soundpacks.installationStatus(
-          id,
           variant,
+          id,
         ),
       });
       onSuccess?.();
@@ -63,8 +63,8 @@ export function useGetThirdPartySoundpackInstallationStatus(
 ) {
   const query = useQuery({
     queryKey: queryKeys.soundpacks.installationStatus(
-      soundpackId,
       variant,
+      soundpackId,
     ),
     queryFn: () =>
       getThirdPartySoundpackInstallationStatus(soundpackId, variant),
@@ -92,8 +92,8 @@ export function useUninstallThirdPartySoundpack(
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.soundpacks.installationStatus(
-          soundpackId,
           variant,
+          soundpackId,
         ),
       });
       onSuccess?.();

--- a/cat-launcher/src/pages/TilesetsPage/hooks.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks.ts
@@ -37,7 +37,7 @@ export function useInstallAndMonitorThirdPartyTileset(
         queryKey: queryKeys.tilesets.listAll(variant),
       });
       queryClient.invalidateQueries({
-        queryKey: queryKeys.tilesets.installationStatus(id, variant),
+        queryKey: queryKeys.tilesets.installationStatus(variant, id),
       });
       onSuccess?.();
     },
@@ -60,8 +60,8 @@ export function useGetThirdPartyTilesetInstallationStatus(
 ) {
   const query = useQuery({
     queryKey: queryKeys.tilesets.installationStatus(
-      tilesetId,
       variant,
+      tilesetId,
     ),
     queryFn: () =>
       getThirdPartyTilesetInstallationStatus(tilesetId, variant),
@@ -89,8 +89,8 @@ export function useUninstallThirdPartyTileset(
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.tilesets.installationStatus(
-          tilesetId,
           variant,
+          tilesetId,
         ),
       });
       onSuccess?.();


### PR DESCRIPTION
### **User description**
Ensure query keys use a consistent [variant, id] ordering across
mods, tilesets, and soundpacks. Previously some keys emitted
[id, variant] while others used [variant, id], which can cause cache
misses and incorrect query identity.

Reorder the parameters for:
- mods.installationStatus and modsActivity
- tilesets.installation_status
- soundpacks.installation_status

This change standardizes key structure to prevent mismatched lookups
and improve cache reliability.


___

### **PR Type**
Bug fix


___

### **Description**
- Standardize query key parameter ordering to [variant, id]

- Fix mods.installationStatus and mods.lastActivity key order

- Fix tilesets.installationStatus key parameter sequence

- Fix soundpacks.installationStatus key parameter sequence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Keys<br/>Inconsistent Order"] -->|"Reorder to<br/>[variant, id]"| B["Standardized<br/>Query Keys"]
  B --> C["Improved Cache<br/>Reliability"]
  B --> D["Consistent Lookups"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>queryKeys.ts</strong><dd><code>Standardize query key parameter ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/lib/queryKeys.ts

<ul><li>Reordered <code>mods.installationStatus</code> from <code>[modId, variant]</code> to <code>[variant, </code><br><code>modId]</code><br> <li> Reordered <code>mods.lastActivity</code> from <code>[modId, variant]</code> to <code>[variant, modId]</code><br> <li> Reordered <code>tilesets.installationStatus</code> from <code>[tilesetId, variant]</code> to <br><code>[variant, tilesetId]</code><br> <li> Reordered <code>soundpacks.installationStatus</code> from <code>[soundpackId, variant]</code> to <br><code>[variant, soundpackId]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/281/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized query key parameter order to [variant, id] across mods, tilesets, and soundpacks. This fixes inconsistent keys that caused cache misses and incorrect query identity.

- **Bug Fixes**
  - Reordered parameters in mods.installationStatus and mods.lastActivity.
  - Reordered parameters in tilesets.installation_status and soundpacks.installation_status.

<sup>Written for commit 685d674566873f20a4a324d0eae6643ac6058492. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





