### PR TITLE
feat(listing): add stable sorting by type and id for assets

### DIFF
--- a/cat-launcher/src-tauri/src/infra/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/utils.rs
@@ -6,6 +6,12 @@ use tokio::fs;
 
 use crate::variants::GameVariant;
 
+pub trait Asset {
+  fn is_third_party(&self) -> bool;
+
+  fn id(&self) -> &str;
+}
+
 pub fn get_github_repo_for_variant(
   variant: &GameVariant,
 ) -> &'static str {
@@ -77,4 +83,13 @@ pub fn get_arch_enum(
     "x86_64" => Ok(Arch::X64),
     _ => Err(ArchNotSupportedError { arch }),
   }
+}
+
+pub fn sort_assets<T: Asset>(items: &mut [T]) {
+  items.sort_by(|a, b| {
+    a.is_third_party()
+      .cmp(&b.is_third_party())
+      .reverse()
+      .then_with(|| a.id().cmp(b.id()))
+  });
 }

--- a/cat-launcher/src-tauri/src/mods/list_all_mods.rs
+++ b/cat-launcher/src-tauri/src/mods/list_all_mods.rs
@@ -7,7 +7,7 @@ use tokio::fs::{read_dir, read_to_string};
 use crate::active_release::repository::{
   ActiveReleaseRepository, ActiveReleaseRepositoryError,
 };
-use crate::infra::utils::OS;
+use crate::infra::utils::{sort_assets, OS};
 use crate::mods::paths::{
   get_mods_resource_path, get_stock_mods_dir, GetStockModsDirError,
 };
@@ -59,6 +59,8 @@ pub async fn list_all_mods(
     let stock_mods = list_all_stock_mods(&stock_mods_dir).await?;
     mods.extend(stock_mods);
   }
+
+  sort_assets(&mut mods);
 
   Ok(mods)
 }

--- a/cat-launcher/src-tauri/src/mods/types.rs
+++ b/cat-launcher/src-tauri/src/mods/types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use crate::infra::utils::Asset;
+
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ModInstallation {
   pub download_url: String,
@@ -37,6 +39,19 @@ pub struct StockMod {
 pub enum Mod {
   Stock(StockMod),
   ThirdParty(ThirdPartyMod),
+}
+
+impl Asset for Mod {
+  fn is_third_party(&self) -> bool {
+    matches!(self, Mod::ThirdParty(_))
+  }
+
+  fn id(&self) -> &str {
+    match self {
+      Mod::Stock(m) => &m.id,
+      Mod::ThirdParty(m) => &m.id,
+    }
+  }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]

--- a/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::active_release::repository::{
   ActiveReleaseRepository, ActiveReleaseRepositoryError,
 };
-use crate::infra::utils::OS;
+use crate::infra::utils::{sort_assets, OS};
 use crate::soundpacks::paths::{
   get_soundpacks_resource_path, get_stock_soundpacks_dir,
   GetStockSoundpacksDirError,
@@ -66,6 +66,8 @@ pub async fn list_all_soundpacks(
       list_all_stock_soundpacks(&stock_soundpacks_dir).await?;
     soundpacks.extend(stock_soundpacks);
   }
+
+  sort_assets(&mut soundpacks);
 
   Ok(soundpacks)
 }

--- a/cat-launcher/src-tauri/src/soundpacks/types.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use crate::infra::utils::Asset;
+
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct SoundpackInstallation {
   pub download_url: String,
@@ -33,6 +35,19 @@ pub struct StockSoundpack {
 pub enum Soundpack {
   Stock(StockSoundpack),
   ThirdParty(ThirdPartySoundpack),
+}
+
+impl Asset for Soundpack {
+  fn is_third_party(&self) -> bool {
+    matches!(self, Soundpack::ThirdParty(_))
+  }
+
+  fn id(&self) -> &str {
+    match self {
+      Soundpack::Stock(s) => &s.id,
+      Soundpack::ThirdParty(s) => &s.id,
+    }
+  }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]

--- a/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
+++ b/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::active_release::repository::{
   ActiveReleaseRepository, ActiveReleaseRepositoryError,
 };
-use crate::infra::utils::OS;
+use crate::infra::utils::{sort_assets, OS};
 use crate::tilesets::paths::{
   get_stock_tilesets_dir, get_tilesets_resource_path,
   GetStockTilesetsDirError,
@@ -65,6 +65,8 @@ pub async fn list_all_tilesets(
       list_all_stock_tilesets(&stock_tilesets_dir).await?;
     tilesets.extend(stock_tilesets);
   }
+
+  sort_assets(&mut tilesets);
 
   Ok(tilesets)
 }

--- a/cat-launcher/src-tauri/src/tilesets/types.rs
+++ b/cat-launcher/src-tauri/src/tilesets/types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use crate::infra::utils::Asset;
+
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct TilesetInstallation {
   pub download_url: String,
@@ -33,6 +35,19 @@ pub struct StockTileset {
 pub enum Tileset {
   Stock(StockTileset),
   ThirdParty(ThirdPartyTileset),
+}
+
+impl Asset for Tileset {
+  fn is_third_party(&self) -> bool {
+    matches!(self, Tileset::ThirdParty(_))
+  }
+
+  fn id(&self) -> &str {
+    match self {
+      Tileset::Stock(t) => &t.id,
+      Tileset::ThirdParty(t) => &t.id,
+    }
+  }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]


### PR DESCRIPTION
### **User description**
Introduce a generic sort_by_type_and_id helper in infra::utils to
consistently order asset listings. The helper sorts items by whether
they are third-party (placed before stock) and then by their id.

Use the new utility in list_all_mods, list_all_soundpacks and
list_all_tilesets to apply deterministic ordering after collecting
built-in and third-party entries. This makes asset lists stable and
predictable for UI rendering and downstream processing.


___

### **PR Type**
Enhancement


___

### **Description**
- Add generic `sort_by_type_and_id` utility for consistent asset ordering

- Apply deterministic sorting to mods, soundpacks, and tilesets listings

- Sort third-party assets before stock assets, then by ID within each group

- Ensures stable and predictable asset list ordering for UI rendering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sort_by_type_and_id utility"] --> B["list_all_mods"]
  A --> C["list_all_soundpacks"]
  A --> D["list_all_tilesets"]
  B --> E["Sorted mods list"]
  C --> F["Sorted soundpacks list"]
  D --> G["Sorted tilesets list"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Add generic sorting utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/infra/utils.rs

<ul><li>Import <code>Ordering</code> from <code>std::cmp</code> for comparison operations<br> <li> Add generic <code>sort_by_type_and_id</code> function that sorts items by type <br>(third-party first) then by ID<br> <li> Function accepts closures for determining third-party status and <br>extracting item IDs</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/282/files#diff-6f50200ca96913ae3b634ea6b84bd3f5e0807aae8cf165dbdf0e7547d26611fe">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_all_mods.rs</strong><dd><code>Apply stable sorting to mods listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/mods/list_all_mods.rs

<ul><li>Import <code>sort_by_type_and_id</code> from infra utils<br> <li> Apply sorting to mods list after collecting built-in and third-party <br>entries<br> <li> Sort by third-party status first, then by mod ID</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/282/files#diff-ce2da28b367858357ed0a11b6d50c8e2bed706d557bcb2d58ee78517a0a03603">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_all_soundpacks.rs</strong><dd><code>Apply stable sorting to soundpacks listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs

<ul><li>Import <code>sort_by_type_and_id</code> from infra utils<br> <li> Apply sorting to soundpacks list after collecting built-in and <br>third-party entries<br> <li> Sort by third-party status first, then by soundpack ID</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/282/files#diff-6e73224644cb6289040295da04f3f4fc5b687f062b2f106c6b7ce587cd851718">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_all_tilesets.rs</strong><dd><code>Apply stable sorting to tilesets listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs

<ul><li>Import <code>sort_by_type_and_id</code> from infra utils<br> <li> Apply sorting to tilesets list after collecting built-in and <br>third-party entries<br> <li> Sort by third-party status first, then by tileset ID</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/282/files#diff-b7af594b4f0e2808d9951fa05b1331dcedb3cf42673810dc842359c2492df5fb">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stable sorting to asset listings via a shared helper. Third-party items come before stock, then sorted by id for consistent UI and downstream processing.

- **New Features**
  - Added Asset trait and sort_assets in infra::utils.
  - Implemented Asset for mods, soundpacks, tilesets; applied sorting in list_all_mods, list_all_soundpacks, list_all_tilesets.
  - Sorting rule: third-party first, then by id.

<sup>Written for commit 2a85e1ef46be397681c5071899aa53ac69fd7d9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





