### PR TITLE
fix: make DownloadProgress serializable in Redux store

### DIFF
--- a/cat-launcher/src/components/DownloadProgress.tsx
+++ b/cat-launcher/src/components/DownloadProgress.tsx
@@ -1,23 +1,18 @@
 import { Progress } from "@/components/ui/progress";
 
 interface DownloadProgressProps {
-  downloaded: bigint;
-  total: bigint;
+  downloaded: number;
+  total: number;
 }
 
 export function DownloadProgress({
   downloaded,
   total,
 }: DownloadProgressProps) {
-  const downloadedNumber = Number(downloaded);
-  const totalNumber = Number(total);
-
   // For some downloads, the total size is not known.
-  const showIndeterminateProgress =
-    totalNumber === 0 && downloadedNumber > 0;
+  const showIndeterminateProgress = total === 0 && downloaded > 0;
 
-  const progress =
-    totalNumber > 0 ? (downloadedNumber * 100) / totalNumber : 0;
+  const progress = total > 0 ? (downloaded * 100) / total : 0;
 
   return (
     <Progress

--- a/cat-launcher/src/hooks/useInstallAndMonitor.ts
+++ b/cat-launcher/src/hooks/useInstallAndMonitor.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import type { DownloadProgress } from "@/generated-types/DownloadProgress";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { useThrottle } from "@/hooks/useThrottle";
+import { toSerializableDownloadProgress } from "@/lib/types";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
   clearInstallationProgress,
@@ -50,7 +51,9 @@ export function useInstallAndMonitor<T>(
 
   const throttledOnProgress = useThrottle(
     (itemId: string, progress: DownloadProgress) => {
-      if (progress.total_bytes === 0n) {
+      const serializableProgress =
+        toSerializableDownloadProgress(progress);
+      if (serializableProgress.total_bytes === 0) {
         return;
       }
 
@@ -59,7 +62,7 @@ export function useInstallAndMonitor<T>(
           type,
           variant,
           id: itemId,
-          progress,
+          progress: serializableProgress,
         }),
       );
     },
@@ -83,8 +86,8 @@ export function useInstallAndMonitor<T>(
           variant,
           id: itemId,
           progress: {
-            bytes_downloaded: 0n,
-            total_bytes: 0n,
+            bytes_downloaded: 0,
+            total_bytes: 0,
           },
         }),
       );

--- a/cat-launcher/src/lib/types.ts
+++ b/cat-launcher/src/lib/types.ts
@@ -1,0 +1,15 @@
+import type { DownloadProgress } from "@/generated-types/DownloadProgress";
+
+export interface SerializableDownloadProgress {
+  bytes_downloaded: number;
+  total_bytes: number;
+}
+
+export function toSerializableDownloadProgress(
+  progress: DownloadProgress,
+): SerializableDownloadProgress {
+  return {
+    bytes_downloaded: Number(progress.bytes_downloaded),
+    total_bytes: Number(progress.total_bytes),
+  };
+}

--- a/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
@@ -70,8 +70,8 @@ export default function InteractionButton({
   if (installationProgressStatus === "Downloading") {
     return (
       <DownloadProgress
-        downloaded={downloadProgress?.bytes_downloaded ?? 0n}
-        total={downloadProgress?.total_bytes ?? 0n}
+        downloaded={downloadProgress?.bytes_downloaded ?? 0}
+        total={downloadProgress?.total_bytes ?? 0}
       />
     );
   }

--- a/cat-launcher/src/store/installationProgressSlice.ts
+++ b/cat-launcher/src/store/installationProgressSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import type { DownloadProgress } from "@/generated-types/DownloadProgress";
+import type { SerializableDownloadProgress } from "@/lib/types";
 import type { GameVariant } from "@/generated-types/GameVariant";
 
 type InstallationType = "release" | "mod" | "soundpack" | "tileset";
@@ -21,7 +21,10 @@ interface InstallationProgressState {
   >;
   downloadProgressByVariant: Record<
     InstallationType,
-    Record<GameVariant, Record<string, DownloadProgress | null>>
+    Record<
+      GameVariant,
+      Record<string, SerializableDownloadProgress | null>
+    >
   >;
 }
 
@@ -82,7 +85,7 @@ export const installationProgressSlice = createSlice({
         type: InstallationType;
         variant: GameVariant;
         id: string;
-        progress: DownloadProgress;
+        progress: SerializableDownloadProgress;
       }>,
     ) => {
       const { type, variant, id, progress } = action.payload;
@@ -90,7 +93,7 @@ export const installationProgressSlice = createSlice({
 
       const { bytes_downloaded, total_bytes } = progress;
 
-      if (total_bytes === 0n) {
+      if (total_bytes === 0) {
         state.installationStatusByVariant[type][variant][id] =
           "Downloading";
       } else if (bytes_downloaded === total_bytes) {


### PR DESCRIPTION
### **User description**
- Create SerializableDownloadProgress type with number fields instead of bigint
- Add toSerializableDownloadProgress conversion function
- Update Redux store to use SerializableDownloadProgress instead of DownloadProgress with bigint
- Convert DownloadProgress from backend to SerializableDownloadProgress before storing
- Update DownloadProgress component to accept number instead of bigint
- Update useInstallAndMonitor hook to convert and use serializable type
- Fix bigint literals to number literals in initial state


___

### **PR Type**
Bug fix


___

### **Description**
- Create SerializableDownloadProgress type with number fields instead of bigint

- Add toSerializableDownloadProgress conversion function to handle bigint-to-number conversion

- Update Redux store to use SerializableDownloadProgress instead of DownloadProgress

- Convert DownloadProgress from backend before storing in Redux

- Update DownloadProgress component and hooks to work with number types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DownloadProgress<br/>bigint fields"] -->|"toSerializableDownloadProgress"| B["SerializableDownloadProgress<br/>number fields"]
  B -->|"store in Redux"| C["Redux Store<br/>installationProgressSlice"]
  C -->|"pass to component"| D["DownloadProgress Component<br/>accepts number"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Create serializable download progress type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/lib/types.ts

<ul><li>Create new SerializableDownloadProgress interface with number fields<br> <li> Implement toSerializableDownloadProgress conversion function<br> <li> Convert bigint values from backend DownloadProgress to numbers</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/283/files#diff-2a1ad5254a0e9340d639824b0d1d87ea3e9c688b9ddc4fd692e256d64b34ed3b">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installationProgressSlice.ts</strong><dd><code>Update Redux store to use serializable type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/store/installationProgressSlice.ts

<ul><li>Replace DownloadProgress type with SerializableDownloadProgress in <br>state<br> <li> Update downloadProgressByVariant to store SerializableDownloadProgress<br> <li> Change bigint literal comparisons to number comparisons<br> <li> Update setDownloadProgress action to accept <br>SerializableDownloadProgress</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/283/files#diff-3cdf2caf9ef6a6c848b265ed41e81e146c92422099a4b9bf13687bbc78dc448d">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useInstallAndMonitor.ts</strong><dd><code>Convert progress before storing in Redux</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useInstallAndMonitor.ts

<ul><li>Import toSerializableDownloadProgress conversion function<br> <li> Convert DownloadProgress to SerializableDownloadProgress before <br>dispatching<br> <li> Update bigint literal comparisons to number comparisons<br> <li> Pass serializable progress to Redux store</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/283/files#diff-4296338d0afc4abae2baf6a466e9dd2528e713cc8c4cfac60b4bf049fce4d5b8">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DownloadProgress.tsx</strong><dd><code>Update component to accept number types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/components/DownloadProgress.tsx

<ul><li>Change component props from bigint to number types<br> <li> Remove Number conversion logic from component<br> <li> Simplify calculations to work directly with number values</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/283/files#diff-53115f7a9fae412a926f14e84b9149d9114c90bb669324c16d7365f03d75ccd9">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InteractionButton.tsx</strong><dd><code>Update default values to numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/InteractionButton.tsx

<ul><li>Update default values from bigint literals to number literals<br> <li> Pass number values to DownloadProgress component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/283/files#diff-d63226cd1178af4c5dfb3a449517e9fee439ac6495bd85d18cf8cba899bf6ea5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-serializable values in the Redux store by replacing bigint-based DownloadProgress with a number-based, serializable type. Prevents Redux warnings and makes progress data safe for persistence and devtools.

- **Bug Fixes**
  - Added SerializableDownloadProgress (number fields) and a toSerializableDownloadProgress helper.
  - Convert backend progress to the serializable type before dispatching.
  - Updated installationProgressSlice to store serializable progress and use number comparisons.
  - Updated DownloadProgress component, useInstallAndMonitor hook, and default literals to use numbers.

<sup>Written for commit f6fbd85d21c0b3a14318455be4f0e8685a717b93. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



