### PR TITLE
fix: cancel throttled progress updates when installation completes

### DIFF
--- a/cat-launcher/src/hooks/useInstallAndMonitor.ts
+++ b/cat-launcher/src/hooks/useInstallAndMonitor.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import type { DownloadProgress } from "@/generated-types/DownloadProgress";
 import type { GameVariant } from "@/generated-types/GameVariant";
-import { useThrottle } from "@/hooks/useThrottle";
+import { useThrottleWithCancel } from "@/hooks/useThrottleWithCancel";
 import { toSerializableDownloadProgress } from "@/lib/types";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
@@ -49,7 +49,10 @@ export function useInstallAndMonitor<T>(
     ][variant][id];
   });
 
-  const throttledOnProgress = useThrottle(
+  const {
+    throttledFunc: throttledOnProgress,
+    cancel: cancelThrottle,
+  } = useThrottleWithCancel(
     (itemId: string, progress: DownloadProgress) => {
       const serializableProgress =
         toSerializableDownloadProgress(progress);
@@ -93,6 +96,10 @@ export function useInstallAndMonitor<T>(
       onSuccess?.(itemId);
     },
     onSettled: (_data, _error, itemId) => {
+      // Cancel any pending throttled dispatches to prevent setting progress
+      // after installation has completed
+      cancelThrottle();
+
       dispatch(
         clearInstallationProgress({
           variant,

--- a/cat-launcher/src/hooks/useThrottleWithCancel.ts
+++ b/cat-launcher/src/hooks/useThrottleWithCancel.ts
@@ -1,0 +1,52 @@
+import { useRef, useCallback, useEffect } from "react";
+
+export function useThrottleWithCancel<Args extends unknown[]>(
+  func: (...args: Args) => void,
+  delay: number,
+): {
+  throttledFunc: (...args: Args) => void;
+  cancel: () => void;
+} {
+  const lastCall = useRef(0);
+  const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const funcRef = useRef(func);
+  funcRef.current = func;
+
+  const throttledFunc = useCallback(
+    (...args: Args): void => {
+      const now = Date.now();
+      const timeSinceLastCall = now - lastCall.current;
+
+      if (timeSinceLastCall >= delay) {
+        lastCall.current = now;
+        funcRef.current(...args);
+      } else {
+        if (timeoutId.current) {
+          clearTimeout(timeoutId.current);
+        }
+        timeoutId.current = setTimeout(() => {
+          lastCall.current = Date.now();
+          funcRef.current(...args);
+        }, delay - timeSinceLastCall);
+      }
+    },
+    [delay],
+  );
+
+  const cancel = useCallback(() => {
+    if (timeoutId.current) {
+      clearTimeout(timeoutId.current);
+      timeoutId.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cancel();
+    };
+  }, [cancel]);
+
+  return { throttledFunc, cancel };
+}

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -50,7 +50,7 @@ export default function ModCard({ variant, mod }: ModCardProps) {
   const modType = getModType(mod);
   const category = getModCategory(mod);
 
-  const isThirdParty = mod.type !== "Stock";
+  const isThirdParty = mod.type === "ThirdParty";
   const modId = mod.content.id;
 
   const { installationStatus } =

--- a/cat-launcher/src/pages/ModsPage/hooks.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks.ts
@@ -11,6 +11,7 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { ModInstallationStatus } from "@/generated-types/ModInstallationStatus";
 
 export function useInstallThirdPartyMod(
   variant: GameVariant,
@@ -31,12 +32,10 @@ export function useInstallThirdPartyMod(
     modId,
     installThirdPartyMod,
     (id: string) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.mods.listAll(variant),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.mods.installationStatus(variant, id),
-      });
+      queryClient.setQueryData<ModInstallationStatus>(
+        queryKeys.mods.installationStatus(variant, id),
+        "Installed",
+      );
       onSuccess?.();
     },
     (error: Error) => {

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
@@ -36,7 +36,7 @@ export default function SoundpackCard({
   const name = getSoundpackName(soundpack);
   const soundpackType = getSoundpackType(soundpack);
 
-  const isThirdParty = soundpack.type !== "Stock";
+  const isThirdParty = soundpack.type === "ThirdParty";
   const soundpackId = soundpack.content.id;
 
   const { installationStatus } =

--- a/cat-launcher/src/pages/SoundpacksPage/hooks.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks.ts
@@ -13,6 +13,7 @@ import {
   uninstallThirdPartySoundpack,
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
+import { SoundpackInstallationStatus } from "@/generated-types/SoundpackInstallationStatus";
 
 export function useInstallThirdPartySoundpack(
   variant: GameVariant,
@@ -33,15 +34,10 @@ export function useInstallThirdPartySoundpack(
     soundpackId,
     installThirdPartySoundpack,
     (id: string) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.soundpacks.listAll(variant),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.soundpacks.installationStatus(
-          variant,
-          id,
-        ),
-      });
+      queryClient.setQueryData<SoundpackInstallationStatus>(
+        queryKeys.soundpacks.installationStatus(variant, id),
+        "Installed",
+      );
       onSuccess?.();
     },
     (error: Error) => {

--- a/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
@@ -36,7 +36,7 @@ export default function TilesetCard({
   const name = getTilesetName(tileset);
   const tilesetType = getTilesetType(tileset);
 
-  const isThirdParty = tileset.type !== "Stock";
+  const isThirdParty = tileset.type === "ThirdParty";
   const tilesetId = tileset.content.id;
 
   const { installationStatus } =

--- a/cat-launcher/src/pages/TilesetsPage/hooks.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks.ts
@@ -13,6 +13,7 @@ import {
   uninstallThirdPartyTileset,
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
+import { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
 
 export function useInstallAndMonitorThirdPartyTileset(
   variant: GameVariant,
@@ -33,12 +34,10 @@ export function useInstallAndMonitorThirdPartyTileset(
     tilesetId,
     installThirdPartyTileset,
     (id: string) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.tilesets.listAll(variant),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.tilesets.installationStatus(variant, id),
-      });
+      queryClient.setQueryData<TilesetInstallationStatus>(
+        queryKeys.tilesets.installationStatus(variant, id),
+        "Installed",
+      );
       onSuccess?.();
     },
     (error: Error) => {


### PR DESCRIPTION
### **User description**
The throttled setDownloadProgress action could dispatch up to 1000ms after
installation completion, potentially setting progress values after the
installation has already been marked as complete. This fix adds a new
useThrottleWithCancel hook that supports cancellation and calls it in the
onSettled callback to prevent any pending throttled dispatches from executing
after installation completes.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `useThrottleWithCancel` hook to cancel pending throttled dispatches

- Cancel throttled progress updates in `onSettled` callback after installation

- Replace `invalidateQueries` with `setQueryData` for faster query updates

- Fix third-party type checking logic in card components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Completes"] -->|"onSettled callback"| B["Cancel Throttle"]
  B -->|"prevents dispatch"| C["No stale progress updates"]
  D["useThrottleWithCancel"] -->|"replaces"| E["useThrottle"]
  F["invalidateQueries"] -->|"replaced by"| G["setQueryData"]
  G -->|"faster update"| H["Query cache"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useThrottleWithCancel.ts</strong><dd><code>New throttle hook with cancellation support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/hooks/useThrottleWithCancel.ts

<ul><li>New hook that wraps a function with throttling and cancellation <br>support<br> <li> Tracks pending timeouts and provides <code>cancel()</code> method to clear them<br> <li> Cleans up timeout on component unmount via useEffect<br> <li> Returns both throttled function and cancel callback</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-514eef720d249a09ee43811470ad397052edbcc16de5fdc23caafd8ffe7f3b76">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Optimize mod installation status query updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/hooks.ts

<ul><li>Import <code>ModInstallationStatus</code> type<br> <li> Replace two <code>invalidateQueries</code> calls with single <code>setQueryData</code> call<br> <li> Directly set installation status to "Installed" instead of refetching<br> <li> Improves performance by avoiding unnecessary query invalidation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-b74a1a3a9b230def6db81382e304133ca66b7a1b75e136ee9e40b4714ee9a3f6">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Optimize soundpack installation status query updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SoundpacksPage/hooks.ts

<ul><li>Import <code>SoundpackInstallationStatus</code> type<br> <li> Replace two <code>invalidateQueries</code> calls with single <code>setQueryData</code> call<br> <li> Directly set installation status to "Installed" instead of refetching<br> <li> Improves performance by avoiding unnecessary query invalidation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-ccc9dbeb425a08de3c77580018f2ccc765ea139dfe4d7b626d04b37ac3485040">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Optimize tileset installation status query updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/TilesetsPage/hooks.ts

<ul><li>Import <code>TilesetInstallationStatus</code> type<br> <li> Replace two <code>invalidateQueries</code> calls with single <code>setQueryData</code> call<br> <li> Directly set installation status to "Installed" instead of refetching<br> <li> Improves performance by avoiding unnecessary query invalidation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-6c0f3793863f874235c11f3c8caf40dc569cfd05bdf7506ae68d60f46fbd3ccd">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useInstallAndMonitor.ts</strong><dd><code>Integrate throttle cancellation into installation monitoring</code></dd></summary>
<hr>

cat-launcher/src/hooks/useInstallAndMonitor.ts

<ul><li>Replace <code>useThrottle</code> import with <code>useThrottleWithCancel</code><br> <li> Destructure <code>throttledFunc</code> and <code>cancel</code> from new hook<br> <li> Call <code>cancelThrottle()</code> in <code>onSettled</code> callback to prevent stale updates<br> <li> Ensures no progress updates dispatch after installation completes</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-4296338d0afc4abae2baf6a466e9dd2528e713cc8c4cfac60b4bf049fce4d5b8">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModCard.tsx</strong><dd><code>Fix third-party mod type checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/ModCard.tsx

<ul><li>Change third-party type check from <code>mod.type !== "Stock"</code> to <code>mod.type </code><br><code>=== "ThirdParty"</code><br> <li> More explicit and correct logic for identifying third-party mods<br> <li> Prevents false positives if new mod types are added</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-f8d8e5c7bec36fe4784af5ed278799d4176bef37dcd22d606315cb937652cc86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SoundpackCard.tsx</strong><dd><code>Fix third-party soundpack type checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx

<ul><li>Change third-party type check from <code>soundpack.type !== "Stock"</code> to <br><code>soundpack.type === "ThirdParty"</code><br> <li> More explicit and correct logic for identifying third-party soundpacks<br> <li> Prevents false positives if new soundpack types are added</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-b11994dc89075c9a1bc4ec2bccd764c4a2ca58ff24e2fba6284f94e4ffaf2973">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TilesetCard.tsx</strong><dd><code>Fix third-party tileset type checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx

<ul><li>Change third-party type check from <code>tileset.type !== "Stock"</code> to <br><code>tileset.type === "ThirdParty"</code><br> <li> More explicit and correct logic for identifying third-party tilesets<br> <li> Prevents false positives if new tileset types are added</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/289/files#diff-23778ded4b8b3334a3fed14a98fd573777021cdf33a255c0e63d978400dbdb29">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

