### PR TITLE
Add typechecking to the lint command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Always follow the directory structure above when creating a new feature.
 
 * The backend implements Tauri commands which are used by the frontend.
 * Commands should be straightforward and should not perform business logic.
-* Commands should prepare arguments to pass to business logic functions. The entire context or framework-dependent data should not be passed to business logic functions.
+* Commands should prepare arguments to pass to business logic functions. The entire context or framework-dependent data should not be passed to business logic functions, in particular, the Tauri `AppHandle` and `App` objects.
 * Error thrown by command should derive `thiserror::Error`, `Debug`, `IntoStaticStr`, `CommandErrorSerialize`.
 
 ```rust
@@ -132,6 +132,7 @@ pub fn get_all_tips() -> Result<(), GetAllTipsError> {
   - `cat-launcher/src-tauri/src/{feature_name}/lib.rs`: Utilities specific to this feature.
   - `cat-launcher/src-tauri/src/{feature_name}/types.rs`: Enums, structs, and other data types specific to this feature.
   - `cat-launcher/src-tauri/src/{feature_name}/repository`: Repository specific to this feature. It should contain an abstract repository trait and its implementation in two separate files.
+  - `cat-launcher/src-tauri/src/{feature_name}/{business_logic_files}`: Files implementing the business logic used in `commands.rs`.
 
 # Agent Responsibility
 

--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "lint": "eslint . --max-warnings 0 && cargo clippy --manifest-path ./src-tauri/Cargo.toml -- -D warnings",
+    "lint": "eslint . --max-warnings 0 && pnpm tsc --noEmit && cargo clippy --manifest-path ./src-tauri/Cargo.toml -- -D warnings",
     "lint:fix": "eslint . --fix && cargo clippy --manifest-path ./src-tauri/Cargo.toml --fix --allow-dirty",
     "format": "prettier --write . && cargo fmt --manifest-path ./src-tauri/Cargo.toml",
     "format:check": "prettier --check . && cargo fmt --manifest-path ./src-tauri/Cargo.toml -- --check",
@@ -20,7 +20,7 @@
       "prettier --write"
     ],
     "*.{ts,tsx}": [
-      "eslint --fix --max-warnings 0"
+      "eslint --fix --max-warnings 0 && pnpm tsc --noEmit"
     ],
     "src-tauri/src/**/*.rs": [
       "sh -c 'cd src-tauri && cargo fmt --all'",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added TypeScript type checking to the lint command and lint-staged to catch type errors during lint runs and pre-commit. Updated AGENTS.md to clarify that Tauri AppHandle/App should not be passed into business logic and to document the business logic file location.

<sup>Written for commit 677b18de92c6386d5ac586d7cfba983733a5f5b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



