### PR TITLE
Ensure only pages are scrollable, not the navbar

### DIFF
--- a/cat-launcher/src/App.tsx
+++ b/cat-launcher/src/App.tsx
@@ -5,17 +5,19 @@ import { routes } from "@/routes";
 function App() {
   return (
     <BrowserRouter>
-      <NavBar />
-      <div className="p-2">
-        <Routes>
-          {routes.map((route) => (
-            <Route
-              key={route.path}
-              path={route.path}
-              element={route.element}
-            />
-          ))}
-        </Routes>
+      <div className="flex h-screen flex-col overflow-hidden">
+        <NavBar />
+        <main className="flex-1 overflow-y-auto p-2">
+          <Routes>
+            {routes.map((route) => (
+              <Route
+                key={route.path}
+                path={route.path}
+                element={route.element}
+              />
+            ))}
+          </Routes>
+        </main>
       </div>
     </BrowserRouter>
   );

--- a/cat-launcher/src/components/NavBar.tsx
+++ b/cat-launcher/src/components/NavBar.tsx
@@ -8,7 +8,7 @@ export default function NavBar() {
   const location = useLocation();
 
   return (
-    <nav className="flex items-center justify-between gap-4 border-b bg-background px-4 py-3">
+    <nav className="flex shrink-0 items-center justify-between gap-4 border-b bg-background px-4 py-3">
       <div className="flex flex-1 items-center justify-center gap-4">
         {routes.map((route) => {
           const Icon = route.icon;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make only the page content scroll while keeping the navbar fixed. This prevents the header from moving on long pages and keeps navigation always visible.

- **Bug Fixes**
  - Wrapped the app in a full-height flex column with overflow-hidden; moved routes into a scrollable main (overflow-y-auto).
  - Set NavBar to shrink-0 to maintain fixed height and prevent scrolling.

<sup>Written for commit b97a4a3d5f3f2587c0a1433ca76912cc11a2e468. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

