### PR TITLE
Fix analytics

### DIFF
--- a/cat-launcher/index.html
+++ b/cat-launcher/index.html
@@ -7,8 +7,22 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self' 'nonce-__VITE_NONCE__' https://*.posthog.com;
+        connect-src 'self' https://*.posthog.com;
+        worker-src 'self' blob: data:;
+        img-src 'self' https://*.posthog.com;
+        style-src 'self' https://*.posthog.com;
+        font-src https://*.posthog.com;
+        media-src https://*.posthog.com;
+        frame-ancestors 'self' https://*.posthog.com;
+      "
+    />
     <title>Tauri + React + Typescript</title>
-    <script>
+    <script nonce="__VITE_NONCE__">
       try {
         const theme = localStorage.getItem("cat-launcher-theme");
         const isDark = theme === "Dark";

--- a/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
+++ b/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
@@ -8,6 +8,7 @@ import { getUserId } from "@/lib/commands";
 const posthogOptions = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   defaults: "2025-11-30",
+  persistence: "localStorage",
 } as const;
 
 export interface PostHogProviderWithIdentifiedUserProps {

--- a/cat-launcher/vite.config.ts
+++ b/cat-launcher/vite.config.ts
@@ -13,6 +13,13 @@ export default defineConfig(async () => ({
       },
     }),
     tailwindcss(),
+    {
+      name: "inject-nonce",
+      transformIndexHtml: (html: string) => {
+        const nonce = crypto.randomUUID();
+        return html.replace(/__VITE_NONCE__/g, nonce);
+      },
+    },
   ],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken analytics by allowing PostHog in the app’s CSP and persisting PostHog data in localStorage. Events now send reliably and user identity is kept between sessions.

- **Bug Fixes**
  - Expanded CSP to allow PostHog and added nonce injection for inline scripts.

<sup>Written for commit 8f56252ace909b8fa2bb42dcf167d802b6f787fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



