### PR TITLE
Exclude config files from type check during linting

### DIFF
--- a/cat-launcher/eslint.config.js
+++ b/cat-launcher/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       ".tauri",
       "coverage",
       "*.min.js",
+      "src-tauri",
     ],
   },
   {

--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -19,8 +19,9 @@
     "*.{ts,tsx,js,jsx,json,css,md}": [
       "prettier --write"
     ],
-    "*.{ts,tsx}": [
-      "eslint --fix --max-warnings 0 && pnpm tsc --noEmit"
+    "src/**/*.{ts,tsx}": [
+      "eslint --fix --max-warnings 0",
+      "sh -c 'tsc --noEmit'"
     ],
     "src-tauri/src/**/*.rs": [
       "sh -c 'cd src-tauri && cargo fmt --all'",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restrict linting and TypeScript checks to app source files. Excludes config files, node_modules, and Tauri code to speed up checks and avoid false positives.

- **Refactors**
  - ESLint now ignores src-tauri.
  - Lint-staged runs eslint and tsc only on src/**/*.{ts,tsx}.

<sup>Written for commit 5a6e4a1f71a6c290967f081c7a221755cd69cb7f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



