### PR TITLE
Update commit guidelines for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,4 +137,4 @@ pub fn get_all_tips() -> Result<(), GetAllTipsError> {
 # Agent Responsibility
 
 * At the end of each task, run the Verification commands to ensure correctness.
-* Run `git log` to check the recent commit history. If the last commit is related to GitButler, do nothing. Otherwise, either create a new commit or amend/squash previous commits.
+* Run `git branch --show-current` to find the current branch name. If current branch is not `main`, `release`, or `gitbutler/workspace`, commit the changes with an appropriate commit message.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated AGENTS.md to base commit decisions on the current branch name using `git branch --show-current` instead of checking commit history.
Agents now commit only when not on `main`, `release`, or `gitbutler/workspace`, reducing accidental commits to protected branches.

<sup>Written for commit e282da6ee5391d3a440bef2991cb6e5963bf8338. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

