### PR TITLE
Add Bl@ck Edition soundpack

### DIFF
--- a/cat-launcher/src-tauri/content/soundpacks.json
+++ b/cat-launcher/src-tauri/content/soundpacks.json
@@ -11,6 +11,18 @@
         "activity_type": "github_commit",
         "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
       }
+    },
+    "black-edition-soundpack": {
+      "id": "black-edition-soundpack",
+      "name": "Bl@ck Edition",
+      "installation": {
+        "download_url": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack/archive/refs/heads/master.zip",
+        "soundpack": "Bl-ck-Edition-Soundpack-master/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack"
+      }
     }
   },
 
@@ -26,6 +38,18 @@
         "activity_type": "github_commit",
         "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
       }
+    },
+    "black-edition-soundpack": {
+      "id": "black-edition-soundpack",
+      "name": "Bl@ck Edition",
+      "installation": {
+        "download_url": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack/archive/refs/heads/master.zip",
+        "soundpack": "Bl-ck-Edition-Soundpack-master/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack"
+      }
     }
   },
 
@@ -40,6 +64,18 @@
       "activity": {
         "activity_type": "github_commit",
         "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
+      }
+    },
+    "black-edition-soundpack": {
+      "id": "black-edition-soundpack",
+      "name": "Bl@ck Edition",
+      "installation": {
+        "download_url": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack/archive/refs/heads/master.zip",
+        "soundpack": "Bl-ck-Edition-Soundpack-master/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack"
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the Bl@ck Edition soundpack to the launcher catalog so users can install it from the UI. Updates include GitHub-based activity tracking for automatic updates.

- **New Features**
  - Added "black-edition-soundpack" with download URL: https://github.com/chronicpayne/Bl-ck-Edition-Soundpack/archive/refs/heads/master.zip and manifest path: Bl-ck-Edition-Soundpack-master/soundpack.txt
  - Configured activity tracking via https://github.com/chronicpayne/Bl-ck-Edition-Soundpack

<sup>Written for commit 6f017e6402214e4faca978cb3d7dcd5e8123d9dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

