### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ CatLauncher is 100% open-source and the .dmg is built directly from the source c
 
 Downloading the AppImage is the easiest way to install CatLauncher and keep it automatically up-to-date. However, the AppImage may not work on all Linux distros. It's been tested to work on Ubuntu 24.04.
 
-To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.9.1_amd64.AppImage`, and then run it like you would any other executable.
+To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.10.0_amd64.AppImage`, and then run it like you would any other executable.
 
 If you encounter issues with the AppImage, you can try installing CatLauncher using the .deb or the .rpm package. It would also help if you can open an issue on GitHub with details of your distro.
 

--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.10.0",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "cat-macros",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.9.1"
+version = "0.10.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update cat-launcher version to 0.10.0 across package.json, Cargo.toml/Cargo.lock, tauri.conf.json, and README download instructions to prepare the 0.10.0 release. Ensures builds, installers, runtime version reporting, and AppImage docs show 0.10.0.

<sup>Written for commit 14bf9fb37f544b400feb300cd0a9a27a4a37ff00. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



