### PR TITLE
Support multiple executable filenames per release

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -194,7 +194,9 @@ pub fn get_game_executable_filenames(
     (g, OS::Windows) => match g {
       GameVariant::BrightNights => &["cataclysm-bn-tiles.exe"],
       GameVariant::DarkDaysAhead => &["cataclysm-tiles.exe"],
-      GameVariant::TheLastGeneration => &["cataclysm-tiles.exe"],
+      GameVariant::TheLastGeneration => {
+        &["cataclysm-tlg-tiles.exe", "cataclysm-tiles.exe"]
+      }
     },
 
     (_, OS::Linux) => &["cataclysm-launcher"],


### PR DESCRIPTION
- Change get_game_executable_filename to return a list of possible filenames
- Update get_game_executable_filepath to try each filename in order
- Rename get_game_executable_filename to get_game_executable_filenames
- This allows handling cases where executable names change between releases



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for multiple executable filenames per release so the launcher can find the game even if the binary name changes. Path resolution now tries candidates in order and returns the first match, including the new TLG executable name on Windows.

- **New Features**
  - Renamed get_game_executable_filename to get_game_executable_filenames and changed it to return a list of candidate names.
  - get_game_executable_filepath now iterates candidates and returns the first existing file; otherwise returns DoesNotExist.
  - Windows TLG candidates now include cataclysm-tlg-tiles.exe and cataclysm-tiles.exe; Linux and Mac remain single entries.

<sup>Written for commit 808cef8dbee7b014bf00ed5e1a93110beb6b63e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



