### PR TITLE
Move CSP to tauri.conf.json

### DIFF
--- a/cat-launcher/index.html
+++ b/cat-launcher/index.html
@@ -7,22 +7,8 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0"
     />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="
-        default-src 'self';
-        script-src 'self' 'nonce-__VITE_NONCE__' https://*.posthog.com;
-        connect-src 'self' https://*.posthog.com;
-        worker-src 'self' blob: data:;
-        img-src 'self' https://*.posthog.com;
-        style-src 'self' https://*.posthog.com;
-        font-src https://*.posthog.com;
-        media-src https://*.posthog.com;
-        frame-ancestors 'self' https://*.posthog.com;
-      "
-    />
     <title>Tauri + React + Typescript</title>
-    <script nonce="__VITE_NONCE__">
+    <script>
       try {
         const theme = localStorage.getItem("cat-launcher-theme");
         const isDark = theme === "Dark";

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -18,7 +18,17 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self'",
+        "script-src": "'self' https://*.posthog.com",
+        "connect-src": "'self' ipc: https://ipc.localhost https://*.posthog.com",
+        "worker-src": "'self' blob: data:",
+        "img-src": "'self' https://*.posthog.com",
+        "style-src": "'self' 'unsafe-inline' https://*.posthog.com",
+        "font-src": "'self' https://*.posthog.com",
+        "media-src": "'self' https://*.posthog.com",
+        "frame-ancestors": "'self' https://*.posthog.com"
+      }
     }
   },
   "bundle": {

--- a/cat-launcher/vite.config.ts
+++ b/cat-launcher/vite.config.ts
@@ -13,13 +13,6 @@ export default defineConfig(async () => ({
       },
     }),
     tailwindcss(),
-    {
-      name: "inject-nonce",
-      transformIndexHtml: (html: string) => {
-        const nonce = crypto.randomUUID();
-        return html.replace(/__VITE_NONCE__/g, nonce);
-      },
-    },
   ],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
CSP is now managed in tauri.conf.json for consistent enforcement and simpler maintenance. Removed the HTML meta tag and nonce handling, and updated directives to allow Tauri IPC and PostHog.

- **Refactors**
  - Moved CSP from index.html to src-tauri/tauri.conf.json.
  - Added directives for PostHog and Tauri IPC: default-src, script-src (self + PostHog), connect-src (self + ipc + ipc.localhost + PostHog), worker-src (self + blob + data), img/style/font/media/frame-ancestors (self + PostHog). Enabled 'unsafe-inline' for styles.
  - Removed Vite inject-nonce plugin and the nonce placeholder from index.html.

<sup>Written for commit 11293b86135a38eb9c96c5606469ec86f13a58ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

