### PR TITLE
Explicitly add PostHog domains

### DIFF
--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -20,14 +20,14 @@
     "security": {
       "csp": {
         "default-src": "'self'",
-        "script-src": "'self' https://*.posthog.com",
-        "connect-src": "'self' ipc: https://ipc.localhost https://*.posthog.com",
+        "script-src": "'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
+        "connect-src": "'self' ipc: https://ipc.localhost http://ipc.localhost https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
         "worker-src": "'self' blob: data:",
-        "img-src": "'self' https://*.posthog.com",
-        "style-src": "'self' 'unsafe-inline' https://*.posthog.com",
-        "font-src": "'self' https://*.posthog.com",
-        "media-src": "'self' https://*.posthog.com",
-        "frame-ancestors": "'self' https://*.posthog.com"
+        "img-src": "'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
+        "style-src": "'self' 'unsafe-inline' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
+        "font-src": "'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
+        "media-src": "'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com",
+        "frame-ancestors": "'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://us.posthog.com https://app.posthog.com"
       }
     }
   },


### PR DESCRIPTION
WebViews on some OSes don't respect wildcard URLs.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CSP from *.posthog.com to explicit PostHog domains in the Tauri app, and allow http://ipc.localhost in connect-src for Windows. This fixes analytics and IPC in WebViews that ignore wildcard sources (e.g., Windows).

- **Bug Fixes**
  - Replaced wildcard with: us.i.posthog.com, us-assets.i.posthog.com, us.posthog.com, app.posthog.com.
  - Applied to: script-src, connect-src (now includes http://ipc.localhost), img-src, style-src, font-src, media-src, frame-ancestors.

<sup>Written for commit beeb76dc9c0db91b77ceb7a1c18604ea11786b17. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





