### PR TITLE
feat: Add Otopack BN Mk 2 support

### DIFF
--- a/cat-launcher/src-tauri/content/soundpacks.json
+++ b/cat-launcher/src-tauri/content/soundpacks.json
@@ -50,6 +50,18 @@
         "activity_type": "github_commit",
         "github": "https://github.com/chronicpayne/Bl-ck-Edition-Soundpack"
       }
+    },
+    "otopack-bn-mk2": {
+      "id": "otopack-bn-mk2",
+      "name": "Otopack BN Mk 2",
+      "installation": {
+        "download_url": "https://github.com/NarandBD/Otopack-BN-Mk-2/archive/refs/heads/main.zip",
+        "soundpack": "Otopack-BN-Mk-2-main/Otopack+ModsUpdates BN/soundpack.txt"
+      },
+      "activity": {
+        "activity_type": "github_commit",
+        "github": "https://github.com/NarandBD/Otopack-BN-Mk-2"
+      }
     }
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added support for the Otopack BN Mk 2 soundpack in Bright Nights, enabling install from the launcher and GitHub activity tracking.

- **New Features**
  - Added `otopack-bn-mk2` entry in `soundpacks.json`.
  - Includes download URL and `soundpack.txt` path.
  - Tracks updates via the linked GitHub repository.

<sup>Written for commit 1ee830682cbf2ee5d66e9751653ca2e91742c7e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

