### PR TITLE
Remove Otopack from BN

### DIFF
--- a/cat-launcher/src-tauri/content/soundpacks.json
+++ b/cat-launcher/src-tauri/content/soundpacks.json
@@ -27,18 +27,6 @@
   },
 
   "BrightNights": {
-    "otopack": {
-      "id": "otopack",
-      "name": "Otopack",
-      "installation": {
-        "download_url": "https://github.com/Kenan2000/Otopack-Mods-Updates/archive/refs/heads/master.zip",
-        "soundpack": "Otopack-Mods-Updates-master/Otopack+ModsUpdates/soundpack.txt"
-      },
-      "activity": {
-        "activity_type": "github_commit",
-        "github": "https://github.com/Kenan2000/Otopack-Mods-Updates"
-      }
-    },
     "black-edition-soundpack": {
       "id": "black-edition-soundpack",
       "name": "Bl@ck Edition",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Otopack soundpack from the BrightNights catalog in soundpacks.json so it no longer appears as an install option in the launcher. No other soundpacks were changed.

<sup>Written for commit 00737ad8582bc952026336cda0b5cec59bfed370. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

