### PR TITLE
Make dark theme the default when no theme is set

### DIFF
--- a/cat-launcher/index.html
+++ b/cat-launcher/index.html
@@ -11,13 +11,13 @@
     <script>
       try {
         const theme = localStorage.getItem("cat-launcher-theme");
-        const isDark = theme === "Dark";
-        document.documentElement.classList.toggle("dark", isDark);
-        document.documentElement.style.colorScheme = isDark
-          ? "dark"
-          : "light";
+        const isLight = theme === "Light";
+        document.documentElement.classList.toggle("dark", !isLight);
+        document.documentElement.style.colorScheme = isLight
+          ? "light"
+          : "dark";
       } catch {
-        // Ignore errors, fall back to light theme
+        // Ignore errors. React will set the theme later.
       }
     </script>
   </head>

--- a/cat-launcher/src-tauri/src/theme/sqlite_theme_preference_repository.rs
+++ b/cat-launcher/src-tauri/src/theme/sqlite_theme_preference_repository.rs
@@ -51,7 +51,7 @@ impl ThemePreferenceRepository for SqliteThemePreferenceRepository {
                     Ok(ThemePreference { theme })
                 }
                 None => {
-                    let default = Theme::Light;
+                    let default = Theme::Dark;
                     conn.execute(
                         "INSERT OR REPLACE INTO theme_preferences (_id, theme) VALUES (1, ?1)",
                         [&default.to_string()],

--- a/cat-launcher/src/theme/ThemeToggle.tsx
+++ b/cat-launcher/src/theme/ThemeToggle.tsx
@@ -11,7 +11,7 @@ export default function ThemeToggle() {
     },
   );
 
-  const Icon = currentTheme === "Dark" ? Sun : Moon;
+  const Icon = currentTheme === "Light" ? Moon : Sun;
 
   return (
     <Button

--- a/cat-launcher/src/theme/useTheme.ts
+++ b/cat-launcher/src/theme/useTheme.ts
@@ -22,8 +22,8 @@ export function setStoredTheme(theme: Theme): void {
 
 export function applyThemeToDom(theme: Theme): void {
   const root = document.documentElement;
-  root.classList.toggle("dark", theme === "Dark");
-  root.style.colorScheme = theme === "Dark" ? "dark" : "light";
+  root.classList.toggle("dark", theme !== "Light");
+  root.style.colorScheme = theme === "Light" ? "light" : "dark";
 }
 
 export function useTheme(onError?: (error: unknown) => void) {
@@ -44,7 +44,7 @@ export function useTheme(onError?: (error: unknown) => void) {
   });
 
   const currentTheme = useMemo(
-    () => themePreference?.theme ?? "Light",
+    () => themePreference?.theme ?? "Dark",
     [themePreference],
   );
 
@@ -81,7 +81,7 @@ export function useTheme(onError?: (error: unknown) => void) {
   });
 
   const handleToggle = () => {
-    const nextTheme = currentTheme === "Dark" ? "Light" : "Dark";
+    const nextTheme = currentTheme === "Light" ? "Dark" : "Light";
     toggleTheme(nextTheme);
   };
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set Dark as the default theme when no preference is stored. Applied in the SQLite repository, useTheme hook, and index.html boot script so first-time or unset users start in Dark, while saved preferences stay unchanged.

<sup>Written for commit 8f5bbe28f5818856a412b5ed678a810d6619ff9e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



