### PR TITLE
feat: implement real-time gameplay time tracking

### DIFF
--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -11,7 +11,6 @@ use crate::fetch_releases::repository::sqlite_releases_repository::SqliteRelease
 use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::launch_game::launch_game::{launch_and_monitor_game, GameEvent, LaunchGameError};
 use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
-use crate::play_time::sqlite_play_time_repository::SqlitePlayTimeRepository;
 use crate::settings::Settings;
 use crate::variants::GameVariant;
 
@@ -42,7 +41,6 @@ pub async fn launch_game(
   settings: State<'_, Settings>,
   releases_repository: State<'_, SqliteReleasesRepository>,
   backup_repository: State<'_, SqliteBackupRepository>,
-  play_time_repository: State<'_, SqlitePlayTimeRepository>,
   active_release_repository: State<'_, SqliteActiveReleaseRepository>,
 ) -> Result<(), LaunchGameCommandError> {
   let data_dir = app_handle.path().app_local_data_dir()?;
@@ -71,7 +69,6 @@ pub async fn launch_game(
     &resource_dir,
     &*releases_repository,
     backup_repository.inner().clone(),
-    play_time_repository.inner().clone(),
     &*active_release_repository,
     on_game_event,
     &settings,

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -42,7 +42,7 @@ use crate::mods::commands::{
   uninstall_third_party_mod_command,
 };
 use crate::play_time::commands::{
-  get_play_time_for_variant, get_play_time_for_version,
+  get_play_time_for_variant, get_play_time_for_version, log_play_time,
 };
 use crate::soundpacks::commands::{
   get_third_party_soundpack_installation_status_command,
@@ -93,6 +93,7 @@ pub fn run() {
       get_tips,
       get_play_time_for_variant,
       get_play_time_for_version,
+      log_play_time,
       update_game_variant_order,
       list_backups_for_variant,
       delete_backup_by_id,

--- a/cat-launcher/src-tauri/src/play_time/play_time.rs
+++ b/cat-launcher/src-tauri/src/play_time/play_time.rs
@@ -21,3 +21,14 @@ pub async fn get_play_time_for_version(
     .get_play_time_for_version(game_variant, version)
     .await
 }
+
+pub async fn log_play_time(
+  game_variant: &GameVariant,
+  version: &str,
+  duration_in_seconds: i64,
+  play_time_repository: &impl PlayTimeRepository,
+) -> Result<(), PlayTimeRepositoryError> {
+  play_time_repository
+    .log_play_time(game_variant, version, duration_in_seconds)
+    .await
+}

--- a/cat-launcher/src/components/PlayTimeMonitor.tsx
+++ b/cat-launcher/src/components/PlayTimeMonitor.tsx
@@ -1,0 +1,13 @@
+import { usePlayTimeMonitor } from "@/hooks/usePlayTimeMonitor";
+import { useAppSelector } from "@/store/hooks";
+
+const PlayTimeMonitor = () => {
+  const { currentlyPlaying, currentlyPlayingVersion } =
+    useAppSelector((state) => state.gameSession);
+
+  usePlayTimeMonitor(currentlyPlaying, currentlyPlayingVersion);
+
+  return null;
+};
+
+export default PlayTimeMonitor;

--- a/cat-launcher/src/hooks/usePlayTimeMonitor.ts
+++ b/cat-launcher/src/hooks/usePlayTimeMonitor.ts
@@ -1,0 +1,68 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { logPlayTime } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+import { toastCL } from "@/lib/utils";
+
+const DURATION_TO_LOG_SECONDS = 60;
+const INTERVAL_MS = DURATION_TO_LOG_SECONDS * 1000;
+
+export function usePlayTimeMonitor(
+  currentlyPlaying: GameVariant | null,
+  currentlyPlayingVersion: string | null,
+) {
+  const queryClient = useQueryClient();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!currentlyPlaying || !currentlyPlayingVersion) {
+      return;
+    }
+
+    const scheduleNextLog = async () => {
+      // Skip if a log is already in flight to prevent overlapping calls
+      if (inFlightRef.current) {
+        return;
+      }
+
+      inFlightRef.current = true;
+      try {
+        await logPlayTime(
+          currentlyPlaying,
+          currentlyPlayingVersion,
+          DURATION_TO_LOG_SECONDS,
+        );
+
+        // Invalidate queries to update UI in real-time if PlayPage is open
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.playTimeForVariant(currentlyPlaying),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.playTimeForVersion(
+            currentlyPlaying,
+            currentlyPlayingVersion,
+          ),
+        });
+      } catch (error) {
+        toastCL("error", "Failed to log play time.", error);
+      } finally {
+        inFlightRef.current = false;
+        timeoutRef.current = setTimeout(scheduleNextLog, INTERVAL_MS);
+      }
+    };
+
+    // Start the first log immediately
+    scheduleNextLog();
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [currentlyPlaying, currentlyPlayingVersion, queryClient]);
+}

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -175,6 +175,18 @@ export async function getPlayTimeForVersion(
   return response;
 }
 
+export async function logPlayTime(
+  variant: GameVariant,
+  version: string,
+  durationInSeconds: number,
+): Promise<void> {
+  await invoke("log_play_time", {
+    variant,
+    version,
+    durationInSeconds,
+  });
+}
+
 export async function getActiveRelease(
   variant: GameVariant,
 ): Promise<string> {

--- a/cat-launcher/src/pages/PlayPage/hooks.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks.ts
@@ -239,7 +239,12 @@ export function useLaunchGame(
       return launchGame(variant, releaseId, worldName ?? null);
     },
     onSuccess: (_, releaseId) => {
-      dispatch(setCurrentlyPlaying({ variant }));
+      dispatch(
+        setCurrentlyPlaying({
+          variant,
+          version: releaseId!,
+        }),
+      );
       queryClient.setQueryData(
         queryKeys.activeRelease(variant),
         () => releaseId!,

--- a/cat-launcher/src/providers/index.tsx
+++ b/cat-launcher/src/providers/index.tsx
@@ -7,6 +7,7 @@ import { Provider } from "react-redux";
 
 import AutoUpdateNotifier from "@/components/AutoUpdateNotifier";
 import GameSessionMonitor from "@/components/GameSessionMonitor";
+import PlayTimeMonitor from "@/components/PlayTimeMonitor";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { store } from "@/store/store";
@@ -35,6 +36,7 @@ export default function Providers({ children }: ProvidersProps) {
                 <Toaster />
                 <AutoUpdateNotifier />
                 <GameSessionMonitor />
+                <PlayTimeMonitor />
               </TooltipProvider>
             </Provider>
           </CatLauncherVersionTracker>

--- a/cat-launcher/src/store/gameSessionSlice.ts
+++ b/cat-launcher/src/store/gameSessionSlice.ts
@@ -4,10 +4,12 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 
 interface GameSessionState {
   currentlyPlaying: GameVariant | null;
+  currentlyPlayingVersion: string | null;
 }
 
 const initialState: GameSessionState = {
   currentlyPlaying: null,
+  currentlyPlayingVersion: null,
 };
 
 export const gameSessionSlice = createSlice({
@@ -16,12 +18,17 @@ export const gameSessionSlice = createSlice({
   reducers: {
     setCurrentlyPlaying: (
       state,
-      action: PayloadAction<{ variant: GameVariant }>,
+      action: PayloadAction<{
+        variant: GameVariant;
+        version: string;
+      }>,
     ) => {
       state.currentlyPlaying = action.payload.variant;
+      state.currentlyPlayingVersion = action.payload.version;
     },
     clearCurrentlyPlaying: (state) => {
       state.currentlyPlaying = null;
+      state.currentlyPlayingVersion = null;
     },
   },
 });


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add real-time gameplay time tracking that logs every minute and updates the UI instantly. Decouples time tracking from the launch flow and tracks both variant and version.

- **New Features**
  - PlayTimeMonitor logs 60s of play time every 60s while a game is active.
  - New Tauri command log_play_time with server-side handler and client wrapper.
  - Invalidate play time queries (variant and version) to refresh the UI in real time.

- **Refactors**
  - Removed play time logging from launch_and_monitor_game and launch_game; no repository passed through the launch path.
  - Store now tracks currentlyPlaying and currentlyPlayingVersion; set on launch, cleared on stop.
  - Mounted PlayTimeMonitor in Providers; updated PlayPage hook to set the version on launch.

<sup>Written for commit 269825bdd19f6bbc9dcb611ad570515ce12769ff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









