### PR TITLE
Replace refresh button with 'Upgrade to Latest' button

### DIFF
--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod play_time;
 mod soundpacks;
 mod theme;
 mod tilesets;
+mod upgrade_to_latest;
 mod users;
 mod utils;
 mod variants;
@@ -57,6 +58,7 @@ use crate::tilesets::commands::{
   install_third_party_tileset_command, list_all_tilesets_command,
   uninstall_third_party_tileset_command,
 };
+use crate::upgrade_to_latest::commands::upgrade_to_latest;
 use crate::users::commands::get_user_id;
 use crate::utils::{
   autoupdate, manage_downloader, manage_http_client, manage_posthog,
@@ -118,6 +120,7 @@ pub fn run() {
       get_preferred_theme,
       set_preferred_theme,
       get_last_played_world,
+      upgrade_to_latest,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/cat-launcher/src-tauri/src/upgrade_to_latest/commands.rs
+++ b/cat-launcher/src-tauri/src/upgrade_to_latest/commands.rs
@@ -1,0 +1,77 @@
+use std::env::consts::OS;
+use std::sync::Arc;
+
+use strum::IntoStaticStr;
+use tauri::ipc::Channel;
+use tauri::{command, AppHandle, Emitter, Manager, State};
+
+use cat_macros::CommandErrorSerialize;
+
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::fetch_releases::fetch_releases::ReleasesUpdatePayload;
+use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
+use crate::game_release::game_release::GameRelease;
+use crate::infra::download::Downloader;
+use crate::infra::installation_progress_monitor::channel_reporter::ChannelReporter;
+use crate::infra::utils::{get_arch_enum, get_os_enum, ArchNotSupportedError, OSNotSupportedError};
+use crate::upgrade_to_latest::upgrade_to_latest::UpgradeToLatestError;
+use crate::variants::GameVariant;
+use reqwest::Client;
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum UpgradeToLatestCommandError {
+  #[error("system directory not found: {0}")]
+  SystemDir(#[from] tauri::Error),
+
+  #[error("upgrade failed: {0}")]
+  Upgrade(#[from] UpgradeToLatestError),
+
+  #[error("failed to get OS enum: {0}")]
+  Os(#[from] OSNotSupportedError),
+
+  #[error("failed to get arch enum: {0}")]
+  Arch(#[from] ArchNotSupportedError),
+}
+
+#[command]
+pub async fn upgrade_to_latest(
+  app_handle: AppHandle,
+  variant: GameVariant,
+  releases_repository: State<'_, SqliteReleasesRepository>,
+  active_release_repository: State<'_, SqliteActiveReleaseRepository>,
+  downloader: State<'_, Downloader>,
+  client: State<'_, Client>,
+  on_download_progress: Channel,
+) -> Result<GameRelease, UpgradeToLatestCommandError> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  let resource_dir = app_handle.path().resource_dir()?;
+
+  let os = get_os_enum(OS)?;
+  let arch = get_arch_enum(std::env::consts::ARCH)?;
+
+  let progress = Arc::new(ChannelReporter::new(on_download_progress));
+
+  let on_releases = move |payload: ReleasesUpdatePayload| {
+    app_handle.emit("releases-update", payload)?;
+    Ok::<(), tauri::Error>(())
+  };
+
+  let release = variant
+    .upgrade_to_latest(
+      &client,
+      &downloader,
+      &os,
+      &arch,
+      &data_dir,
+      &resource_dir,
+      &*releases_repository,
+      &*active_release_repository,
+      progress,
+      on_releases,
+    )
+    .await?;
+
+  Ok(release)
+}

--- a/cat-launcher/src-tauri/src/upgrade_to_latest/mod.rs
+++ b/cat-launcher/src-tauri/src/upgrade_to_latest/mod.rs
@@ -1,0 +1,2 @@
+pub mod commands;
+pub mod upgrade_to_latest;

--- a/cat-launcher/src-tauri/src/upgrade_to_latest/upgrade_to_latest.rs
+++ b/cat-launcher/src-tauri/src/upgrade_to_latest/upgrade_to_latest.rs
@@ -1,0 +1,242 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use reqwest::Client;
+use tokio::fs;
+
+use crate::active_release::repository::ActiveReleaseRepository;
+use crate::fetch_releases::fetch_releases::ReleasesUpdatePayload;
+use crate::fetch_releases::repository::ReleasesRepository;
+use crate::filesystem::paths::{
+  get_or_create_asset_download_dir,
+  get_or_create_asset_installation_dir, AssetDownloadDirError,
+  AssetExtractionDirError,
+};
+use crate::game_release::game_release::{
+  GameRelease, GameReleaseStatus, ReleaseType,
+};
+use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::download::Downloader;
+use crate::infra::github::asset::AssetDownloadError;
+use crate::infra::utils::{Arch, OS};
+use crate::install_release::installation_status::status::GetInstallationStatusError;
+use crate::variants::GameVariant;
+
+#[derive(thiserror::Error, Debug)]
+pub enum UpgradeToLatestError {
+  #[error("failed to fetch releases: {0}")]
+  FetchReleases(Box<dyn Error + Send + Sync>),
+
+  #[error("no releases available")]
+  NoReleasesAvailable,
+
+  #[error("no experimental release available")]
+  NoExperimentalRelease,
+
+  #[error("failed to get download directory: {0}")]
+  DownloadDir(#[from] AssetDownloadDirError),
+
+  #[error("failed to get extraction directory: {0}")]
+  ExtractionDir(#[from] AssetExtractionDirError),
+
+  #[error("failed to create downloader: {0}")]
+  Downloader(#[from] downloader::Error),
+
+  #[error("no compatible asset found")]
+  NoCompatibleAsset,
+
+  #[error("failed to download asset: {0}")]
+  Download(#[from] AssetDownloadError),
+
+  #[error("failed to extract asset: {0}")]
+  Extract(#[from] ExtractionError),
+
+  #[error("failed to get release status: {0}")]
+  ReleaseStatus(#[from] GetInstallationStatusError),
+
+  #[error("failed to set active release: {0}")]
+  ActiveRelease(
+    #[from] crate::active_release::active_release::ActiveReleaseError,
+  ),
+
+  #[error("failed to access releases cache: {0}")]
+  Repository(
+    #[from]
+    crate::fetch_releases::repository::ReleasesRepositoryError,
+  ),
+
+  #[error("failed to fetch from github: {0}")]
+  GitHubFetch(
+    #[from] crate::infra::github::utils::GitHubReleaseFetchError,
+  ),
+}
+
+#[allow(clippy::too_many_arguments)]
+impl GameVariant {
+  pub async fn upgrade_to_latest<E, F>(
+    &self,
+    client: &Client,
+    downloader: &Downloader,
+    os: &OS,
+    arch: &Arch,
+    data_dir: &std::path::Path,
+    resources_dir: &std::path::Path,
+    releases_repository: &dyn ReleasesRepository,
+    active_release_repository: &dyn ActiveReleaseRepository,
+    progress: Arc<dyn downloader::progress::Reporter + Send + Sync>,
+    on_releases: F,
+  ) -> Result<GameRelease, UpgradeToLatestError>
+  where
+    E: Error,
+    F: Fn(ReleasesUpdatePayload) -> Result<(), E>,
+  {
+    // Try to fetch the latest releases from GitHub
+    let fetched_releases =
+      crate::infra::github::utils::fetch_github_releases(
+        client,
+        crate::infra::utils::get_github_repo_for_variant(self),
+        Some(100),
+      )
+      .await
+      .ok();
+
+    // Get cached releases as fallback
+    let cached_releases = releases_repository
+      .get_cached_releases(self)
+      .await
+      .unwrap_or_default();
+
+    // Use fetched releases if available, otherwise use cached
+    let releases_to_use = if let Some(fetched) = fetched_releases {
+      releases_repository
+        .update_cached_releases(self, &fetched)
+        .await
+        .ok(); // Update cache but don't fail if it doesn't work
+      fetched
+    } else {
+      cached_releases
+    };
+
+    // Convert GitHub releases to GameReleases
+    let game_releases: Vec<GameRelease> = releases_to_use
+      .iter()
+      .map(|r| {
+        crate::game_release::utils::gh_release_to_game_release(
+          r, self,
+        )
+      })
+      .collect();
+
+    if game_releases.is_empty() {
+      return Err(UpgradeToLatestError::NoReleasesAvailable);
+    }
+
+    // Find the latest experimental release
+    let latest_experimental = game_releases
+      .iter()
+      .filter(|r| r.release_type == ReleaseType::Experimental)
+      .max_by_key(|r| r.created_at)
+      .ok_or(UpgradeToLatestError::NoExperimentalRelease)?
+      .clone();
+
+    // Emit update event
+    let payload = crate::fetch_releases::utils::get_releases_payload(
+      self,
+      &releases_to_use,
+      crate::fetch_releases::fetch_releases::ReleasesUpdateStatus::Success,
+    );
+    let _ = on_releases(payload);
+
+    // Install the release
+    let mut release = latest_experimental;
+    if release.status == GameReleaseStatus::Unknown {
+      release.status =
+        release.get_installation_status(os, data_dir).await?;
+    }
+
+    if release.status == GameReleaseStatus::ReadyToPlay {
+      self
+        .set_active_release(
+          &release.version,
+          active_release_repository,
+        )
+        .await?;
+      return Ok(release);
+    }
+
+    let download_dir =
+      get_or_create_asset_download_dir(self, data_dir).await?;
+    let asset = release
+      .get_asset(os, arch, resources_dir, releases_repository)
+      .await
+      .ok_or(UpgradeToLatestError::NoCompatibleAsset)?;
+
+    if release.status == GameReleaseStatus::NotDownloaded
+      || release.status == GameReleaseStatus::Corrupted
+      || release.status == GameReleaseStatus::Unknown
+    {
+      asset.download(downloader, &download_dir, progress).await?;
+      release.status = GameReleaseStatus::NotInstalled;
+    }
+
+    let download_filepath = download_dir.join(&asset.name);
+    let installation_dir = get_or_create_asset_installation_dir(
+      self,
+      &release.version,
+      data_dir,
+    )
+    .await?;
+
+    extract_archive(&download_filepath, &installation_dir, os)
+      .await?;
+
+    release.status = GameReleaseStatus::ReadyToPlay;
+
+    self
+      .set_active_release(&release.version, active_release_repository)
+      .await?;
+
+    // Failure to remove file does not mean failure to install
+    let _ = fs::remove_file(&download_filepath).await;
+
+    delete_other_installations(&installation_dir).await;
+
+    Ok(release)
+  }
+}
+
+async fn delete_other_installations(
+  installation_dir: &std::path::Path,
+) {
+  let Some(parent) = installation_dir.parent() else {
+    return;
+  };
+
+  let Ok(mut entries) = fs::read_dir(parent).await else {
+    return;
+  };
+
+  let Ok(kept_path) = fs::canonicalize(installation_dir).await else {
+    return;
+  };
+
+  while let Ok(Some(entry)) = entries.next_entry().await {
+    let path = entry.path();
+
+    let Ok(metadata) = fs::metadata(&path).await else {
+      continue;
+    };
+
+    if !metadata.is_dir() {
+      continue;
+    }
+
+    let Ok(canonical_path) = fs::canonicalize(&path).await else {
+      continue;
+    };
+
+    if canonical_path != kept_path {
+      let _ = fs::remove_dir_all(&path).await;
+    }
+  }
+}

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -432,3 +432,20 @@ export async function uninstallThirdPartySoundpack(
     variant: variant,
   });
 }
+
+export async function upgradeToLatest(
+  variant: GameVariant,
+  onDownloadProgress: (progress: DownloadProgress) => void,
+): Promise<GameRelease> {
+  const channel = new Channel();
+  channel.onmessage = (progress) => {
+    onDownloadProgress(progress as DownloadProgress);
+  };
+
+  const response = await invoke<GameRelease>("upgrade_to_latest", {
+    variant,
+    onDownloadProgress: channel,
+  });
+
+  return response;
+}


### PR DESCRIPTION
- Removed the manual refresh button from ReleaseSelector component
- Added new 'Upgrade to Latest' button that upgrades to the latest experimental version
- Created upgrade_to_latest backend feature that:
  - Fetches latest experimental releases from GitHub (with cached releases as fallback)
  - Installs the latest experimental version
  - Sets it as the active release
- Added upgradeToLatest command to frontend commands API
- Added upgrade_to_latest hook in ReleaseSelector with appropriate loading/success/error states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the manual refresh with an “Upgrade to Latest” action that installs and activates the newest experimental build for the selected variant. Adds a backend command and progress wiring to fetch from GitHub (with cached fallback), install, and set the release active.

- New Features
  - UI: Replaced refresh button with “Upgrade to Latest” in ReleaseSelector; shows loading state and success/error toasts.
  - Backend: Added upgrade_to_latest command to fetch releases (GitHub with cache fallback), pick the latest experimental, download with progress, extract, and set active.
  - Events/Progress: Emits releases-update during the flow; frontend upgradeToLatest API uses a Channel to stream download progress.
  - Cleanup: Removes old installations and the downloaded archive after a successful install; no-op if the latest experimental is already installed.

<sup>Written for commit 4ba9c37635b2621589614a89e06be5b44ac6aadc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

