### PR TITLE
Add Pre-Installed button for stock mods, tilesets, and soundpacks

### DIFF
--- a/cat-launcher/src/components/PreInstalledButton.tsx
+++ b/cat-launcher/src/components/PreInstalledButton.tsx
@@ -1,0 +1,9 @@
+import { Button } from "./ui/button";
+
+export function PreInstalledButton() {
+  return (
+    <Button className="w-full" disabled>
+      Pre-Installed
+    </Button>
+  );
+}

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -19,6 +19,7 @@ import {
   useUninstallThirdPartyMod,
 } from "./hooks";
 import { ModInstallationConfirmationDialog } from "./ModInstallationConfirmationDialog";
+import { PreInstalledButton } from "@/components/PreInstalledButton";
 
 interface ModCardProps {
   variant: GameVariant;
@@ -107,9 +108,9 @@ export default function ModCard({ variant, mod }: ModCardProps) {
           </AlertDescription>
         </Alert>
       </CardContent>
-      {isThirdParty && (
-        <CardFooter className="flex flex-col gap-4 items-stretch">
-          {modInstallationProgress === "Downloading" &&
+      <CardFooter className="flex flex-col gap-4 items-stretch">
+        {isThirdParty ? (
+          modInstallationProgress === "Downloading" &&
           modDownloadProgress ? (
             <DownloadProgress
               downloaded={modDownloadProgress.bytes_downloaded}
@@ -136,9 +137,11 @@ export default function ModCard({ variant, mod }: ModCardProps) {
                   ? "Downloading..."
                   : "Install"}
             </Button>
-          )}
-        </CardFooter>
-      )}
+          )
+        ) : (
+          <PreInstalledButton />
+        )}
+      </CardFooter>
       <ModInstallationConfirmationDialog
         open={confirmationDialogOpen}
         onOpenChange={setConfirmationDialogOpen}

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
@@ -15,6 +15,7 @@ import {
   useInstallThirdPartySoundpack,
   useUninstallThirdPartySoundpack,
 } from "./hooks";
+import { PreInstalledButton } from "@/components/PreInstalledButton";
 
 interface SoundpackCardProps {
   variant: GameVariant;
@@ -77,9 +78,9 @@ export default function SoundpackCard({
           </div>
         </div>
       </CardHeader>
-      {isThirdParty && (
-        <CardFooter className="flex flex-col gap-4 items-stretch">
-          {soundpackInstallationProgress === "Downloading" &&
+      <CardFooter className="flex flex-col gap-4 items-stretch">
+        {isThirdParty ? (
+          soundpackInstallationProgress === "Downloading" &&
           soundpackDownloadProgress ? (
             <DownloadProgress
               downloaded={soundpackDownloadProgress.bytes_downloaded}
@@ -108,9 +109,11 @@ export default function SoundpackCard({
                   ? "Downloading..."
                   : "Install"}
             </Button>
-          )}
-        </CardFooter>
-      )}
+          )
+        ) : (
+          <PreInstalledButton />
+        )}
+      </CardFooter>
     </Card>
   );
 }

--- a/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
@@ -15,6 +15,7 @@ import {
   useInstallAndMonitorThirdPartyTileset,
   useUninstallThirdPartyTileset,
 } from "./hooks";
+import { PreInstalledButton } from "@/components/PreInstalledButton";
 
 interface TilesetCardProps {
   variant: GameVariant;
@@ -75,9 +76,9 @@ export default function TilesetCard({
           </div>
         </div>
       </CardHeader>
-      {isThirdParty && (
-        <CardFooter className="flex flex-col gap-4 items-stretch">
-          {tilesetInstallationProgress === "Downloading" &&
+      <CardFooter className="flex flex-col gap-4 items-stretch">
+        {isThirdParty ? (
+          tilesetInstallationProgress === "Downloading" &&
           tilesetDownloadProgress ? (
             <DownloadProgress
               downloaded={tilesetDownloadProgress.bytes_downloaded}
@@ -104,9 +105,11 @@ export default function TilesetCard({
                   ? "Downloading..."
                   : "Install"}
             </Button>
-          )}
-        </CardFooter>
-      )}
+          )
+        ) : (
+          <PreInstalledButton />
+        )}
+      </CardFooter>
     </Card>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a disabled “Pre-Installed” button on stock mods, tilesets, and soundpacks to clearly show built-in content and prevent install actions. Introduces a reusable PreInstalledButton component and updates card footers to show either install controls (third-party) or the pre-installed indicator.

<sup>Written for commit 20871cccbdc4e765e670b3cbd3b81ef0e9833feb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

