### PR TITLE
Add Upgrade button and remove refresh button from release selector

### DIFF
--- a/cat-launcher/src/pages/PlayPage/GameVariantCard.tsx
+++ b/cat-launcher/src/pages/PlayPage/GameVariantCard.tsx
@@ -63,6 +63,7 @@ export default function GameVariantCard({
         <InteractionButton
           variant={variantInfo.id}
           selectedReleaseId={selectedReleaseId}
+          setSelectedReleaseId={setSelectedReleaseId}
         />
         <PlayTime
           variant={variantInfo.id}

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -1,8 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
-import { Button } from "@/components/ui/button";
 import {
   VirtualizedCombobox,
   type ComboboxItem,
@@ -14,10 +11,9 @@ import {
   triggerFetchReleasesForVariant,
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
-import { cn, toastCL } from "@/lib/utils";
+import { toastCL } from "@/lib/utils";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
-  FetchStatus,
   onFetchingReleasesFailed,
   startFetchingReleases,
 } from "@/store/releasesSlice";
@@ -36,9 +32,6 @@ export default function ReleaseSelector({
 
   const releases = useAppSelector(
     (state) => state.releases.releasesByVariant[variant],
-  );
-  const releasesFetchStatus = useAppSelector(
-    (state) => state.releases.fetchStatusByVariant[variant],
   );
 
   const {
@@ -177,11 +170,6 @@ export default function ReleaseSelector({
     ],
   );
 
-  // Consider isReleaseFetchingComplete even if it completes due to an error
-  const isReleaseFetchingComplete =
-    !isReleasesTriggerLoading &&
-    releasesFetchStatus !== FetchStatus.Fetching;
-
   // Even if isReleasesTriggerLoading is true, releases from previous release
   // events might be available. Consider isReleaseFetchingLoading only when
   // there are no items as well.
@@ -220,19 +208,6 @@ export default function ReleaseSelector({
             disabled={isReleaseFetchingLoading || isInstalling}
           />
         </div>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => triggerFetchReleases(variant)}
-          disabled={!isReleaseFetchingComplete || isInstalling}
-        >
-          <RefreshCw
-            className={cn(
-              !isReleaseFetchingComplete && "animate-spin",
-            )}
-            size={16}
-          />
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an Upgrade button for the active release selection that installs the latest release for the variant, and removed the manual refresh button from the release selector to simplify the UI. Upgrade is disabled while a game is running.

- **New Features**
  - Show Upgrade only when viewing the active release and a newer release exists; clicking updates selection and starts install.
  - InteractionButton now accepts setSelectedReleaseId to update selection from the card.

- **Refactors**
  - Removed the refresh button and related fetch status logic from ReleaseSelector; rely on existing release fetch behavior.

<sup>Written for commit ec2001841c51bab03a8cf5f50c30599ef4351e11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









