### PR TITLE
Auto-select latest release when no active release exists

### DIFF
--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
+
 import {
   VirtualizedCombobox,
   type ComboboxItem,
@@ -88,22 +89,11 @@ export default function ReleaseSelector({
     () => (_r: GameRelease) => true,
   );
 
+  const latestRelease = useMemo(() => {
+    return releases?.[0];
+  }, [releases]);
+
   const comboboxItems = useMemo<ComboboxItem[]>(() => {
-    const latestRelease = releases.reduce(
-      (prev: undefined | GameRelease, curr) => {
-        if (!prev) {
-          return curr;
-        }
-
-        if (curr.created_at > prev.created_at) {
-          return curr;
-        }
-
-        return prev;
-      },
-      undefined,
-    );
-
     return (
       releases.filter(appliedFilter).map((r) => {
         const isActive = r.version === activeRelease;
@@ -122,7 +112,13 @@ export default function ReleaseSelector({
         };
       }) ?? []
     );
-  }, [releases, activeRelease, variant, appliedFilter]);
+  }, [
+    releases,
+    activeRelease,
+    variant,
+    appliedFilter,
+    latestRelease,
+  ]);
 
   useEffect(() => {
     // Selected release may become unavailable after filtering
@@ -157,16 +153,22 @@ export default function ReleaseSelector({
       }
 
       if (activeReleaseError || activeRelease === "") {
-        return items[0];
+        return (
+          items.find((i) => i.value === latestRelease?.version) ??
+          items?.[0]
+        );
       }
 
-      return items.find((i) => i.value === activeRelease) ?? items[0];
+      return (
+        items.find((i) => i.value === activeRelease) ?? items?.[0]
+      );
     },
     [
       activeRelease,
       isActiveReleaseLoading,
       activeReleaseError,
       installationStatusByVersion,
+      latestRelease,
     ],
   );
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default the release selector to the latest release when there’s no active release or an error, so first-load always shows the most recent version.

- **Bug Fixes**
  - Use releases[0] as latestRelease and select it when no active release exists or errors; fallback to the first item if needed.
  - Add latestRelease to combobox and selection memo dependencies to keep selection in sync after filtering.

<sup>Written for commit 3439a296664e52c6151c11e7bdcc28e461955502. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



