### PR TITLE
Preserve variant selection across page switches

### DIFF
--- a/cat-launcher/src/pages/AssetsPage/index.tsx
+++ b/cat-launcher/src/pages/AssetsPage/index.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react";
 
 import VariantSelector from "@/components/VariantSelector";
-import type { GameVariant } from "@/generated-types/GameVariant";
 import { useGameVariants } from "@/hooks/useGameVariants";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { setSelectedVariant } from "@/store/selectedVariantSlice";
 import AssetTypeSelector from "./AssetTypeSelector";
 import { type AssetType, ASSET_COMPONENTS } from "./types";
 
 function AssetsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();
-  const [selectedVariant, setSelectedVariant] =
-    useState<GameVariant | null>(null);
+  const selectedVariant = useAppSelector(
+    (state) => state.selectedVariant.variant,
+  );
+  const dispatch = useAppDispatch();
   const [assetType, setAssetType] = useState<AssetType>("mods");
 
   return (
@@ -19,7 +22,9 @@ function AssetsPage() {
         <VariantSelector
           gameVariants={gameVariants}
           selectedVariant={selectedVariant}
-          onVariantChange={setSelectedVariant}
+          onVariantChange={(variant) =>
+            dispatch(setSelectedVariant(variant))
+          }
           isLoading={gameVariantsLoading}
         />
         {selectedVariant && (

--- a/cat-launcher/src/pages/BackupsPage/index.tsx
+++ b/cat-launcher/src/pages/BackupsPage/index.tsx
@@ -3,11 +3,12 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/SearchInput";
 import VariantSelector from "@/components/VariantSelector";
-import { GameVariant } from "@/generated-types/GameVariant";
 import { useCombinedBackups } from "@/hooks/useCombinedBackups";
 import { useGameVariants } from "@/hooks/useGameVariants";
 import { useSearch } from "@/hooks/useSearch";
 import { toastCL } from "@/lib/utils";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { setSelectedVariant } from "@/store/selectedVariantSlice";
 import BackupFilter, { BackupFilterFn } from "./BackupFilter";
 import { BackupsTable } from "./BackupsTable";
 import { DeleteBackupDialog } from "./DeleteBackupDialog";
@@ -31,8 +32,10 @@ function formatTimestampForSearch(timestamp: bigint): string {
 function BackupsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();
-  const [selectedVariant, setSelectedVariant] =
-    useState<GameVariant | null>(null);
+  const selectedVariant = useAppSelector(
+    (state) => state.selectedVariant.variant,
+  );
+  const dispatch = useAppDispatch();
   const [newManualDialogOpen, setNewManualDialogOpen] =
     useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -43,7 +46,7 @@ function BackupsPage() {
     () => (_backup: CombinedBackup) => true,
   );
 
-  const activeVariant = (selectedVariant ?? gameVariants[0]?.id)!;
+  const activeVariant = selectedVariant ?? gameVariants[0].id;
 
   const {
     combinedBackups,
@@ -115,7 +118,9 @@ function BackupsPage() {
         <VariantSelector
           gameVariants={gameVariants}
           selectedVariant={selectedVariant}
-          onVariantChange={setSelectedVariant}
+          onVariantChange={(variant) =>
+            dispatch(setSelectedVariant(variant))
+          }
           isLoading={gameVariantsLoading}
         />
         <Button

--- a/cat-launcher/src/store/selectedVariantSlice.ts
+++ b/cat-launcher/src/store/selectedVariantSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+import { GameVariant } from "@/generated-types/GameVariant";
+
+interface SelectedVariantState {
+  variant: GameVariant | null;
+}
+
+const initialState: SelectedVariantState = {
+  variant: null,
+};
+
+export const selectedVariantSlice = createSlice({
+  name: "selectedVariant",
+  initialState,
+  reducers: {
+    setSelectedVariant: (
+      state,
+      action: PayloadAction<GameVariant | null>,
+    ) => {
+      state.variant = action.payload;
+    },
+  },
+});
+
+export const { setSelectedVariant } = selectedVariantSlice.actions;
+export default selectedVariantSlice.reducer;

--- a/cat-launcher/src/store/store.ts
+++ b/cat-launcher/src/store/store.ts
@@ -3,12 +3,14 @@ import { configureStore } from "@reduxjs/toolkit";
 import gameSessionReducer from "./gameSessionSlice";
 import installationProgressReducer from "./installationProgressSlice";
 import releasesReducer from "./releasesSlice";
+import selectedVariantReducer from "./selectedVariantSlice";
 
 export const store = configureStore({
   reducer: {
     gameSession: gameSessionReducer,
     releases: releasesReducer,
     installationProgress: installationProgressReducer,
+    selectedVariant: selectedVariantReducer,
   },
 });
 


### PR DESCRIPTION
- Created selectedVariantSlice Redux store to manage selected variant globally
- Updated AssetsPage to use Redux store instead of local state
- Updated BackupsPage to use Redux store instead of local state
- Variant selection now persists when switching between AssetsPage and BackupsPage



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the selected game variant when moving between Assets and Backups pages. Stores the selection in Redux so users don’t need to reselect.

- **New Features**
  - Added selectedVariantSlice and wired it into the Redux store.
  - Updated AssetsPage and BackupsPage to read from and dispatch to the global selected variant.

<sup>Written for commit efb73265b59a499a877762facad17901749af876. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



