### PR TITLE
Settings tab

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -449,9 +449,11 @@ dependencies = [
  "async-trait",
  "cat-macros",
  "chrono",
+ "dirs",
  "dmg",
  "downloader",
  "flate2",
+ "font-kit",
  "posthog-rs",
  "r2d2",
  "r2d2_sqlite",
@@ -473,6 +475,7 @@ dependencies = [
  "unrar",
  "url",
  "uuid",
+ "walkdir",
  "zip 6.0.0",
 ]
 
@@ -629,14 +632,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -648,6 +675,18 @@ checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -947,6 +986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1068,18 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1198,10 +1258,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "font-kit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "core-text",
+ "dirs",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1252,6 +1343,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3074,6 +3176,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,7 +4450,7 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -4562,7 +4683,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -6302,6 +6423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6387,6 +6517,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -44,6 +44,9 @@ r2d2_sqlite = "0.22.0"
 uuid = { version = "1.19.0", features = ["v4"] }
 posthog-rs = "0.3.7"
 url = "2.5.7"
+font-kit = "0.14.3"
+walkdir = "2.5.0"
+dirs = "6.0.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.9.0"

--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -137,3 +137,12 @@ CREATE TABLE IF NOT EXISTS installed_soundpacks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_installed_soundpacks_game_variant ON installed_mods (game_variant);
+
+-- This table stores launcher settings.
+-- The _id column with CHECK(_id = 1) ensures only one row can exist.
+CREATE TABLE IF NOT EXISTS settings (
+    _id INTEGER PRIMARY KEY DEFAULT 1 CHECK(_id = 1),
+    max_backups INTEGER NOT NULL CHECK(max_backups >= 0 AND max_backups <= 20),
+    parallel_requests INTEGER NOT NULL CHECK(parallel_requests >= 1 AND parallel_requests <= 16),
+    font_path TEXT
+);

--- a/cat-launcher/src-tauri/src/constants.rs
+++ b/cat-launcher/src-tauri/src/constants.rs
@@ -1,2 +1,6 @@
-pub const DEFAULT_MAX_BACKUPS: usize = 5;
+pub const DEFAULT_MAX_BACKUPS: u16 = 5;
 pub const DEFAULT_PARALLEL_REQUESTS: u16 = 4;
+pub const MIN_MAX_BACKUPS: u16 = 0;
+pub const MAX_MAX_BACKUPS: u16 = 20;
+pub const MIN_PARALLEL_REQUESTS: u16 = 1;
+pub const MAX_PARALLEL_REQUESTS: u16 = 16;

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -220,11 +220,11 @@ async fn cleanup_old_backups(
     .get_backups_sorted_by_timestamp(variant)
     .await?;
 
-  if backups.len() <= settings.max_backups.get() {
+  if backups.len() <= settings.max_backups as usize {
     return Ok(());
   }
 
-  let num_to_delete = backups.len() - settings.max_backups.get();
+  let num_to_delete = backups.len() - settings.max_backups as usize;
   let backups_to_delete = backups.into_iter().take(num_to_delete);
 
   let mut set = JoinSet::new();

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -44,6 +44,9 @@ use crate::mods::commands::{
 use crate::play_time::commands::{
   get_play_time_for_variant, get_play_time_for_version, log_play_time,
 };
+use crate::settings::commands::{
+  get_fonts, get_settings, update_settings,
+};
 use crate::soundpacks::commands::{
   get_third_party_soundpack_installation_status_command,
   install_third_party_soundpack_command, list_all_soundpacks_command,
@@ -78,10 +81,10 @@ pub fn run() {
     .plugin(tauri_plugin_updater::Builder::new().build())
     .plugin(tauri_plugin_opener::init())
     .setup(|app| {
-      manage_settings(app)?;
       manage_http_client(app);
-      manage_downloader(app);
       manage_repositories(app)?;
+      manage_settings(app)?;
+      manage_downloader(app);
       manage_posthog(app);
 
       migrate_to_local_data_dir(app);
@@ -127,6 +130,9 @@ pub fn run() {
       get_preferred_theme,
       set_preferred_theme,
       get_last_played_world,
+      get_settings,
+      update_settings,
+      get_fonts,
       confirm_quit,
     ])
     .run(tauri::generate_context!())

--- a/cat-launcher/src-tauri/src/settings/commands.rs
+++ b/cat-launcher/src-tauri/src/settings/commands.rs
@@ -1,0 +1,65 @@
+use strum::IntoStaticStr;
+use tauri::State;
+
+use cat_macros::CommandErrorSerialize;
+
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::settings::fonts::{get_available_fonts, Font, FontError};
+use crate::settings::repository::sqlite_settings_repository::SqliteSettingsRepository;
+use crate::settings::settings::{
+  get_settings as get_settings_logic,
+  update_settings as update_settings_logic, GetSettingsError,
+  UpdateSettingsError,
+};
+use crate::settings::Settings;
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum GetSettingsCommandError {
+  #[error("failed to get settings: {0}")]
+  GetSettings(#[from] GetSettingsError),
+}
+
+#[tauri::command]
+pub async fn get_settings(
+  repo: State<'_, SqliteSettingsRepository>,
+) -> Result<Settings, GetSettingsCommandError> {
+  let settings = get_settings_logic(repo.inner()).await?;
+  Ok(settings)
+}
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum UpdateSettingsCommandError {
+  #[error("failed to update settings: {0}")]
+  UpdateSettings(#[from] UpdateSettingsError),
+}
+
+#[tauri::command]
+pub async fn update_settings(
+  settings: Settings,
+  repo: State<'_, SqliteSettingsRepository>,
+) -> Result<(), UpdateSettingsCommandError> {
+  update_settings_logic(&settings, repo.inner()).await?;
+  Ok(())
+}
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum GetFontsCommandError {
+  #[error("failed to get fonts: {0}")]
+  GetFonts(#[from] FontError),
+
+  #[error("failed to get OS: {0}")]
+  OS(#[from] OSNotSupportedError),
+}
+
+#[tauri::command]
+pub async fn get_fonts() -> Result<Vec<Font>, GetFontsCommandError> {
+  let os = get_os_enum(std::env::consts::OS)?;
+  let fonts = get_available_fonts(&os)?;
+  Ok(fonts)
+}

--- a/cat-launcher/src-tauri/src/settings/fonts.rs
+++ b/cat-launcher/src-tauri/src/settings/fonts.rs
@@ -1,0 +1,81 @@
+use std::path::{Path, PathBuf};
+
+use font_kit::font::Font as FontKitFont;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use walkdir::WalkDir;
+
+use crate::infra::utils::OS;
+use crate::settings::paths::get_font_directories;
+
+#[derive(Debug, Serialize, Deserialize, Clone, TS, PartialEq)]
+#[ts(export)]
+pub struct Font {
+  pub name: String,
+  pub path: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FontError {
+  #[error("failed to list fonts: {0}")]
+  List(String),
+}
+
+fn get_fonts_in_directory(dir: PathBuf) -> Vec<Font> {
+  let mut fonts = Vec::new();
+  for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+    let path = entry.path();
+    if path.is_file() {
+      if let Ok(font) = FontKitFont::from_path(path, 0) {
+        let name = font.full_name();
+        let path_str = path.to_string_lossy().to_string();
+        fonts.push(Font {
+          name,
+          path: path_str,
+        });
+      }
+    }
+  }
+  fonts
+}
+
+pub fn get_available_fonts(os: &OS) -> Result<Vec<Font>, FontError> {
+  let mut fonts = Vec::new();
+  let directories = get_font_directories(os);
+
+  for dir in directories {
+    if dir.as_os_str().is_empty() || !dir.exists() {
+      continue;
+    }
+    fonts.extend(get_fonts_in_directory(dir));
+  }
+
+  fonts.sort_by(|a, b| a.name.cmp(&b.name));
+  fonts.dedup_by(|a, b| a.name == b.name);
+
+  Ok(fonts)
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum GetFontFromPathError {
+  #[error("font file does not exist")]
+  DoesNotExist,
+  #[error("failed to load font: {0}")]
+  Load(String),
+}
+
+pub fn get_font_from_path(
+  path: &str,
+) -> Result<Font, GetFontFromPathError> {
+  let path_obj = Path::new(path);
+  if !path_obj.exists() {
+    return Err(GetFontFromPathError::DoesNotExist);
+  }
+  match FontKitFont::from_path(path_obj, 0) {
+    Ok(font) => Ok(Font {
+      name: font.full_name(),
+      path: path.to_string(),
+    }),
+    Err(e) => Err(GetFontFromPathError::Load(e.to_string())),
+  }
+}

--- a/cat-launcher/src-tauri/src/settings/mod.rs
+++ b/cat-launcher/src-tauri/src/settings/mod.rs
@@ -1,4 +1,8 @@
+pub mod commands;
+pub mod fonts;
+pub mod paths;
+pub mod repository;
 #[allow(clippy::module_inception)]
 pub mod settings;
 
-pub use settings::{GameSettings, Settings};
+pub use settings::Settings;

--- a/cat-launcher/src-tauri/src/settings/paths.rs
+++ b/cat-launcher/src-tauri/src/settings/paths.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use crate::infra::utils::OS;
+
+pub fn get_font_directories(os: &OS) -> Vec<PathBuf> {
+  match os {
+    OS::Linux => vec![
+      PathBuf::from("/usr/share/fonts"),
+      PathBuf::from("/usr/local/share/fonts"),
+      dirs::home_dir()
+        .map(|h| h.join(".fonts"))
+        .unwrap_or_default(),
+      dirs::home_dir()
+        .map(|h| h.join(".local/share/fonts"))
+        .unwrap_or_default(),
+    ],
+    OS::Windows => vec![
+      PathBuf::from("C:\\Windows\\Fonts"),
+      dirs::home_dir()
+        .map(|h| h.join("AppData\\Local\\Microsoft\\Windows\\Fonts"))
+        .unwrap_or_default(),
+    ],
+    OS::Mac => vec![
+      PathBuf::from("/System/Library/Fonts"),
+      PathBuf::from("/Library/Fonts"),
+      dirs::home_dir()
+        .map(|h| h.join("Library/Fonts"))
+        .unwrap_or_default(),
+    ],
+  }
+}

--- a/cat-launcher/src-tauri/src/settings/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod settings_repository;
+pub mod sqlite_settings_repository;

--- a/cat-launcher/src-tauri/src/settings/repository/settings_repository.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/settings_repository.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+
+use crate::settings::fonts::GetFontFromPathError;
+use crate::settings::Settings;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SettingsRepositoryError {
+  #[error("failed to get settings: {0}")]
+  Get(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+  #[error("failed to update settings: {0}")]
+  Update(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+  #[error("failed to load font: {0}")]
+  FontLoad(#[from] GetFontFromPathError),
+}
+
+#[async_trait]
+pub trait SettingsRepository: Send + Sync {
+  async fn get_settings(
+    &self,
+  ) -> Result<Settings, SettingsRepositoryError>;
+  async fn update_settings(
+    &self,
+    settings: &Settings,
+  ) -> Result<(), SettingsRepositoryError>;
+}

--- a/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::params;
+use tokio::task;
+
+use super::settings_repository::{
+  SettingsRepository, SettingsRepositoryError,
+};
+use crate::settings::fonts::get_font_from_path;
+use crate::settings::Settings;
+
+type Pool = r2d2::Pool<SqliteConnectionManager>;
+
+#[derive(Clone)]
+pub struct SqliteSettingsRepository {
+  pool: Pool,
+}
+
+impl SqliteSettingsRepository {
+  pub fn new(pool: Pool) -> Self {
+    Self { pool }
+  }
+}
+
+#[async_trait]
+impl SettingsRepository for SqliteSettingsRepository {
+  async fn get_settings(
+    &self,
+  ) -> Result<Settings, SettingsRepositoryError> {
+    let pool = self.pool.clone();
+
+    task::spawn_blocking(move || {
+      let conn = pool
+        .get()
+        .map_err(|e| SettingsRepositoryError::Get(Box::new(e)))?;
+
+      let mut stmt = conn
+        .prepare("SELECT max_backups, parallel_requests, font_path FROM settings WHERE _id = ?1")
+        .map_err(|e| SettingsRepositoryError::Get(Box::new(e)))?;
+
+      let (max_backups, parallel_requests, font_path) = match stmt.query_row([1], |row| {
+        let max_backups: u16 = row.get(0)?;
+        let parallel_requests: u16 = row.get(1)?;
+        let font_path: Option<String> = row.get(2)?;
+        Ok((max_backups, parallel_requests, font_path))
+      }) {
+        Ok(res) => res,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+          // If no row exists, return default settings
+          let defaults = Settings::default();
+          (defaults.max_backups, defaults.parallel_requests, None)
+        }
+        Err(e) => return Err(SettingsRepositoryError::Get(Box::new(e))),
+      };
+
+      let font = font_path
+        .map(|p| get_font_from_path(&p))
+        .transpose()
+        .map_err(SettingsRepositoryError::FontLoad)?;
+
+      Ok(Settings {
+        max_backups,
+        parallel_requests,
+        font,
+      })
+    })
+    .await
+    .map_err(|e| SettingsRepositoryError::Get(Box::new(e)))?
+  }
+
+  async fn update_settings(
+    &self,
+    settings: &Settings,
+  ) -> Result<(), SettingsRepositoryError> {
+    let pool = self.pool.clone();
+    let max_backups = settings.max_backups;
+    let parallel_requests = settings.parallel_requests;
+    let font_path = settings.font.as_ref().map(|f| f.path.clone());
+
+    task::spawn_blocking(move || {
+      let conn = pool
+        .get()
+        .map_err(|e| SettingsRepositoryError::Update(Box::new(e)))?;
+
+      conn
+        .execute(
+          "INSERT OR REPLACE INTO settings (_id, max_backups, parallel_requests, font_path) VALUES (?1, ?2, ?3, ?4)",
+          params![1, max_backups, parallel_requests, font_path],
+        )
+        .map_err(|e| SettingsRepositoryError::Update(Box::new(e)))?;
+
+      Ok(())
+    })
+    .await
+    .map_err(|e| SettingsRepositoryError::Update(Box::new(e)))?
+  }
+}

--- a/cat-launcher/src-tauri/src/settings/settings.rs
+++ b/cat-launcher/src-tauri/src/settings/settings.rs
@@ -1,43 +1,54 @@
-use std::collections::HashMap;
-use std::num::{NonZeroU16, NonZeroUsize};
-
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use ts_rs::TS;
 
 use crate::constants::{
   DEFAULT_MAX_BACKUPS, DEFAULT_PARALLEL_REQUESTS,
 };
-use crate::variants::links::Link;
+use crate::settings::fonts::Font;
+use crate::settings::repository::settings_repository::SettingsRepository;
+use crate::settings::repository::settings_repository::SettingsRepositoryError;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GameSettings {
-  pub name: String,
-  pub links: Vec<Link>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, TS)]
+#[ts(export)]
 pub struct Settings {
-  pub max_backups: NonZeroUsize,
-  pub parallel_requests: NonZeroU16,
-  pub games: HashMap<String, GameSettings>,
-}
-
-#[derive(Debug, Error)]
-pub enum LoadSettingsError {
-  #[error("Could not open settings.json")]
-  OpenFile(#[source] std::io::Error),
-
-  #[error("Could not parse settings.json")]
-  Parse(#[from] serde_json::Error),
+  pub max_backups: u16,
+  pub parallel_requests: u16,
+  pub font: Option<Font>,
 }
 
 impl Default for Settings {
   fn default() -> Self {
     Self {
-      max_backups: NonZeroUsize::new(DEFAULT_MAX_BACKUPS).unwrap(),
-      parallel_requests: NonZeroU16::new(DEFAULT_PARALLEL_REQUESTS)
-        .unwrap(),
-      games: HashMap::new(),
+      max_backups: DEFAULT_MAX_BACKUPS,
+      parallel_requests: DEFAULT_PARALLEL_REQUESTS,
+      font: None,
     }
   }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetSettingsError {
+  #[error("failed to get settings: {0}")]
+  Repository(#[from] SettingsRepositoryError),
+}
+
+pub async fn get_settings(
+  repo: &dyn SettingsRepository,
+) -> Result<Settings, GetSettingsError> {
+  let settings = repo.get_settings().await?;
+  Ok(settings)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UpdateSettingsError {
+  #[error("failed to update settings: {0}")]
+  Repository(#[from] SettingsRepositoryError),
+}
+
+pub async fn update_settings(
+  settings: &Settings,
+  repo: &dyn SettingsRepository,
+) -> Result<(), UpdateSettingsError> {
+  repo.update_settings(settings).await?;
+  Ok(())
 }

--- a/cat-launcher/src-tauri/src/variants/commands.rs
+++ b/cat-launcher/src-tauri/src/variants/commands.rs
@@ -2,7 +2,6 @@ use tauri::{command, State};
 
 use cat_macros::CommandErrorSerialize;
 
-use crate::settings::Settings;
 use crate::variants::get_game_variants_info::{self, GameVariantInfo, GetGameVariantsInfoError};
 use crate::variants::repository::sqlite_game_variant_order_repository::SqliteGameVariantOrderRepository;
 use crate::variants::update_game_variant_order::{self, UpdateGameVariantOrderError};
@@ -43,14 +42,12 @@ pub enum GetGameVariantsInfoCommandError {
 
 #[command]
 pub async fn get_game_variants_info(
-  settings: State<'_, Settings>,
   game_variant_order_repository: State<
     '_,
     SqliteGameVariantOrderRepository,
   >,
 ) -> Result<Vec<GameVariantInfo>, GetGameVariantsInfoCommandError> {
   let res = get_game_variants_info::get_game_variants_info(
-    &settings,
     &*game_variant_order_repository,
   )
   .await?;

--- a/cat-launcher/src-tauri/src/variants/game_variant.rs
+++ b/cat-launcher/src-tauri/src/variants/game_variant.rs
@@ -3,7 +3,6 @@ use strum::{Display, EnumIter, EnumString, IntoStaticStr};
 use ts_rs::TS;
 
 use crate::game_release::game_release::ReleaseType;
-use crate::settings::Settings;
 use crate::variants::links::Link;
 
 #[derive(
@@ -33,20 +32,56 @@ impl GameVariant {
     self.into()
   }
 
-  pub fn name<'a>(&self, settings: &'a Settings) -> &'a str {
-    settings
-      .games
-      .get(self.id())
-      .map(|variant_settings| variant_settings.name.as_str())
-      .unwrap_or_else(|| self.id())
+  pub fn display_name(&self) -> &'static str {
+    match self {
+      GameVariant::DarkDaysAhead => "Dark Days Ahead",
+      GameVariant::BrightNights => "Bright Nights",
+      GameVariant::TheLastGeneration => "The Last Generation",
+    }
   }
 
-  pub fn links<'a>(&self, settings: &'a Settings) -> &'a [Link] {
-    settings
-      .games
-      .get(self.id())
-      .map(|variant_settings| variant_settings.links.as_slice())
-      .unwrap_or_else(|| &[])
+  pub fn links(&self) -> Vec<Link> {
+    match self {
+      GameVariant::DarkDaysAhead => vec![
+        Link {
+          label: "Guide".to_string(),
+          href: "https://cdda-guide.nornagon.net/".to_string(),
+        },
+        Link {
+          label: "Discord".to_string(),
+          href: "https://discord.gg/jFEc7Yp".to_string(),
+        },
+        Link {
+          label: "Reddit".to_string(),
+          href: "https://www.reddit.com/r/cataclysmdda/".to_string(),
+        },
+      ],
+      GameVariant::BrightNights => vec![
+        Link {
+          label: "Guide".to_string(),
+          href: "https://next.cbn-guide.pages.dev/".to_string(),
+        },
+        Link {
+          label: "Discord".to_string(),
+          href: "https://discord.gg/XW7XhXuZ89".to_string(),
+        },
+        Link {
+          label: "Reddit".to_string(),
+          href: "https://www.reddit.com/r/cataclysmbn/".to_string(),
+        },
+      ],
+      GameVariant::TheLastGeneration => vec![
+        Link {
+          label: "Discord".to_string(),
+          href: "https://discord.com/invite/zT9sXmZNCK".to_string(),
+        },
+        Link {
+          label: "Wiki".to_string(),
+          href: "https://cataclysmtlg.miraheze.org/wiki/Main_Page"
+            .to_string(),
+        },
+      ],
+    }
   }
 
   pub fn determine_release_type(

--- a/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
+++ b/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
@@ -1,6 +1,5 @@
 use strum::IntoEnumIterator;
 
-use crate::settings::Settings;
 use crate::variants::links::Link;
 use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepository;
 use crate::variants::GameVariant;
@@ -14,19 +13,6 @@ pub struct GameVariantInfo {
   pub links: Vec<Link>,
 }
 
-impl GameVariantInfo {
-  pub fn from_variant(
-    variant: GameVariant,
-    settings: &Settings,
-  ) -> Self {
-    GameVariantInfo {
-      id: variant,
-      name: variant.name(settings).to_string(),
-      links: variant.links(settings).to_vec(),
-    }
-  }
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum GetGameVariantsInfoError {
   #[error("failed to get game variant order")]
@@ -34,7 +20,6 @@ pub enum GetGameVariantsInfoError {
 }
 
 pub async fn get_game_variants_info(
-  settings: &Settings,
   game_variant_order_repository: &impl GameVariantOrderRepository,
 ) -> Result<Vec<GameVariantInfo>, GetGameVariantsInfoError> {
   let ordered_variants =
@@ -48,7 +33,11 @@ pub async fn get_game_variants_info(
 
   let result = variants_to_display
     .into_iter()
-    .map(|variant| GameVariantInfo::from_variant(variant, settings))
+    .map(|variant| GameVariantInfo {
+      id: variant,
+      name: variant.display_name().to_string(),
+      links: variant.links(),
+    })
     .collect();
   Ok(result)
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add settings page with UI for managing launcher configuration

- Refactor settings from NonZero types to numeric primitives

- Implement SQLite-based settings repository with get/update operations

- Add Tauri commands to expose settings functionality to frontend

- Remove game-specific settings from Settings struct, hardcode variant links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings UI<br/>SettingsPage"] -->|useSettings hook| B["React Query<br/>get/update"]
  B -->|Tauri commands| C["Settings Commands<br/>get_settings/update_settings"]
  C -->|logic functions| D["Settings Logic<br/>get/update operations"]
  D -->|repository trait| E["SqliteSettingsRepository<br/>database access"]
  E -->|SQL| F["settings table<br/>max_backups, parallel_requests"]
  A -->|form validation| G["useSettingsForm hook<br/>zod schema"]
  G -->|numeric inputs| H["SettingsForm Component<br/>max_backups, parallel_requests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Reorganize settings module structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-5c30a1237b3fec3e5a849b2a1e1204e91684826dc2335a7dbb11c57134125b84">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings.rs</strong><dd><code>Simplify Settings struct and add logic functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-a79bc29a8767635ca6b18193ce33b40cdb6de6bf59532dd96e291726708bcedf">+36/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Add Tauri commands for settings operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-28357d0945cd25b4dc88dfabb735705c12ff1376540ae4173907350acd4daf6c">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings_repository.rs</strong><dd><code>Define settings repository trait interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-b4156caea9726ef6f0e3bb644e3ce2160adf04c4ba5a2c644b6357d90b93afe5">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_settings_repository.rs</strong><dd><code>Implement SQLite-based settings persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-dd7ef0e083efb67580a756feb548e08d788fac78a087a07878046b60bfbb5fed">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Export repository modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-9f7eb62c10259ab867190ebe2e1acb4382c02a55d2ef2e6cb81c23271a8e42ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register settings commands and repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Simplify settings management and add repository initialization</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-b3ee322098b457e66256bbc93ebafa48258bb7677544ec6ff974981ea1915719">+11/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>game_variant.rs</strong><dd><code>Replace settings-based variant info with hardcoded data</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-82ce342a47e2e3378def91e338ced601fbb1f88f5444c5f1f8893f80a83f695f">+48/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>get_game_variants_info.rs</strong><dd><code>Remove settings dependency from variant info retrieval</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-d14f3cf40fa755dc18546aaf71c46cb2a40ca39dae640ee8c389fee994bb9355">+5/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Remove settings parameter from variant command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-050df8c9fc71684949f3a0f1a22e949d8f5823918ddb39e9799dffd403ce4fe8">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Add settings table with constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Add TypeScript bindings for settings commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add query key for settings caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Create main settings page component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-88c20a4a7beeb132a1839cd3e20846d071cc68af3a387ad096b46593ef2f4cd4">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SettingsForm.tsx</strong><dd><code>Implement settings form with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-3e1cbd78131e47bb534761af9fc7cede3678e6b738b9b4849559f8e209d71519">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useSettings.ts</strong><dd><code>Create hook for settings query and mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-cbc6ef99223438c9aad34285f2e3dac9f006a9c9f7f5801c50ed6ca60bd88fb1">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSettingsForm.ts</strong><dd><code>Create hook for settings form state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-415e3801d0f15159f739ecdc3b1590bf22bd0912c66466153a31ac82b2f2be56">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>select.tsx</strong><dd><code>Add select component UI primitives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-a28cfd23322ef768921b97c767bf31d22c3f51da46f1b4b7e0bf2981bfa50f3e">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>routes.tsx</strong><dd><code>Add settings page route to navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-1e5bca5f2ad612aadcc10f3c1749eeb1094085f3e49863d6bef96bd632673277">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>launch_game.rs</strong><dd><code>Update settings field access from NonZero to numeric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-e0af1e526282c234e69308809193c6c834da1fe02862127f7573e52c1f7d6ec1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add radix-ui select dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-0f82b8d2b9f21dbc61745f560e387f5e77c43354f5107fcb2547d156eded0f24">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Update lock file with select package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/345/files#diff-59b1c27b19930985f662c4cb8a8ee04d0ee5b586d40eb5e2a88fec15adc2626d">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Settings tab to let users view and update launcher settings (max backups and parallel requests), stored in SQLite and used in backup cleanup and download concurrency. Added font support with OS-specific discovery and an optional font stored in settings.

- **New Features**
  - Settings page with form, validation, apply/cancel/reset, and helpful warnings.
  - SQLite settings table now includes font_path; added Tauri commands get_settings, update_settings, and get_fonts.
  - Downloader uses parallel_requests; backup cleanup respects max_backups.

- **Refactors**
  - Removed variant name/link overrides; variants now have built-in display names and links. get_game_variants_info no longer depends on Settings.
  - Dropped settings.json loading; settings are read from the DB and defaults are applied in code.
  - Added min/max validation limits for settings in constants and the DB schema.

<sup>Written for commit 8b1ea3423652e510217eb0f5e4c67fb307d2b926. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

