### PR TITLE
feat(releases): filter out non-installable releases

### DIFF
--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -15,7 +15,7 @@ use crate::game_release::game_release::GameRelease;
 use crate::infra::github::utils::{
   fetch_github_releases, GitHubReleaseFetchError,
 };
-use crate::infra::utils::get_github_repo_for_variant;
+use crate::infra::utils::{get_github_repo_for_variant, Arch, OS};
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -53,6 +53,8 @@ impl GameVariant {
     resources_dir: &Path,
     releases_repository: &dyn ReleasesRepository,
     on_releases: F,
+    os: &OS,
+    arch: &Arch,
   ) -> Result<(), FetchReleasesError<E>>
   where
     E: Error,
@@ -70,6 +72,8 @@ impl GameVariant {
       self,
       &merged,
       ReleasesUpdateStatus::Fetching,
+      os,
+      arch,
     );
     on_releases(payload).map_err(FetchReleasesError::Send)?;
 
@@ -82,6 +86,8 @@ impl GameVariant {
       self,
       &fetched_releases,
       ReleasesUpdateStatus::Success,
+      os,
+      arch,
     );
     on_releases(payload).map_err(FetchReleasesError::Send)?;
 


### PR DESCRIPTION
### **User description**
Motivation:
- To prevent users from seeing releases that they cannot install on their current operating system.
- To accurately reflect the status of releases that have no compatible assets.

Changes:
- Update `fetch_releases` to detect current OS and architecture.
- Update `get_releases_payload` to check for compatible assets and filter out releases that are not installable.
- Update `FetchReleasesError` to include OS and Architecture detection errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Filter releases by OS and architecture compatibility

- Add OS and architecture detection to release fetching

- Check for installable assets before displaying releases

- Extend error handling for unsupported platforms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch Releases Command"] --> B["Detect OS & Arch"]
  B --> C["Fetch GitHub Releases"]
  C --> D["Filter by Installable Assets"]
  D --> E["Return Compatible Releases"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Add OS and arch detection to release command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/commands.rs

<ul><li>Import OS and architecture constants from std::env<br> <li> Add utility imports for OS/Arch enum conversion and error types<br> <li> Extend <code>FetchReleasesCommandError</code> with <code>Os</code> and <code>Arch</code> error variants<br> <li> Pass detected OS and architecture to <code>fetch_releases</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/355/files#diff-22e12e78248e5c9195a1a4abb391b94237f25e974790b7da0cfdb99123cf681c">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fetch_releases.rs</strong><dd><code>Thread OS and arch through fetch pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs

<ul><li>Import <code>Arch</code> and <code>OS</code> types from infra utilities<br> <li> Add <code>os</code> and <code>arch</code> parameters to <code>fetch_releases</code> method signature<br> <li> Pass OS and architecture to <code>get_releases_payload</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/355/files#diff-19283ad499418d43a7d777b1f92ca8a791b38df4d5639d5abc0a4f27db3b37ae">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Filter releases by platform asset compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/fetch_releases/utils.rs

<ul><li>Import <code>get_platform_asset_substrs</code> utility function<br> <li> Import <code>Arch</code> and <code>OS</code> types<br> <li> Add new <code>is_installable</code> function to check asset compatibility<br> <li> Update <code>get_releases_payload</code> to filter releases using <code>is_installable</code><br> <li> Filter out non-installable releases before creating payload</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/355/files#diff-119eef27e04fbf03c964f89066867f12f0152b9c1a8cc05acb2df48bc0fdd721">+28/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only show releases that the user's OS and architecture can install. This avoids incompatible builds and keeps the releases list accurate.

- **New Features**
  - Detect current OS and architecture and pass them through the fetch pipeline.
  - Filter out releases that have no compatible assets (via platform-aware is_installable).
  - Add specific errors for unsupported OS/arch detection.

<sup>Written for commit 832214cafa0cc587b8b0155d48ceca83c90a4f4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

