### PR TITLE
feat(releases): fetch and display release notes

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "ttf-parser",
  "unrar",
  "url",
+ "urlencoding",
  "uuid",
  "walkdir",
  "zip 6.0.0",
@@ -5459,6 +5460,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ r2d2_sqlite = "0.22.0"
 uuid = { version = "1.19.0", features = ["v4"] }
 posthog-rs = "0.3.7"
 url = "2.5.7"
+urlencoding = "2.1.3"
 ttf-parser = "0.25.1"
 walkdir = "2.5.0"
 

--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -20,6 +20,14 @@ CREATE TABLE IF NOT EXISTS releases (
     FOREIGN KEY (game_variant) REFERENCES variants (name)
 );
 
+-- This table stores release notes for each release.
+-- It is separate from the releases table to avoid altering the existing table schema.
+CREATE TABLE IF NOT EXISTS release_notes (
+    release_id INTEGER PRIMARY KEY,
+    body TEXT,
+    FOREIGN KEY (release_id) REFERENCES releases (id) ON DELETE CASCADE
+);
+
 -- This index speeds up filtering releases by game_variant, which is a common
 -- operation in both get_cached_releases and update_cached_releases.
 CREATE INDEX IF NOT EXISTS idx_releases_game_variant ON releases (game_variant);

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -46,3 +46,28 @@ pub async fn fetch_releases_for_variant(
 
   Ok(())
 }
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum FetchReleaseNotesCommandError {
+  #[error("failed to fetch release notes: {0}")]
+  Fetch(
+    #[from]
+    crate::fetch_releases::fetch_releases::FetchReleaseNotesError,
+  ),
+}
+
+#[command]
+pub async fn fetch_release_notes(
+  variant: GameVariant,
+  tag_name: String,
+  releases_repository: State<'_, SqliteReleasesRepository>,
+  client: State<'_, Client>,
+) -> Result<Option<String>, FetchReleaseNotesCommandError> {
+  let notes = variant
+    .fetch_release_notes(&tag_name, &client, &*releases_repository)
+    .await?;
+
+  Ok(notes)
+}

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -27,6 +27,7 @@ pub enum ReleaseType {
 pub struct GameRelease {
   pub variant: GameVariant,
   pub version: String,
+  pub body: Option<String>,
   pub release_type: ReleaseType,
   pub status: GameReleaseStatus,
   #[ts(type = "string")]

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -66,6 +66,7 @@ pub fn gh_release_to_game_release(
   GameRelease {
     variant: *variant,
     version: gh_release.tag_name.clone(),
+    body: gh_release.body.clone(),
     release_type: variant.determine_release_type(
       &gh_release.tag_name,
       gh_release.prerelease,

--- a/cat-launcher/src-tauri/src/infra/github/release.rs
+++ b/cat-launcher/src-tauri/src/infra/github/release.rs
@@ -9,6 +9,7 @@ pub struct GitHubRelease {
   pub id: u64,
   pub tag_name: String,
   pub prerelease: bool,
+  pub body: Option<String>,
   pub assets: Vec<GitHubAsset>,
   #[serde(with = "rfc3339")]
   pub created_at: DateTime<Utc>,

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -25,7 +25,9 @@ use crate::active_release::commands::get_active_release;
 use crate::backups::commands::{
   delete_backup_by_id, list_backups_for_variant, restore_backup_by_id,
 };
-use crate::fetch_releases::commands::fetch_releases_for_variant;
+use crate::fetch_releases::commands::{
+  fetch_release_notes, fetch_releases_for_variant,
+};
 use crate::game_tips::commands::get_tips;
 use crate::install_release::commands::install_release;
 use crate::install_release::installation_status::commands::get_installation_status;
@@ -97,6 +99,7 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       get_game_variants_info,
       fetch_releases_for_variant,
+      fetch_release_notes,
       install_release,
       launch_game,
       get_active_release,

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -208,6 +208,20 @@ export async function getActiveRelease(
   return response ?? "";
 }
 
+export async function fetchReleaseNotes(
+  variant: GameVariant,
+  tagName: string,
+): Promise<string | null> {
+  const response = await invoke<string | null>(
+    "fetch_release_notes",
+    {
+      variant,
+      tag_name: tagName,
+    },
+  );
+  return response;
+}
+
 export async function installReleaseForVariant(
   releaseId: string,
   variant: GameVariant,

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -11,6 +11,9 @@ export const queryKeys = {
 
   releases: (variant: GameVariant) => ["releases", variant] as const,
 
+  releaseNotes: (variant: GameVariant, version: string) =>
+    ["release_notes", variant, version] as const,
+
   tips: (variant: GameVariant) => ["tips", variant] as const,
 
   playTimeForVariant: (variant: GameVariant) =>

--- a/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
@@ -7,7 +7,6 @@ interface ReleaseLabelProps {
   variant: GameVariant;
   version: string;
   isActive: boolean;
-  isLatest: boolean;
 }
 
 function getShortReleaseName(
@@ -40,7 +39,6 @@ export default function ReleaseLabel({
   variant,
   version,
   isActive,
-  isLatest,
 }: ReleaseLabelProps) {
   const shortReleaseName = useMemo(
     () => getShortReleaseName(variant, version),
@@ -53,7 +51,6 @@ export default function ReleaseLabel({
         {shortReleaseName}
       </div>
       <div className="flex items-center gap-1">
-        {isLatest && <Badge>Latest</Badge>}
         {isActive && <Badge>Active</Badge>}
       </div>
     </div>

--- a/cat-launcher/src/pages/PlayPage/ReleaseNotesButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseNotesButton.tsx
@@ -1,0 +1,72 @@
+import { FileText } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { GameRelease } from "@/generated-types/GameRelease";
+import { toastCL } from "@/lib/utils";
+import useReleaseNotes from "./hooks/useReleaseNotes";
+
+interface ReleaseNotesButtonProps {
+  release: GameRelease | undefined;
+}
+
+export default function ReleaseNotesButton({
+  release,
+}: ReleaseNotesButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { notes, isLoading } = useReleaseNotes(release, (error) => {
+    const errorMessage = release
+      ? `Failed to fetch release notes for ${release.version}.`
+      : "Failed to fetch release notes.";
+    toastCL("error", errorMessage, error);
+  });
+
+  if (!release) {
+    return null;
+  }
+
+  const label = "Release Notes";
+  const loadingLabel = "Loading...";
+  const emptyLabel = "No release notes available.";
+  const closeLabel = "Close";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" title={label}>
+          <FileText className="h-4 w-4" />
+          {label}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[80vh] max-w-3xl flex-col">
+        <DialogHeader>
+          <DialogTitle>{label}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Release notes for version {release.version}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex-1 overflow-y-auto whitespace-pre-wrap font-mono text-sm">
+          {isLoading
+            ? loadingLabel
+            : notes || release.body || emptyLabel}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">{closeLabel}</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -21,6 +21,7 @@ import {
 import { useReleaseEvents } from "./hooks";
 import ReleaseFilter, { FilterFn } from "./ReleaseFilter";
 import ReleaseLabel from "./ReleaseLabel";
+import ReleaseNotesButton from "./ReleaseNotesButton";
 
 export default function ReleaseSelector({
   variant,
@@ -34,6 +35,10 @@ export default function ReleaseSelector({
   const releases = useAppSelector(
     (state) => state.releases.releasesByVariant[variant],
   );
+
+  const selectedRelease = useMemo(() => {
+    return releases.find((r) => r.version === selectedReleaseId);
+  }, [releases, selectedReleaseId]);
 
   const {
     mutate: triggerFetchReleases,
@@ -97,7 +102,6 @@ export default function ReleaseSelector({
     return (
       releases.filter(appliedFilter).map((r) => {
         const isActive = r.version === activeRelease;
-        const isLatest = r.version === latestRelease?.version;
 
         return {
           value: r.version,
@@ -106,19 +110,12 @@ export default function ReleaseSelector({
               variant={variant}
               version={r.version}
               isActive={isActive}
-              isLatest={isLatest}
             />
           ),
         };
       }) ?? []
     );
-  }, [
-    releases,
-    activeRelease,
-    variant,
-    appliedFilter,
-    latestRelease,
-  ]);
+  }, [releases, activeRelease, variant, appliedFilter]);
 
   useEffect(() => {
     // Selected release may become unavailable after filtering
@@ -210,6 +207,7 @@ export default function ReleaseSelector({
             disabled={isReleaseFetchingLoading || isInstalling}
           />
         </div>
+        <ReleaseNotesButton release={selectedRelease} />
       </div>
     </div>
   );

--- a/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotes.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotes.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import type { GameRelease } from "@/generated-types/GameRelease";
+import { fetchReleaseNotes } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export default function useReleaseNotes(
+  release: GameRelease | undefined,
+  onReleaseNotesError?: (error: Error) => void,
+) {
+  const onReleaseNotesErrorRef = useRef(onReleaseNotesError);
+
+  useEffect(() => {
+    onReleaseNotesErrorRef.current = onReleaseNotesError;
+  }, [onReleaseNotesError]);
+
+  const {
+    data: notes,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: release
+      ? queryKeys.releaseNotes(release.variant, release.version)
+      : ["release_notes", "disabled"],
+    queryFn: async () => {
+      if (!release) return null;
+      return await fetchReleaseNotes(
+        release.variant,
+        release.version,
+      );
+    },
+    enabled: !!release,
+    placeholderData: release?.body,
+  });
+
+  useEffect(() => {
+    if (error && onReleaseNotesErrorRef.current) {
+      onReleaseNotesErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  return { notes, isLoading, error };
+}


### PR DESCRIPTION
### **User description**
Motivation:
- Users want to see what's new in each release before installing or playing.

Changes:
- Add `release_notes` table in SQLite schema to store release notes.
- Update `GitHubRelease` and `GameRelease` structs to include `body`.
- Implement `fetch_release_notes` in `GameVariant` to fetch notes from DB or GitHub.
- Add `fetch_release_notes` command that calls the business logic.
- Add `ReleaseNotesButton` to `ReleaseSelector` in frontend using a custom hook `useReleaseNotes`.
- Remove "Latest" badge from release selector to save space.
- Update `schema.sql` and `sqlite_releases_repository.rs` to handle the new table.


___

### **PR Type**
Enhancement


___

### **Description**
- Add release notes fetching and display functionality
  - New `fetch_release_notes` command to retrieve notes from DB or GitHub
  - `release_notes` table in SQLite schema for caching

- Update data structures to include release notes
  - Add `body` field to `GitHubRelease` and `GameRelease` structs
  - Implement `fetch_github_release_by_tag` utility function

- Add frontend UI components for release notes
  - New `ReleaseNotesButton` component with modal dialog
  - Custom `useReleaseNotes` hook for data fetching and caching

- Remove "Latest" badge from release selector to save space


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub API"] -->|fetch_github_release_by_tag| B["GitHubRelease<br/>with body"]
  B -->|update_cached_releases| C["SQLite<br/>release_notes table"]
  C -->|get_cached_releases| D["GameRelease<br/>with body"]
  D -->|useReleaseNotes hook| E["ReleaseNotesButton<br/>Modal Dialog"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>commands.rs</strong><dd><code>Add fetch_release_notes command with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-22e12e78248e5c9195a1a4abb391b94237f25e974790b7da0cfdb99123cf681c">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fetch_releases.rs</strong><dd><code>Implement fetch_release_notes business logic method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-19283ad499418d43a7d777b1f92ca8a791b38df4d5639d5abc0a4f27db3b37ae">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sqlite_releases_repository.rs</strong><dd><code>Update SQL queries to fetch and cache release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-be47627b9d3426d47abd67dbbd4dcf18a0b6a256399a070a39d1a7fd7dffcdd6">+16/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>game_release.rs</strong><dd><code>Add body field to GameRelease struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-49f0fa7bd75a2f2d7ac3e2fe198ec4d9e8ee944f4e61da32c27d133bf3f0b7c1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Map release body in conversion function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-8db7a5d9f2885a42967d2465e356d7aacdc947cef5b2284b66a29dcdec6319e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release.rs</strong><dd><code>Add body field to GitHubRelease struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-fcd7bfa3b167094238a282a771d3f1e3d18b26613475152099ce9a5c0bda6b58">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.rs</strong><dd><code>Add fetch_github_release_by_tag function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-bba6edf0e8b2a302e3e99c7c80de35e4a314ece7a0e643762484f21a2d5de011">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register fetch_release_notes command handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>Add fetchReleaseNotes command wrapper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add releaseNotes query key for caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useReleaseNotes.ts</strong><dd><code>Create custom hook for release notes fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-66b0da6000b02cc4fb71f73e012def7174663885aff59dd1c1efe0700a060951">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReleaseLabel.tsx</strong><dd><code>Remove isLatest prop and Latest badge display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-d9e9323882d463074e5976634b4f6ac07f2f264dc654905d99a5da9e2bbbca40">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReleaseNotesButton.tsx</strong><dd><code>Create ReleaseNotesButton component with modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-6e8070acfa8367c433b7cb13ecc7813d6a1b59a276a967994ca29c528d06c21a">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReleaseSelector.tsx</strong><dd><code>Integrate ReleaseNotesButton and remove Latest logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-d4edef2318e1b05f17a9f0d94a0b580b1bf82554cee672573d5e1f80067c0b07">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add urlencoding dependency for URL encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-2b3d88798673dc02d1dc670095173dd88479151362c6e11fab9cbc66502c2f29">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>schema.sql</strong><dd><code>Create release_notes table with foreign key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/356/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added release notes viewing in the Play page so users can see what’s new before installing or playing. Notes load from the local cache when available, or are fetched from GitHub by tag.

- **New Features**
  - Cache note bodies in a new release_notes table and return them with releases.
  - Extend GitHubRelease/GameRelease with an optional body field.
  - Add fetch_release_notes command and backend logic with cache-first, GitHub-fallback (releases/tags) flow.
  - Add ReleaseNotesButton with a dialog, powered by a useReleaseNotes hook and queryKeys.releaseNotes.
  - Remove the “Latest” badge in the release selector to save space.

- **Dependencies**
  - Add urlencoding to safely encode tag names in GitHub API requests.

<sup>Written for commit 63ecfc89f60021365a9b8b428e7a121bd5303c5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

