### PR TITLE
fix(db): correct table references for tilesets and soundpacks indexes

### DIFF
--- a/cat-launcher/src-tauri/schemas/schema.sql
+++ b/cat-launcher/src-tauri/schemas/schema.sql
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS installed_tilesets (
     FOREIGN KEY (game_variant) REFERENCES variants (name) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_installed_tilesets_game_variant ON installed_mods (game_variant);
+CREATE INDEX IF NOT EXISTS idx_installed_tilesets_game_variant ON installed_tilesets (game_variant);
 
 -- This table stores installed soundpacks for each game variant.
 CREATE TABLE IF NOT EXISTS installed_soundpacks (
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS installed_soundpacks (
     FOREIGN KEY (game_variant) REFERENCES variants (name) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_installed_soundpacks_game_variant ON installed_mods (game_variant);
+CREATE INDEX IF NOT EXISTS idx_installed_soundpacks_game_variant ON installed_soundpacks (game_variant);
 
 -- This table stores application settings.
 CREATE TABLE IF NOT EXISTS settings (


### PR DESCRIPTION
### **User description**
Motivation:
- Fix incorrect table names in index definitions to ensure proper indexing for installed tilesets and soundpacks.

Changes:
- Update idx_installed_tilesets_game_variant to reference installed_tilesets table instead of installed_mods.
- Update idx_installed_soundpacks_game_variant to reference installed_soundpacks table instead of installed_mods.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect table references in database indexes

- Update idx_installed_tilesets_game_variant to reference installed_tilesets table

- Update idx_installed_soundpacks_game_variant to reference installed_soundpacks table

- Ensure proper indexing for tilesets and soundpacks data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Database Schema"] -->|"Fix index references"| B["idx_installed_tilesets_game_variant"]
  A -->|"Fix index references"| C["idx_installed_soundpacks_game_variant"]
  B -->|"Now references"| D["installed_tilesets table"]
  C -->|"Now references"| E["installed_soundpacks table"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Fix index table references in database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/schemas/schema.sql

<ul><li>Corrected <code>idx_installed_tilesets_game_variant</code> index to reference <br><code>installed_tilesets</code> table instead of <code>installed_mods</code><br> <li> Corrected <code>idx_installed_soundpacks_game_variant</code> index to reference <br><code>installed_soundpacks</code> table instead of <code>installed_mods</code><br> <li> Ensures indexes are properly associated with their respective tables <br>for optimal query performance</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/360/files#diff-725a3fb536de5531a19d9bf741ca9a3123a46edecee22b0259545f5b3e472792">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect index table references for tilesets and soundpacks so game_variant queries are properly indexed and faster.

- **Bug Fixes**
  - idx_installed_tilesets_game_variant now targets installed_tilesets(game_variant).
  - idx_installed_soundpacks_game_variant now targets installed_soundpacks(game_variant).

<sup>Written for commit 1458dc58dc20184ab99f9969826551bd00fdac6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

