### PR TITLE
chore: add jj version control support

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,3 +2,4 @@
 env = "cp .env.example .env && direnv allow"
 install = "pnpm --prefix cat-launcher install"
 beads = "cp -r $WT_ROOT/.beads ."
+jj = "cp -r $WT_ROOT/.jj ."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,8 @@ pub fn get_all_tips() -> Result<(), GetAllTipsError> {
 
 * If you discover a secondary task while working on a given task, track it.
 * At the end of each task, run the Verification commands to ensure correctness.
-* Use the `git commit --signoff` command to commit changes.
+* Use `jj describe -m` to commit changes. Do not use `git`. Follow the commit guidelines below.
+* At the end of every commit, append `Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>`.
 * Don't commit unless asked by the user.
 
 ## Issue Tracking


### PR DESCRIPTION
### **User description**
Motivation:
- Enable jj version control as an alternative to git in the repository.

Changes:
- Add .jj folder handling to wt.toml post-create setup.
- Update AGENTS.md with jj-specific commit instructions and workflow.
- Document use of 'jj describe -m' for committing changes.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add jj version control support as alternative to git

- Configure .jj folder copying in post-create setup

- Update commit workflow to use `jj describe -m` command

- Document signoff requirement for all commits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["wt.toml config"] -->|"add jj post-create"| B["Copy .jj folder"]
  C["AGENTS.md docs"] -->|"replace git commit"| D["Use jj describe -m"]
  D -->|"append signoff"| E["Signed-off-by footer"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wt.toml</strong><dd><code>Add jj folder setup to post-create</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.config/wt.toml

<ul><li>Add <code>jj</code> post-create command to copy <code>.jj</code> folder from workspace root<br> <li> Enables jj version control initialization during workspace setup</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/380/files#diff-de61c070cb252f311799422fe6a252e2166e0bc85a4886e25c370d8a29c7f21e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Update commit workflow to use jj</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Replace <code>git commit --signoff</code> with <code>jj describe -m</code> command<br> <li> Add explicit instruction to append signoff footer to commits<br> <li> Clarify that git should not be used for commits</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/380/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add jj version control support and switch contributor workflow to use jj instead of git. Setup now copies the .jj directory, and docs show how to commit with jj and include a sign-off.

- **New Features**
  - wt.toml: copy the .jj folder during post-create setup.
  - AGENTS.md: commit with `jj describe -m` and append `Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>`.

<sup>Written for commit cd58e2b734688bff9692d4f97cbe26b963a5d0da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

