### PR TITLE
feat: Add cross-platform button to open installation folder

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -49,6 +49,8 @@
     "@tanstack/react-virtual": "^3.13.13",
     "@tauri-apps/api": "^2.9.1",
     "@tauri-apps/plugin-opener": "~2.5.2",
+    "@tauri-apps/plugin-os": "~2.3.2",
+    "@tauri-apps/plugin-shell": "~2.3.4",
     "@tauri-apps/plugin-updater": "~2.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/cat-launcher/pnpm-lock.yaml
+++ b/cat-launcher/pnpm-lock.yaml
@@ -68,6 +68,12 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ~2.5.2
         version: 2.5.2
+      '@tauri-apps/plugin-os':
+        specifier: ~2.3.2
+        version: 2.3.2
+      '@tauri-apps/plugin-shell':
+        specifier: ~2.3.4
+        version: 2.3.4
       '@tauri-apps/plugin-updater':
         specifier: ~2.9.0
         version: 2.9.0
@@ -1219,6 +1225,12 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.2':
     resolution: {integrity: sha512-ei/yRRoCklWHImwpCcDK3VhNXx+QXM9793aQ64YxpqVF0BDuuIlXhZgiAkc15wnPVav+IbkYhmDJIv5R326Mew==}
+
+  '@tauri-apps/plugin-os@2.3.2':
+    resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
+
+  '@tauri-apps/plugin-shell@2.3.4':
+    resolution: {integrity: sha512-ktsRWf8wHLD17aZEyqE8c5x98eNAuTizR1FSX475zQ4TxaiJnhwksLygQz+AGwckJL5bfEP13nWrlTNQJUpKpA==}
 
   '@tauri-apps/plugin-updater@2.9.0':
     resolution: {integrity: sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg==}
@@ -3433,6 +3445,14 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
   '@tauri-apps/plugin-opener@2.5.2':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-os@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-shell@2.3.4':
     dependencies:
       '@tauri-apps/api': 2.9.1
 

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -466,6 +466,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
+ "tauri-plugin-shell",
  "tauri-plugin-updater",
  "thiserror 2.0.17",
  "tokio",
@@ -1485,6 +1487,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2758,6 +2770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2910,7 @@ checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
  "objc2 0.6.3",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -2909,8 +2932,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
  "objc2 0.6.3",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.3",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3006,6 +3048,32 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4266,10 +4334,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4505,6 +4605,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4782,6 +4891,45 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b76f884a3937e04b631ffdc3be506088fa979369d25147361352f2f352e5ed"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+ "tokio",
 ]
 
 [[package]]

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -47,6 +47,8 @@ url = "2.5.7"
 urlencoding = "2.1.3"
 ttf-parser = "0.25.1"
 walkdir = "2.5.0"
+tauri-plugin-shell = "2"
+tauri-plugin-os = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.9.0"

--- a/cat-launcher/src-tauri/capabilities/default.json
+++ b/cat-launcher/src-tauri/capabilities/default.json
@@ -2,6 +2,44 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
-  "permissions": ["core:default", "opener:default"]
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "os:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "open-win",
+          "cmd": "explorer",
+          "args": [
+            {
+              "validator": "^.*$"
+            }
+          ]
+        },
+        {
+          "name": "open-mac",
+          "cmd": "open",
+          "args": [
+            {
+              "validator": "^.*$"
+            }
+          ]
+        },
+        {
+          "name": "open-linux",
+          "cmd": "xdg-open",
+          "args": [
+            {
+              "validator": "^.*$"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -81,6 +81,8 @@ fn confirm_quit(app_handle: AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_os::init())
+    .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_updater::Builder::new().build())
     .plugin(tauri_plugin_opener::init())
     .setup(|app| {


### PR DESCRIPTION
### **User description**
Hi! 👋

I've implemented a button next to the version selector that allows users to quickly open the local installation directory of the selected game release.

Changes implemented:

Added tauri-plugin-shell and tauri-plugin-os dependencies.

Updated src-tauri/capabilities/default.json to allow execution of scoped open commands (explorer on Windows, open on macOS, xdg-open on Linux).

Implemented path sanitization (replacing dots and hyphens with underscores) to correctly match the directory structure created by the launcher.

Testing & Validation:

✅ Windows 11: Verified and fully working. Tested with different variants (CDDA, Bright Nights and The Last Generation) and versions (Stable/Experimental). It correctly opens the specific folder or the parent asset folder.

⚠️ Linux / macOS: I don't have access to these environments to test the runtime execution. However, I verified the cross-platform logic by mocking the platform detection during debug (forcing linux platform on Windows). I confirmed via console logs/errors that the app correctly attempts to execute xdg-open when Linux is detected, so the logic is sound.

Hope this helps!


___

### **PR Type**
Enhancement


___

### **Description**
- Add cross-platform button to open game installation folders

- Integrate tauri-plugin-shell and tauri-plugin-os dependencies

- Implement path sanitization for version directory matching

- Configure scoped shell permissions for Windows, macOS, Linux


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ReleaseSelector Component"] -->|imports| B["tauri-plugin-shell"]
  A -->|imports| C["tauri-plugin-os"]
  B -->|executes| D["Platform-specific Commands"]
  C -->|detects| E["Current Platform"]
  E -->|windows| F["explorer.exe"]
  E -->|macos| G["open"]
  E -->|linux| H["xdg-open"]
  F -->|opens| I["Installation Folder"]
  G -->|opens| I
  H -->|opens| I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Register OS and Shell plugins in Tauri builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/src/lib.rs

<ul><li>Initialize tauri-plugin-os and tauri-plugin-shell plugins in the Tauri <br>builder<br> <li> Plugins are registered before the updater plugin</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReleaseSelector.tsx</strong><dd><code>Add button to open installation folder with cross-platform support</code></dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx

<ul><li>Import Command from tauri-plugin-shell for executing system commands<br> <li> Import path utilities (join, appLocalDataDir) from Tauri API<br> <li> Import platform detection function from tauri-plugin-os<br> <li> Add new button with folder emoji icon to open installation directory<br> <li> Implement cross-platform logic to detect OS and execute appropriate <br>command<br> <li> Sanitize version string by replacing dots and hyphens with underscores<br> <li> Construct game path using appLocalDataDir, variant, and sanitized <br>version<br> <li> Include error handling and console logging for debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-d4edef2318e1b05f17a9f0d94a0b580b1bf82554cee672573d5e1f80067c0b07">+45/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Tauri OS and Shell plugin dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/package.json

<ul><li>Add @tauri-apps/plugin-os version ~2.3.2 as dependency<br> <li> Add @tauri-apps/plugin-shell version ~2.3.4 as dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-0f82b8d2b9f21dbc61745f560e387f5e77c43354f5107fcb2547d156eded0f24">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lock file with new plugin versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/pnpm-lock.yaml

<ul><li>Lock @tauri-apps/plugin-os to version 2.3.2<br> <li> Lock @tauri-apps/plugin-shell to version 2.3.4<br> <li> Both plugins depend on @tauri-apps/api 2.9.1</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-59b1c27b19930985f662c4cb8a8ee04d0ee5b586d40eb5e2a88fec15adc2626d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add Rust plugin dependencies to Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/Cargo.toml

<ul><li>Add tauri-plugin-shell version 2 as Rust dependency<br> <li> Add tauri-plugin-os version 2 as Rust dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-2b3d88798673dc02d1dc670095173dd88479151362c6e11fab9cbc66502c2f29">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.json</strong><dd><code>Configure shell and OS permissions for folder opening</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/capabilities/default.json

<ul><li>Add os:default permission for OS detection functionality<br> <li> Add shell:allow-execute permission with three scoped commands<br> <li> Configure explorer command for Windows with path validation<br> <li> Configure open command for macOS with path validation<br> <li> Configure xdg-open command for Linux with path validation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/385/files#diff-f40012fc3f2b07779c6c2e4c1c3f61d875e451c4cfcb42e25e426d621e3f36c1">+41/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cross-platform button next to the release selector to open the installation folder for the selected release. Uses platform detection and path sanitization to open the correct folder on Windows, macOS, and Linux.

- New Features
  - One-click “Open Installation Folder” button on the Play page.
  - Detects OS and runs explorer/open/xdg-open via scoped shell commands.
  - Sanitizes version IDs (dots/hyphens to underscores) to match launcher folders.
  - Verified on Windows 11; macOS/Linux logic implemented but not runtime-tested.

- Dependencies
  - Added @tauri-apps/plugin-os and @tauri-apps/plugin-shell; registered both in src-tauri.
  - Updated capabilities/default.json to allow scoped shell executions (explorer, open, xdg-open).

<sup>Written for commit 3d5fa3a14c79ffdcfb10ed9a3ecebd52bc902d3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

