### PR TITLE
feat(analytics): record posthog event when quit is confirmed

### DIFF
--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
     "security": {
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "**"
-        ]
+        "scope": ["**"]
       },
       "csp": {
         "default-src": "'self' asset: http://asset.localhost",

--- a/cat-launcher/src/providers/QuitConfirmationProvider.tsx
+++ b/cat-launcher/src/providers/QuitConfirmationProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 
 import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 import { confirmQuit, listenToQuitRequested } from "@/lib/commands";
@@ -14,6 +15,7 @@ export default function QuitConfirmationProvider({
   const isCurrentlyPlaying = useAppSelector(
     (state) => state.gameSession.currentlyPlaying != null,
   );
+  const posthog = usePostHog();
 
   useEffect(() => {
     const quitHandler = () => {
@@ -33,13 +35,20 @@ export default function QuitConfirmationProvider({
     return cleanup;
   }, [isCurrentlyPlaying]);
 
+  const handleConfirmQuit = async () => {
+    if (posthog) {
+      posthog.capture("quit_confirmed");
+    }
+    await confirmQuit();
+  };
+
   return (
     <>
       {children}
       <ConfirmationDialog
         open={quitDialogOpen}
         onOpenChange={setQuitDialogOpen}
-        onConfirm={confirmQuit}
+        onConfirm={handleConfirmQuit}
         title="Quit CatLauncher?"
         description="If you quit CatLauncher, play time won't be recorded. Additionally, CatLauncher won't be able to save logs in case your game crashes. It's not recommended to quit CatLauncher while a game is running."
         confirmText="Quit"


### PR DESCRIPTION
### **User description**
Motivation:
- To track when users confirm quitting the launcher while a game is running.

Changes:
- Integrated PostHog analytics into QuitConfirmationProvider.
- Captured 'quit_confirmed' event upon user confirmation in the dialog.


___

### **PR Type**
Enhancement


___

### **Description**
- Integrated PostHog analytics to track quit confirmations

- Records 'quit_confirmed' event when user confirms quitting

- Added usePostHog hook to QuitConfirmationProvider component

- Minor formatting adjustment to tauri.conf.json scope array


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User confirms quit"] -->|"capture event"| B["PostHog analytics"]
  A -->|"execute action"| C["confirmQuit function"]
  B --> D["quit_confirmed event recorded"]
  C --> E["Application quits"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuitConfirmationProvider.tsx</strong><dd><code>Integrate PostHog analytics for quit event tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/providers/QuitConfirmationProvider.tsx

<ul><li>Imported <code>usePostHog</code> hook from posthog-js/react library<br> <li> Added <code>posthog</code> instance initialization via usePostHog hook<br> <li> Created new <code>handleConfirmQuit</code> async function that captures <br>'quit_confirmed' event before confirming quit<br> <li> Updated ConfirmationDialog onConfirm prop to use new handler instead <br>of direct confirmQuit call</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/387/files#diff-50ebceaba709e438b96dfa0f5fe61ece6afb88056d1f509e642e1a2f120b51a3">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Format scope array on single line</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src-tauri/tauri.conf.json

<ul><li>Reformatted assetProtocol scope array from multi-line to single-line <br>format</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/387/files#diff-a129d0a394e29d198f60425580a5ef2de79dfc1717a9252f1190ec4618cfb0db">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added PostHog tracking to QuitConfirmationProvider to record a “quit_confirmed” event when the user confirms quitting while a game is running. The event is captured, then the quit proceeds; no user-facing changes.

<sup>Written for commit 2e2e1d5a25bcb7c6fdd64ead960a2899d6b2793c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

