### PR TITLE
feat(play): enhance upgrade button with multiple release types support

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -35,6 +35,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",

--- a/cat-launcher/pnpm-lock.yaml
+++ b/cat-launcher/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -570,6 +573,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -610,8 +626,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -656,6 +694,19 @@ packages:
 
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -747,6 +798,19 @@ packages:
 
   '@radix-ui/react-progress@1.1.8':
     resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2920,6 +2984,18 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       react: 19.2.1
@@ -2960,6 +3036,12 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -2967,6 +3049,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
@@ -3002,6 +3099,32 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -3089,6 +3212,23 @@ snapshots:
     dependencies:
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
     "security": {
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "**"
-        ]
+        "scope": ["**"]
       },
       "csp": {
         "default-src": "'self' asset: http://asset.localhost",

--- a/cat-launcher/src/components/DropdownButton.tsx
+++ b/cat-launcher/src/components/DropdownButton.tsx
@@ -1,0 +1,146 @@
+import { ChevronDown } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface DropdownButtonProps extends React.ComponentProps<
+  typeof Button
+> {
+  options: {
+    id: string;
+
+    label: string;
+
+    onClick: () => void;
+
+    disabled?: boolean;
+
+    tooltip?: string;
+  }[];
+
+  mainButtonDisabled?: boolean;
+}
+
+export function DropdownButton({
+  children,
+
+  onClick,
+
+  disabled,
+
+  mainButtonDisabled,
+
+  options,
+
+  className,
+
+  variant = "default",
+
+  size = "default",
+
+  ...props
+}: DropdownButtonProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-md border shadow-sm",
+
+        variant === "secondary" && "border-none shadow-none",
+
+        variant === "ghost" && "border-none shadow-none",
+
+        variant === "link" && "border-none shadow-none",
+
+        className,
+      )}
+    >
+      <Button
+        {...props}
+        variant={variant}
+        size={size}
+        disabled={disabled || mainButtonDisabled}
+        onClick={onClick}
+        className={cn(
+          "grow rounded-r-none border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
+
+          "focus-visible:z-10",
+        )}
+      >
+        {children}
+      </Button>
+
+      <div
+        className={cn(
+          "h-3/5 w-[1px]",
+
+          variant === "default"
+            ? "bg-primary-foreground/30"
+            : "bg-border",
+
+          (variant === "ghost" || variant === "link") &&
+            "bg-transparent",
+        )}
+      />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            {...props}
+            variant={variant}
+            size={size}
+            disabled={disabled || options.length === 0}
+            className={cn(
+              "shrink-0 rounded-l-none border-0 px-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
+
+              "focus-visible:z-10",
+            )}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="end">
+          {options.map((option) => {
+            const item = (
+              <DropdownMenuItem
+                key={option.id}
+                onClick={option.onClick}
+                disabled={option.disabled}
+              >
+                {option.label}
+              </DropdownMenuItem>
+            );
+
+            if (option.tooltip) {
+              return (
+                <Tooltip key={option.id}>
+                  <TooltipTrigger asChild>
+                    <span>{item}</span>
+                  </TooltipTrigger>
+
+                  <TooltipContent side="left">
+                    <p>{option.tooltip}</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            }
+
+            return item;
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/cat-launcher/src/components/ui/dropdown-menu.tsx
+++ b/cat-launcher/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,275 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  CircleIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return (
+    <DropdownMenuPrimitive.Root
+      data-slot="dropdown-menu"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group
+      data-slot="dropdown-menu-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return (
+    <DropdownMenuPrimitive.Sub
+      data-slot="dropdown-menu-sub"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/cat-launcher/src/lib/constants.ts
+++ b/cat-launcher/src/lib/constants.ts
@@ -1,4 +1,12 @@
+import type { ReleaseType } from "@/generated-types/ReleaseType";
+
 export const UPDATE_LINK =
   "https://github.com/abhi-kr-2100/CatLauncher/releases/";
 
 export const TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS = 10 * 1000; // 10 seconds
+
+export const RELEASE_TYPE_LABELS: Record<ReleaseType, string> = {
+  Stable: "Stable",
+  ReleaseCandidate: "Release Candidate",
+  Experimental: "Experimental",
+};

--- a/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
@@ -1,7 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
-
 import { DownloadProgress } from "@/components/DownloadProgress";
+import { DropdownButton } from "@/components/DropdownButton";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -10,8 +8,6 @@ import {
 } from "@/components/ui/tooltip";
 import type { GameReleaseStatus } from "@/generated-types/GameReleaseStatus";
 import type { GameVariant } from "@/generated-types/GameVariant";
-import { getActiveRelease } from "@/lib/commands";
-import { queryKeys } from "@/lib/queryKeys";
 import { toastCL } from "@/lib/utils";
 import { useAppSelector } from "@/store/hooks";
 import { InstallationProgressStatus } from "@/store/installationProgressSlice";
@@ -19,8 +15,8 @@ import {
   useInstallAndMonitorRelease,
   useInstallationStatus,
   usePlayGame,
-  useReleases,
   useResumeLastWorld,
+  useUpgradeInfo,
 } from "./hooks";
 
 export default function InteractionButton({
@@ -34,26 +30,19 @@ export default function InteractionButton({
   const isThisVariantRunning = currentlyPlaying === variant;
   const isAnyVariantRunning = currentlyPlaying !== null;
 
-  const { releases } = useReleases(variant);
-  const latestReleaseId = releases?.[0]?.version;
-
-  const { data: activeRelease } = useQuery<string | undefined>({
-    queryKey: queryKeys.activeRelease(variant),
-    queryFn: () => getActiveRelease(variant),
-  });
-
-  const shouldAllowUpgrading = useMemo(() => {
-    return (
-      selectedReleaseId &&
-      activeRelease &&
-      selectedReleaseId === activeRelease &&
-      latestReleaseId &&
-      selectedReleaseId !== latestReleaseId
-    );
-  }, [selectedReleaseId, activeRelease, latestReleaseId]);
-
   const { install, installationProgressStatus, downloadProgress } =
     useInstallAndMonitorRelease(variant, selectedReleaseId);
+
+  const { latestReleaseId, upgradeOptions, shouldAllowUpgrading } =
+    useUpgradeInfo(
+      variant,
+      selectedReleaseId,
+      setSelectedReleaseId,
+      install,
+      (e) => {
+        toastCL("error", "Failed to get active release.", e);
+      },
+    );
 
   const { installationStatus, installationStatusError } =
     useInstallationStatus(variant, selectedReleaseId);
@@ -126,7 +115,7 @@ export default function InteractionButton({
       {shouldAllowUpgrading && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
+            <DropdownButton
               className="grow w-[30%]"
               onClick={() => {
                 if (latestReleaseId) {
@@ -135,14 +124,16 @@ export default function InteractionButton({
                 }
               }}
               disabled={isAnyVariantRunning || isStartingGame}
+              mainButtonDisabled={
+                selectedReleaseId === latestReleaseId
+              }
+              options={upgradeOptions}
             >
               Upgrade
-            </Button>
+            </DropdownButton>
           </TooltipTrigger>
           <TooltipContent>
-            <p>
-              Install and switch to the latest experimental version.
-            </p>
+            <p>Install and switch to the latest version.</p>
           </TooltipContent>
         </Tooltip>
       )}

--- a/cat-launcher/src/pages/PlayPage/hooks/index.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/index.ts
@@ -8,3 +8,4 @@ export * from "./useLastPlayedWorld";
 export * from "./useResumeLastWorld";
 export * from "./useLaunchGame";
 export * from "./usePlayTime";
+export * from "./useUpgradeInfo";

--- a/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
@@ -1,0 +1,120 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+
+import type { GameRelease } from "@/generated-types/GameRelease";
+import type { GameVariant } from "@/generated-types/GameVariant";
+import type { ReleaseType } from "@/generated-types/ReleaseType";
+import { getActiveRelease } from "@/lib/commands";
+import { RELEASE_TYPE_LABELS } from "@/lib/constants";
+import { queryKeys } from "@/lib/queryKeys";
+import { useReleases } from "./useReleases";
+
+const RELEASE_TYPE_ORDER: ReleaseType[] = [
+  "Stable",
+  "ReleaseCandidate",
+  "Experimental",
+];
+
+export function useUpgradeInfo(
+  variant: GameVariant,
+  selectedReleaseId: string | undefined,
+  setSelectedReleaseId: (id: string) => void,
+  install: (id: string) => void,
+  onActiveReleaseError?: (error: unknown) => void,
+) {
+  const onActiveReleaseErrorRef = useRef(onActiveReleaseError);
+
+  useEffect(() => {
+    onActiveReleaseErrorRef.current = onActiveReleaseError;
+  }, [onActiveReleaseError]);
+
+  const { releases } = useReleases(variant);
+  const latestReleaseId = releases?.[0]?.version;
+
+  const latestByReleaseType = useMemo(() => {
+    const latest: Partial<Record<ReleaseType, GameRelease>> = {};
+    for (const r of releases) {
+      if (!latest[r.release_type]) {
+        latest[r.release_type] = r;
+      }
+    }
+    return latest;
+  }, [releases]);
+
+  const supportedTypes = useMemo<ReleaseType[]>(() => {
+    const presentTypes = Object.keys(
+      latestByReleaseType,
+    ) as ReleaseType[];
+    return presentTypes.sort(
+      (a, b) =>
+        RELEASE_TYPE_ORDER.indexOf(a) - RELEASE_TYPE_ORDER.indexOf(b),
+    );
+  }, [latestByReleaseType]);
+
+  const upgradeOptions = useMemo(() => {
+    return supportedTypes
+      .map((type) => {
+        const latest = latestByReleaseType[type];
+        if (!latest) return null;
+
+        const isCurrent = latest.version === selectedReleaseId;
+
+        return {
+          id: type,
+          label: `Latest ${RELEASE_TYPE_LABELS[type]}`,
+          onClick: () => {
+            setSelectedReleaseId(latest.version);
+            install(latest.version);
+          },
+          disabled: isCurrent,
+          tooltip: isCurrent ? "Already installed" : undefined,
+        };
+      })
+      .filter((opt): opt is NonNullable<typeof opt> => opt !== null);
+  }, [
+    supportedTypes,
+    latestByReleaseType,
+    selectedReleaseId,
+    setSelectedReleaseId,
+    install,
+  ]);
+
+  const { data: activeRelease, error: activeReleaseError } = useQuery<
+    string | undefined
+  >({
+    queryKey: queryKeys.activeRelease(variant),
+    queryFn: () => getActiveRelease(variant),
+  });
+
+  useEffect(() => {
+    if (activeReleaseError && onActiveReleaseErrorRef.current) {
+      onActiveReleaseErrorRef.current(activeReleaseError);
+    }
+  }, [activeReleaseError]);
+
+  const shouldAllowUpgrading = useMemo(() => {
+    if (
+      !selectedReleaseId ||
+      !activeRelease ||
+      selectedReleaseId !== activeRelease
+    ) {
+      return false;
+    }
+    // Allow if there is any supported release type that has a different version from current
+    return supportedTypes.some((type) => {
+      const latest = latestByReleaseType[type];
+      return latest && latest.version !== selectedReleaseId;
+    });
+  }, [
+    selectedReleaseId,
+    activeRelease,
+    supportedTypes,
+    latestByReleaseType,
+  ]);
+
+  return {
+    latestReleaseId,
+    upgradeOptions,
+    shouldAllowUpgrading,
+  };
+}


### PR DESCRIPTION
### **User description**
Motivation:
- To allow users to upgrade to specific release types (Stable, Experimental, Release Candidate) rather than just the latest experimental version.

Changes:
- Implement a reusable DropdownButton component with tooltip support for individual options and improved split-button styling.
- Add RELEASE_TYPE_LABELS constant to map release types to human-readable labels.
- Extract complex upgrade logic and release type derivation into a new useUpgradeInfo hook.
- Refactor InteractionButton to use the new hook and DropdownButton component.
- Ensure already installed versions are disabled in the upgrade menu with an informative tooltip.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `useUpgradeInfo` hook to encapsulate upgrade logic and release type handling

- Implement reusable `DropdownButton` component with tooltip support for menu items

- Create `dropdown-menu` UI component wrapping Radix UI dropdown menu primitive

- Add `RELEASE_TYPE_LABELS` constant mapping release types to human-readable labels

- Refactor `InteractionButton` to support upgrading to specific release types

- Add `@radix-ui/react-dropdown-menu` dependency for dropdown menu functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useUpgradeInfo Hook"] -->|derives upgrade options| B["DropdownButton Component"]
  C["RELEASE_TYPE_LABELS"] -->|maps types| A
  D["@radix-ui/react-dropdown-menu"] -->|powers| E["dropdown-menu UI"]
  E -->|used by| B
  B -->|integrated into| F["InteractionButton"]
  A -->|provides| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Add release type labels mapping constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-b5b3b184da8bc6d7688125cbe9e3b2601d724aade8ba102a07103d22b0a30c7d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useUpgradeInfo.ts</strong><dd><code>Extract upgrade logic into custom hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-4c3ebdcd38762f96ecc3f8916f6d400e95e9f22337a2727e1ba8885c02efb51b">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export new useUpgradeInfo hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-3a221f10929a364e9c6ea631f48b518ca1b427e75ec7fb673ec73d8d6cc8de7e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DropdownButton.tsx</strong><dd><code>Create reusable dropdown button component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-3db707b386b146b920bd2dfe0d33c4bea42ca85023c603d0cf90ea374496ae71">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dropdown-menu.tsx</strong><dd><code>Add Radix UI dropdown menu wrapper components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-74bbcd6cfa0cc5dc3c27fed0693d7d3095b55df024ddee00c743ad21ca4e0ea1">+275/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>InteractionButton.tsx</strong><dd><code>Refactor to use dropdown button and upgrade hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-d63226cd1178af4c5dfb3a449517e9fee439ac6495bd85d18cf8cba899bf6ea5">+17/-29</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add @radix-ui/react-dropdown-menu dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-0f82b8d2b9f21dbc61745f560e387f5e77c43354f5107fcb2547d156eded0f24">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Update lock file with dropdown menu dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-59b1c27b19930985f662c4cb8a8ee04d0ee5b586d40eb5e2a88fec15adc2626d">+140/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tauri.conf.json</strong><dd><code>Format security scope configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/392/files#diff-a129d0a394e29d198f60425580a5ef2de79dfc1717a9252f1190ec4618cfb0db">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a split Upgrade button on the Play page so users can upgrade to Stable, Release Candidate, or Experimental. Default click upgrades to the latest; installed options are disabled and show helpful tooltips.

- New Features
  - Split Upgrade button: main action upgrades to latest; dropdown offers Latest Stable/RC/Experimental with per-item tooltips.
  - Reusable DropdownButton and Radix-based dropdown menu UI.
  - useUpgradeInfo hook derives latest per release type, builds menu options, and controls upgrade availability; added RELEASE_TYPE_LABELS.

- Refactors
  - InteractionButton now uses useUpgradeInfo and DropdownButton.
  - Cleaner upgrade logic and improved split-button styling.

<sup>Written for commit 6f22cc1855d35231467e5f8aad1256ec29c42ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

