### PR TITLE
refactor(settings): extract footer to fixed component

### DIFF
--- a/cat-launcher/src/pages/SettingsPage/components/SettingsPageFooter.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/SettingsPageFooter.tsx
@@ -1,0 +1,51 @@
+import { SyntheticEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface SettingsPageFooterProps {
+  isDirty: boolean;
+  isUpdating: boolean;
+  apply: (e: SyntheticEvent) => void;
+  cancel: () => void;
+  resetToDefault: () => void;
+}
+
+export function SettingsPageFooter({
+  isDirty,
+  isUpdating,
+  apply,
+  cancel,
+  resetToDefault,
+}: SettingsPageFooterProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border overflow-x-auto">
+      <div className="container mx-auto max-w-2xl px-4 py-4">
+        <div className="flex justify-end gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={resetToDefault}
+            disabled={isUpdating}
+          >
+            Reset to Default
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={cancel}
+            disabled={!isDirty}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            onClick={apply}
+            disabled={!isDirty || isUpdating}
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/SettingsPage/index.tsx
+++ b/cat-launcher/src/pages/SettingsPage/index.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 
-import { Button } from "@/components/ui/button";
 import { toastCL } from "@/lib/utils";
 import { FontSettings } from "./components/FontSettings";
 import { MasterReset } from "./components/MasterReset";
+import { SettingsPageFooter } from "./components/SettingsPageFooter";
 import { useSettingsForm } from "./hooks";
 
 export default function SettingsPage() {
@@ -48,40 +48,18 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="container mx-auto max-w-2xl px-4">
+    <div className="container mx-auto max-w-2xl px-4 pb-24">
       <form onSubmit={apply} className="space-y-8">
         <MasterReset />
 
         <FontSettings control={form.control} />
-
-        <div className="flex justify-end gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              if (!isUpdating) {
-                resetToDefault();
-              }
-            }}
-            disabled={isUpdating}
-          >
-            Reset to Default
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={cancel}
-            disabled={!form.formState.isDirty}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            disabled={!form.formState.isDirty || isUpdating}
-          >
-            Apply
-          </Button>
-        </div>
+        <SettingsPageFooter
+          isDirty={form.formState.isDirty}
+          isUpdating={isUpdating}
+          apply={apply}
+          cancel={cancel}
+          resetToDefault={resetToDefault}
+        />
       </form>
     </div>
   );


### PR DESCRIPTION
### **User description**
Motivation:
- Make the settings page footer fixed at the bottom of the viewport.
- Improve code organization by extracting button actions into a separate component.

Changes:
- Create new SettingsPageFooter component in a dedicated file.
- Move footer buttons (Reset to Default, Cancel, Apply) to the fixed footer.
- Add padding to main container to prevent content overlap with fixed footer.
- Import and use the new SettingsPageFooter component in SettingsPage.


___

### **PR Type**
Enhancement


___

### **Description**
- Extract footer buttons into dedicated fixed component

- Position footer fixed at bottom of viewport

- Add padding to main container preventing content overlap

- Improve code organization and maintainability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SettingsPage<br/>with inline buttons"] -- "extract footer logic" --> B["SettingsPageFooter<br/>fixed component"]
  A -- "add padding" --> C["Main container<br/>pb-24"]
  B -- "position fixed" --> D["Footer at<br/>bottom viewport"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SettingsPageFooter.tsx</strong><dd><code>New fixed footer component with button actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SettingsPage/components/SettingsPageFooter.tsx

<ul><li>New component created to encapsulate footer buttons<br> <li> Implements fixed positioning at bottom of viewport<br> <li> Accepts props for button states and callbacks<br> <li> Includes Reset to Default, Cancel, and Apply buttons</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/394/files#diff-ce3c08c2b17052f02f4c5e5a0d607a13576c616372eae36b7ed212b13bf1efe0">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Refactor to use extracted footer component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SettingsPage/index.tsx

<ul><li>Remove inline footer buttons and move to new component<br> <li> Add bottom padding to main container to prevent overlap<br> <li> Import and integrate SettingsPageFooter component<br> <li> Pass form state and callbacks to footer component</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/394/files#diff-88c20a4a7beeb132a1839cd3e20846d071cc68af3a387ad096b46593ef2f4cd4">+10/-31</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the Settings page footer fixed and extracted the action buttons into a dedicated component. Actions stay visible while scrolling and the page code is cleaner.

- **Refactors**
  - Added SettingsPageFooter component with Apply, Cancel, and Reset.
  - Pinned footer to the bottom; added container padding to prevent overlap.
  - Passed isDirty, isUpdating, and handlers as props; removed inline footer buttons from SettingsPage.

<sup>Written for commit 4ee81157a93a87ff63210280f9f4a7ce6ac4929e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

