### PR TITLE
fix(upgrade): restrict TheLastGeneration to stable releases only

### DIFF
--- a/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
@@ -113,29 +113,20 @@ export default function InteractionButton({
         </Button>
       )}
       {shouldAllowUpgrading && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownButton
-              className="grow w-[30%]"
-              onClick={() => {
-                if (latestReleaseId) {
-                  setSelectedReleaseId(latestReleaseId);
-                  install(latestReleaseId);
-                }
-              }}
-              disabled={isAnyVariantRunning || isStartingGame}
-              mainButtonDisabled={
-                selectedReleaseId === latestReleaseId
-              }
-              options={upgradeOptions}
-            >
-              Upgrade
-            </DropdownButton>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Install and switch to the latest version.</p>
-          </TooltipContent>
-        </Tooltip>
+        <DropdownButton
+          className="grow w-[30%]"
+          onClick={() => {
+            if (latestReleaseId) {
+              setSelectedReleaseId(latestReleaseId);
+              install(latestReleaseId);
+            }
+          }}
+          disabled={isAnyVariantRunning || isStartingGame}
+          mainButtonDisabled={selectedReleaseId === latestReleaseId}
+          options={upgradeOptions}
+        >
+          Upgrade
+        </DropdownButton>
       )}
     </div>
   );

--- a/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
@@ -32,6 +32,13 @@ export function useUpgradeInfo(
   const latestReleaseId = releases?.[0]?.version;
 
   const latestByReleaseType = useMemo(() => {
+    // The Last Generation has Stable and Experimental releases, but Experimental releases are deprecated.
+    if (variant === "TheLastGeneration" && releases.length > 0) {
+      return {
+        Stable: releases[0],
+      };
+    }
+
     const latest: Partial<Record<ReleaseType, GameRelease>> = {};
     for (const r of releases) {
       if (!latest[r.release_type]) {
@@ -39,7 +46,7 @@ export function useUpgradeInfo(
       }
     }
     return latest;
-  }, [releases]);
+  }, [releases, variant]);
 
   const supportedTypes = useMemo<ReleaseType[]>(() => {
     const presentTypes = Object.keys(


### PR DESCRIPTION
### **User description**
Motivation:
- Experimental releases for TheLastGeneration are deprecated and should not be offered to users.

Changes:
- Modified useUpgradeInfo hook to filter out Experimental releases for TheLastGeneration variant.
- Updated InteractionButton to wrap the upgrade button in a Tooltip with helpful text.


___

### **PR Type**
Bug fix


___

### **Description**
- Filter out Experimental releases for TheLastGeneration variant

- Remove Tooltip wrapper from upgrade button in InteractionButton


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useUpgradeInfo Hook"] -->|"Filter Experimental releases"| B["TheLastGeneration Variant"]
  B -->|"Return only Stable"| C["latestByReleaseType"]
  D["InteractionButton"] -->|"Remove Tooltip"| E["DropdownButton"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useUpgradeInfo.ts</strong><dd><code>Filter Experimental releases for TheLastGeneration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts

<ul><li>Added conditional check to filter releases for TheLastGeneration <br>variant<br> <li> Returns only Stable release type for TheLastGeneration, excluding <br>Experimental releases<br> <li> Preserves existing behavior for other variants</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/398/files#diff-4c3ebdcd38762f96ecc3f8916f6d400e95e9f22337a2727e1ba8885c02efb51b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InteractionButton.tsx</strong><dd><code>Remove Tooltip wrapper from upgrade button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/PlayPage/InteractionButton.tsx

<ul><li>Removed Tooltip wrapper component from upgrade button<br> <li> Simplified DropdownButton rendering by removing TooltipTrigger and <br>TooltipContent<br> <li> Maintains all button functionality and styling</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/398/files#diff-d63226cd1178af4c5dfb3a449517e9fee439ac6495bd85d18cf8cba899bf6ea5">+14/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

