### PR TITLE
refactor(settings): add master reset and mods warnings

### DIFF
--- a/cat-launcher/src/pages/ModsPage/ModsList.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModsList.tsx
@@ -4,6 +4,8 @@ import { getVariantLabel, toastCL } from "@/lib/utils";
 import { useSearch } from "@/hooks/useSearch";
 import { useMods } from "./hooks";
 import ModCard from "./ModCard";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
 
 interface ModsListProps {
   variant: GameVariant;
@@ -50,6 +52,18 @@ export default function ModsList({ variant }: ModsListProps) {
         placeholder="Search mods..."
         className="mb-4 mt-2"
       />
+
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription>
+          <p>Third-party mods can break your game.</p>
+          <p>
+            If your game is broken, master reset it by going to
+            "Settings."
+          </p>
+        </AlertDescription>
+      </Alert>
+
       {!filteredMods || filteredMods.length === 0 ? (
         <p className="text-muted-foreground">
           {hasActiveSearch

--- a/cat-launcher/src/pages/SettingsPage/components/MasterReset.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/MasterReset.tsx
@@ -61,8 +61,7 @@ export function MasterReset() {
           </p>
           <p>
             Worlds that use custom mods, won't be playable until you
-            reinstall them. Restoring old backups may lead to the game
-            breaking again.
+            reinstall them.
           </p>
         </AlertDescription>
       </Alert>

--- a/cat-launcher/src/pages/SettingsPage/index.tsx
+++ b/cat-launcher/src/pages/SettingsPage/index.tsx
@@ -51,9 +51,9 @@ export default function SettingsPage() {
   return (
     <div className="container mx-auto max-w-2xl px-4 pb-24">
       <form onSubmit={apply} className="space-y-8">
-        <MasterReset />
         <FontSettings control={form.control} />
         <ColorSettings control={form.control} />
+        <MasterReset />
 
         <SettingsPageFooter
           isDirty={form.formState.isDirty}


### PR DESCRIPTION
### **User description**
Motivation:
- Improve user awareness of potential risks when using mods and master reset functionality
- Better UX by displaying warnings at relevant locations

Changes:
- Add destructive alert warning on ModsList about mod risks and master reset recovery option
- Update MasterReset warning to mention that restoring old backups may lead to game breaking again
- Reorganize SettingsPage to display MasterReset component alongside other settings


___

### **PR Type**
Enhancement


___

### **Description**
- Add destructive alert warning to ModsList about mod risks

- Display master reset recovery option in mods warning

- Reorganize SettingsPage to show MasterReset after other settings

- Simplify MasterReset warning text for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ModsList["ModsList Component"]
  Alert["Destructive Alert Warning"]
  MasterReset["MasterReset Component"]
  SettingsPage["SettingsPage Layout"]
  
  ModsList -- "adds warning about mod risks" --> Alert
  Alert -- "mentions master reset recovery" --> MasterReset
  SettingsPage -- "reorders components" --> MasterReset
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModsList.tsx</strong><dd><code>Add destructive alert warning to mods list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/ModsPage/ModsList.tsx

<ul><li>Import Alert and AlertTriangle components from UI library<br> <li> Add destructive alert warning below search input<br> <li> Alert informs users about mod risks and master reset recovery option</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/399/files#diff-eeaddda99ed7f83376c48918b821c922a74200573114d3f045f1d4eebb820508">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MasterReset.tsx</strong><dd><code>Simplify master reset warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SettingsPage/components/MasterReset.tsx

<ul><li>Remove warning text about restoring old backups causing game breaking<br> <li> Simplify alert description for better clarity<br> <li> Keep core message about custom mods and reinstallation</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/399/files#diff-e5e2c6f74d99379f45440a448677a9e55723f85f24a616bce333160edf118dad">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Reorganize settings page component order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cat-launcher/src/pages/SettingsPage/index.tsx

<ul><li>Move MasterReset component after FontSettings and ColorSettings<br> <li> Reorder form sections to display MasterReset alongside other settings<br> <li> Improve visual hierarchy of settings page</ul>


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/399/files#diff-88c20a4a7beeb132a1839cd3e20846d071cc68af3a387ad096b46593ef2f4cd4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear warnings around mods and master reset to reduce breakage and guide users to recovery. Improves Settings page layout so Master Reset appears alongside other controls.

- **New Features**
  - Added a destructive alert on the Mods page warning that third‑party mods can break the game and pointing users to Master Reset in Settings.

- **Refactors**
  - Moved Master Reset below Font and Color settings for better context.
  - Simplified Master Reset warning copy.

<sup>Written for commit 2ea9b9afab6f0ca6daccba8a4a45b0b1e97604cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

