### PR TITLE
feat(achievements): add game achievements display

### DIFF
--- a/cat-launcher/src-tauri/src/achievements/achievements.rs
+++ b/cat-launcher/src-tauri/src/achievements/achievements.rs
@@ -1,0 +1,196 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::active_release::repository::ActiveReleaseRepository;
+use crate::filesystem::paths::{
+  get_game_resources_dir, get_or_create_user_game_data_dir,
+  GetGameExecutableDirError, GetUserGameDataDirError,
+};
+use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::variants::GameVariant;
+
+use super::types::{Achievement, CharacterAchievements};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AchievementFile {
+  pub achievement_version: i32,
+  pub achievements: Vec<String>,
+  pub avatar_name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AchievementName {
+  String(String),
+  Object { str: String },
+}
+
+impl AchievementName {
+  fn into_string(self) -> String {
+    match self {
+      AchievementName::String(s) => s,
+      AchievementName::Object { str } => str,
+    }
+  }
+}
+
+#[derive(Deserialize)]
+struct AchievementJsonEntry {
+  id: String,
+  #[serde(rename = "type")]
+  entry_type: String,
+  name: Option<AchievementName>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetAchievementsError {
+  #[error("failed to get user game data directory: {0}")]
+  UserGameData(#[from] GetUserGameDataDirError),
+  #[error("failed to read achievements directory: {0}")]
+  Read(#[from] std::io::Error),
+  #[error("failed to get active release: {0}")]
+  ActiveRelease(
+    #[from] crate::active_release::active_release::ActiveReleaseError,
+  ),
+  #[error("unsupported OS: {0}")]
+  UnsupportedOS(#[from] OSNotSupportedError),
+  #[error("failed to get game resources directory: {0}")]
+  GameResourcesDir(#[from] GetGameExecutableDirError),
+  #[error("failed to parse achievements.json: {0}")]
+  Serde(#[from] serde_json::Error),
+}
+
+async fn load_achievement_names(
+  variant: &GameVariant,
+  data_dir: &Path,
+  active_release_repository: &dyn ActiveReleaseRepository,
+) -> Result<HashMap<String, String>, GetAchievementsError> {
+  let Some(active_release) = variant
+    .get_active_release(active_release_repository)
+    .await?
+  else {
+    return Ok(HashMap::new());
+  };
+
+  let os = get_os_enum(std::env::consts::OS)?;
+  let resources_dir =
+    get_game_resources_dir(variant, &active_release, data_dir, &os)
+      .await?;
+
+  let achievements_json_path = resources_dir
+    .join("data")
+    .join("json")
+    .join("achievements.json");
+
+  let content =
+    match tokio::fs::read_to_string(achievements_json_path).await {
+      Ok(c) => c,
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        return Ok(HashMap::new());
+      }
+      Err(e) => return Err(GetAchievementsError::Read(e)),
+    };
+
+  let entries =
+    serde_json::from_str::<Vec<AchievementJsonEntry>>(&content)?;
+
+  let id_to_name = entries
+    .into_iter()
+    .filter(|entry| entry.entry_type == "achievement")
+    .filter_map(|entry| {
+      entry.name.map(|name| (entry.id, name.into_string()))
+    })
+    .collect();
+
+  Ok(id_to_name)
+}
+
+async fn load_character_achievement_ids(
+  achievements_dir: PathBuf,
+) -> Result<HashMap<String, HashSet<String>>, GetAchievementsError> {
+  let mut dir = match tokio::fs::read_dir(achievements_dir).await {
+    Ok(dir) => dir,
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+      return Ok(HashMap::new());
+    }
+    Err(e) => return Err(GetAchievementsError::Read(e)),
+  };
+
+  let mut character_achievements_map: HashMap<
+    String,
+    HashSet<String>,
+  > = HashMap::new();
+
+  while let Some(entry) = dir.next_entry().await? {
+    let path = entry.path();
+    if path.extension().and_then(|s| s.to_str()) != Some("json") {
+      continue;
+    }
+
+    let Ok(content) = tokio::fs::read_to_string(&path).await else {
+      continue;
+    };
+
+    let Ok(achievement_file) =
+      serde_json::from_str::<AchievementFile>(&content)
+    else {
+      continue;
+    };
+
+    character_achievements_map
+      .entry(achievement_file.avatar_name)
+      .or_default()
+      .extend(achievement_file.achievements);
+  }
+
+  Ok(character_achievements_map)
+}
+
+pub async fn get_achievements(
+  variant: &GameVariant,
+  data_dir: &Path,
+  active_release_repository: &dyn ActiveReleaseRepository,
+) -> Result<Vec<CharacterAchievements>, GetAchievementsError> {
+  let id_to_name = load_achievement_names(
+    variant,
+    data_dir,
+    active_release_repository,
+  )
+  .await?;
+
+  let user_data_dir =
+    get_or_create_user_game_data_dir(variant, data_dir).await?;
+  let achievements_dir = user_data_dir.join("achievements");
+
+  let character_achievements_map =
+    load_character_achievement_ids(achievements_dir).await?;
+
+  let mut result: Vec<CharacterAchievements> =
+    character_achievements_map
+      .into_iter()
+      .map(|(name, achievement_ids)| {
+        let mut achievements: Vec<Achievement> = achievement_ids
+          .into_iter()
+          .map(|id| {
+            let friendly_name =
+              id_to_name.get(&id).unwrap_or(&id).to_string();
+            Achievement {
+              id,
+              name: friendly_name,
+            }
+          })
+          .collect();
+        achievements.sort_by(|a, b| a.name.cmp(&b.name));
+        CharacterAchievements {
+          character_name: name,
+          achievements,
+        }
+      })
+      .collect();
+
+  result.sort_by(|a, b| a.character_name.cmp(&b.character_name));
+
+  Ok(result)
+}

--- a/cat-launcher/src-tauri/src/achievements/commands.rs
+++ b/cat-launcher/src-tauri/src/achievements/commands.rs
@@ -1,0 +1,39 @@
+use cat_macros::CommandErrorSerialize;
+use strum::IntoStaticStr;
+use tauri::{AppHandle, Manager, State};
+
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::variants::GameVariant;
+
+use super::achievements::{get_achievements, GetAchievementsError};
+use super::types::CharacterAchievements;
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum GetAchievementsForVariantCommandError {
+  #[error("failed to get achievements: {0}")]
+  GetAchievements(#[from] GetAchievementsError),
+  #[error("failed to get data directory: {0}")]
+  DataDir(#[from] tauri::Error),
+}
+
+#[tauri::command]
+pub async fn get_achievements_for_variant(
+  variant: GameVariant,
+  app_handle: AppHandle,
+  active_release_repository: State<'_, SqliteActiveReleaseRepository>,
+) -> Result<
+  Vec<CharacterAchievements>,
+  GetAchievementsForVariantCommandError,
+> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  let achievements = get_achievements(
+    &variant,
+    &data_dir,
+    active_release_repository.inner(),
+  )
+  .await?;
+
+  Ok(achievements)
+}

--- a/cat-launcher/src-tauri/src/achievements/mod.rs
+++ b/cat-launcher/src-tauri/src/achievements/mod.rs
@@ -1,0 +1,3 @@
+pub mod achievements;
+pub mod commands;
+pub mod types;

--- a/cat-launcher/src-tauri/src/achievements/types.rs
+++ b/cat-launcher/src-tauri/src/achievements/types.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct Achievement {
+  pub id: String,
+  pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterAchievements {
+  pub character_name: String,
+  pub achievements: Vec<Achievement>,
+}

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod constants;
 pub mod filesystem;
 pub mod settings;
 
+mod achievements;
 pub mod active_release;
 mod backups;
 mod fetch_releases;
@@ -22,6 +23,7 @@ mod users;
 mod utils;
 mod variants;
 
+use crate::achievements::commands::get_achievements_for_variant;
 use crate::active_release::commands::get_active_release;
 use crate::backups::commands::{
   delete_backup_by_id, list_backups_for_variant, restore_backup_by_id,
@@ -145,6 +147,7 @@ pub fn run() {
       get_default_settings,
       confirm_quit,
       master_reset,
+      get_achievements_for_variant,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -2,6 +2,7 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 
 import type { BackupEntry } from "@/generated-types/BackupEntry";
+import type { CharacterAchievements } from "@/generated-types/CharacterAchievements";
 import type { ColorTheme } from "@/generated-types/ColorTheme";
 import type { DownloadProgress } from "@/generated-types/DownloadProgress";
 import type { Font } from "@/generated-types/Font";
@@ -511,4 +512,16 @@ export async function masterReset(
   variant: GameVariant,
 ): Promise<void> {
   await invoke("master_reset", { variant });
+}
+
+export async function getAchievementsForVariant(
+  variant: GameVariant,
+): Promise<CharacterAchievements[]> {
+  const response = await invoke<CharacterAchievements[]>(
+    "get_achievements_for_variant",
+    {
+      variant,
+    },
+  );
+  return response;
 }

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -74,4 +74,7 @@ export const queryKeys = {
   settings: () => ["settings"] as const,
 
   defaultSettings: () => ["default_settings"] as const,
+
+  achievements: (variant: GameVariant) =>
+    ["achievements", variant] as const,
 };

--- a/cat-launcher/src/pages/AchievementsPage/components/AchievementsList.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/AchievementsList.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { CharacterAchievements } from "@/generated-types/CharacterAchievements";
+
+interface AchievementsListProps {
+  achievements: CharacterAchievements[];
+}
+
+export default function AchievementsList({
+  achievements,
+}: AchievementsListProps) {
+  if (achievements.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground p-8">
+        No achievements found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {achievements.map((charData) => (
+        <Card key={charData.characterName}>
+          <CardHeader className="pb-2">
+            <CardTitle>{charData.characterName}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {charData.achievements.map((achievement) => (
+                <Badge key={achievement.id} variant="secondary">
+                  {achievement.name}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/AchievementsPage/components/AchievementsSidebar.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/AchievementsSidebar.tsx
@@ -1,0 +1,21 @@
+import { Sidebar } from "@/components/Sidebar";
+import { achievementsRoutes } from "../routes";
+
+interface AchievementsSidebarProps {
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+}
+
+export default function AchievementsSidebar({
+  isCollapsed,
+  onToggleCollapse,
+}: AchievementsSidebarProps) {
+  return (
+    <Sidebar
+      items={achievementsRoutes}
+      isCollapsed={isCollapsed}
+      onToggleCollapse={onToggleCollapse}
+      basePath="/achievements"
+    />
+  );
+}

--- a/cat-launcher/src/pages/AchievementsPage/components/GameAchievements.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/GameAchievements.tsx
@@ -1,0 +1,78 @@
+import { useState, useCallback, useMemo } from "react";
+
+import { SearchInput } from "@/components/SearchInput";
+import VariantSelector from "@/components/VariantSelector";
+import type { CharacterAchievements } from "@/generated-types/CharacterAchievements";
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { useGameVariants } from "@/hooks/useGameVariants";
+import { useSearch } from "@/hooks/useSearch";
+import { toastCL } from "@/lib/utils";
+import AchievementsList from "./AchievementsList";
+import { useAchievements } from "../hooks/useAchievements";
+
+export default function GameAchievements() {
+  const {
+    gameVariants,
+    isLoading: gameVariantsLoading,
+    isError: gameVariantsError,
+    error: gameVariantsErrorObj,
+  } = useGameVariants();
+
+  const [selectedVariant, setSelectedVariant] =
+    useState<GameVariant | null>(null);
+
+  const onAchievementsError = useCallback((error: Error) => {
+    toastCL("error", "Failed to load achievements", error);
+  }, []);
+
+  const { data: achievements, isLoading: achievementsLoading } =
+    useAchievements(selectedVariant, onAchievementsError);
+
+  const searchOptions = useMemo(
+    () => ({
+      searchFn: (item: CharacterAchievements, query: string) =>
+        item.characterName.toLowerCase().includes(query),
+    }),
+    [],
+  );
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    filteredItems: filteredAchievements,
+  } = useSearch(achievements ?? [], searchOptions);
+
+  if (gameVariantsLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (gameVariantsError) {
+    return (
+      <p>Error: {gameVariantsErrorObj?.message ?? "Unknown error"}</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div className="flex gap-4 items-end">
+        <VariantSelector
+          gameVariants={gameVariants}
+          selectedVariant={selectedVariant}
+          onVariantChange={setSelectedVariant}
+          isLoading={gameVariantsLoading}
+        />
+        <SearchInput
+          placeholder="Search character..."
+          value={searchQuery}
+          onChange={setSearchQuery}
+        />
+      </div>
+
+      {achievementsLoading ? (
+        <p>Loading achievements...</p>
+      ) : (
+        <AchievementsList achievements={filteredAchievements} />
+      )}
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/AchievementsPage/components/PlayTime.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/PlayTime.tsx
@@ -1,0 +1,23 @@
+import { useGameVariants } from "@/hooks/useGameVariants";
+import PlayTimeChart from "./PlayTimeChart";
+
+export default function PlayTime() {
+  const {
+    gameVariants,
+    isLoading: gameVariantsLoading,
+    isError: gameVariantsError,
+    error: gameVariantsErrorObj,
+  } = useGameVariants();
+
+  if (gameVariantsLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (gameVariantsError) {
+    return (
+      <p>Error: {gameVariantsErrorObj?.message ?? "Unknown error"}</p>
+    );
+  }
+
+  return <PlayTimeChart variants={gameVariants} />;
+}

--- a/cat-launcher/src/pages/AchievementsPage/hooks/useAchievements.ts
+++ b/cat-launcher/src/pages/AchievementsPage/hooks/useAchievements.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { getAchievementsForVariant } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useAchievements(
+  variant: GameVariant | null,
+  onAchievementsError?: (error: Error) => void,
+) {
+  const onAchievementsErrorRef = useRef(onAchievementsError);
+
+  useEffect(() => {
+    onAchievementsErrorRef.current = onAchievementsError;
+  }, [onAchievementsError]);
+
+  const query = useQuery({
+    queryKey: variant
+      ? queryKeys.achievements(variant)
+      : ["achievements", null],
+    queryFn: () =>
+      variant
+        ? getAchievementsForVariant(variant)
+        : Promise.resolve([]),
+    enabled: !!variant,
+  });
+
+  useEffect(() => {
+    if (query.error && onAchievementsErrorRef.current) {
+      onAchievementsErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
+  return query;
+}

--- a/cat-launcher/src/pages/AchievementsPage/index.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/index.tsx
@@ -1,28 +1,41 @@
-import { useGameVariants } from "@/hooks/useGameVariants";
-import PlayTimeChart from "./components/PlayTimeChart";
+import { useCallback, useState } from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import AchievementsSidebar from "./components/AchievementsSidebar";
+import { achievementsRoutes } from "./routes";
 
 function AchievementsPage() {
-  const {
-    gameVariants,
-    isLoading: gameVariantsLoading,
-    isError: gameVariantsError,
-    error: gameVariantsErrorObj,
-  } = useGameVariants();
+  const [isCollapsed, setIsCollapsed] = useState(true);
 
-  if (gameVariantsLoading) {
-    return <p>Loading...</p>;
-  }
-
-  if (gameVariantsError) {
-    return (
-      <p>Error: {gameVariantsErrorObj?.message ?? "Unknown error"}</p>
-    );
-  }
+  const onToggleCollapse = useCallback(() => {
+    setIsCollapsed((prev) => !prev);
+  }, []);
 
   return (
-    <main className="p-8">
-      <PlayTimeChart variants={gameVariants} />
-    </main>
+    <div className="flex flex-1 overflow-hidden">
+      <AchievementsSidebar
+        isCollapsed={isCollapsed}
+        onToggleCollapse={onToggleCollapse}
+      />
+
+      <section className="flex-1 overflow-y-auto p-8">
+        <Routes>
+          <Route
+            index
+            element={
+              <Navigate to={achievementsRoutes[0].path} replace />
+            }
+          />
+          {achievementsRoutes.map((route) => (
+            <Route
+              key={route.path}
+              path={route.path}
+              element={route.element}
+            />
+          ))}
+        </Routes>
+      </section>
+    </div>
   );
 }
 

--- a/cat-launcher/src/pages/AchievementsPage/routes.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/routes.tsx
@@ -1,0 +1,22 @@
+import type { BaseRoute } from "@/routes";
+import { Clock, Trophy } from "lucide-react";
+
+import PlayTime from "./components/PlayTime";
+import GameAchievements from "./components/GameAchievements";
+
+export type AchievementsRoute = BaseRoute;
+
+export const achievementsRoutes: AchievementsRoute[] = [
+  {
+    path: "play-time",
+    element: <PlayTime />,
+    label: "Play Time",
+    icon: Clock,
+  },
+  {
+    path: "game-achievements",
+    element: <GameAchievements />,
+    label: "Game Achievements",
+    icon: Trophy,
+  },
+];

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -34,7 +34,7 @@ export const routes: BaseRoute[] = [
     icon: Gamepad2,
   },
   {
-    path: "/achievements",
+    path: "/achievements/*",
     element: <AchievementsPage />,
     label: "Achievements",
     icon: Award,


### PR DESCRIPTION
### **User description**
Motivation:
- To allow users to view their in-game achievements for different characters and game variants.

Changes:
- Implement `get_achievements_for_variant` Tauri command.
- Implement business logic to parse achievement files and map them to friendly names from `achievements.json`.
- Create `useAchievements` hook with standardized error handling.
- Add `AchievementsList` component to display achievements in the UI.
- Integrate achievements display into the `AchievementsPage` with filtering and variant selection.


___

### **PR Type**
Enhancement


___

### **Description**
- Implement backend achievement parsing from game files

- Create Tauri command to fetch achievements by game variant

- Add React hook and UI components for achievement display

- Integrate achievements page with variant selection and filtering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Achievement Files"] -->|Parse| B["get_achievements()"]
  C["achievements.json"] -->|Map Names| B
  B -->|Tauri Command| D["get_achievements_for_variant"]
  D -->|API| E["useAchievements Hook"]
  E -->|Data| F["AchievementsList Component"]
  G["VariantSelector"] -->|Filter| E
  H["Character Filter"] -->|Filter| F
  F -->|Display| I["AchievementsPage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>achievements.rs</strong><dd><code>Core achievement parsing and mapping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-635805881b785ef7bd6756de09ab9b34aafbb2f34349fd139e22408c08616edb">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>commands.rs</strong><dd><code>Tauri command for variant achievement retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-27cd740e82c1e31e483e3dc5f0d8b41d4907da13f5f40432af485f4426175fad">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>TypeScript-exportable achievement data structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-4ff1a60d5b265a8345107aa62b55aa5c19a44fd78739ce6e056f8703e530341b">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Module exports for achievements functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-54c4b10cc6e6158f7f2db23043240866356e69332e9fd5fba396969ae1501d11">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register achievements module and Tauri command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-e55a396fb980091dc975a4f82d365209a83f39d01aec31c01c6a8d7f0e3a3845">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.ts</strong><dd><code>TypeScript wrapper for achievements Tauri command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-ff04962ad082663ab9529061dcf99923984e0f96f51e34faa41a50db34b3cc9b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queryKeys.ts</strong><dd><code>Add query key for achievements caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-f0224bacfc430991dcf42d155eb5564aeddacb00952eb21b1f50b6bdbe28fbcb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAchievements.ts</strong><dd><code>React Query hook with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-88b663d0d957828dd548fedb8946b918397a0eee4d7638895836b17d6dfdd511">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AchievementsList.tsx</strong><dd><code>UI component displaying achievements by character</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-d06b497c3ec3ba5e5b3d34be5d93d713a45621b066cd9c5c5fbf4d2d1a0a4f43">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Integrate achievements with variant and character filtering</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/CatLauncher/pull/418/files#diff-1525a0b0a098299841264634ac66a1449fc09950742f1dad9d718f25549463b2">+66/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Achievements section with a collapsible sidebar splitting Play Time and Game Achievements. Fetch and display per-character achievements by variant via a Tauri command that maps IDs from resources/achievements.json and safely handles missing files.

- **New Features**
  - Nested achievements routes with AchievementsSidebar (/achievements/play-time, /achievements/game-achievements); main route updated to /achievements/*.
  - GameAchievements view with VariantSelector, search, and AchievementsList; PlayTime view shows PlayTimeChart.

- **Refactors**
  - Restructured AchievementsPage to a route-based layout and removed redundant logic.

<sup>Written for commit 889849cbe556e1f7e846c721b7df2c701aa2c64f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

