### PR TITLE
refactor: align project with AGENTS.md standards

### DIFF
--- a/RefactoringReport.md
+++ b/RefactoringReport.md
@@ -1,0 +1,60 @@
+# Refactoring Report
+
+This report identifies inconsistencies between the current codebase and the standards defined in `AGENTS.md`.
+
+## 1. Frontend Hooks - Error Handling Pattern
+
+The `AGENTS.md` specifies that custom hooks wrapping `useQuery` and `useMutation` should take error callbacks and use `useRef`/`useEffect` to handle them. Several hooks in the project do not follow this pattern or follow it only partially (missing `useRef` or `useEffect` sync).
+
+### Identified Inconsistencies:
+
+- **Global Hooks (`cat-launcher/src/hooks/`):**
+    - `useDeleteBackup.ts`: Takes `onError` but doesn't use `useRef`/`useEffect` pattern.
+    - `useRestoreBackup.ts`: Takes `onError` but doesn't use `useRef`/`useEffect` pattern.
+    - `useManualBackups.ts`: Missing error callbacks and `useEffect` sync.
+    - `useDeleteManualBackup.ts`: Takes `onError` but doesn't use `useRef`/`useEffect` pattern.
+    - `useBackups.ts`: Missing error callbacks and `useEffect` sync.
+    - `useRestoreManualBackup.ts`: Takes `onError` but doesn't use `useRef`/`useEffect` pattern.
+    - `useCreateManualBackup.ts`: Takes `onError` but doesn't use `useRef`/`useEffect` pattern.
+
+- **Page-specific Hooks:**
+    - `cat-launcher/src/pages/game-tips/hooks/useGetTips.ts`: Missing error callbacks and `useEffect` sync.
+    - `cat-launcher/src/pages/TilesetsPage/hooks.ts`: `useGetThirdPartyTilesetInstallationStatus` and `useListAllTilesets` missing callbacks. `useUninstallThirdPartyTileset` doesn't use `useRef`/`useEffect`.
+    - `cat-launcher/src/pages/ModsPage/hooks/useUninstallThirdPartyMod.ts`: Doesn't use `useRef`/`useEffect`.
+    - `cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts`: Missing error callbacks.
+    - `cat-launcher/src/pages/PlayPage/hooks/useLaunchGame.ts`: Takes `onError` but uses it directly in `useMutation` without `useRef`.
+    - `cat-launcher/src/pages/SoundpacksPage/hooks.ts`: `useGetThirdPartySoundpackInstallationStatus` and `useListAllSoundpacks` missing callbacks. `useUninstallThirdPartySoundpack` doesn't use `useRef`/`useEffect`.
+
+### Suggested Fixes:
+Refactor these hooks to:
+1. Accept optional error callback(s).
+2. Store callbacks in `useRef`.
+3. Update `useRef` in `useEffect` when callbacks change.
+4. Use `useEffect` to trigger the callback when the `error` state from `useQuery` or `useMutation` changes.
+
+---
+
+## 2. Raw `useQuery`/`useMutation` Usage
+
+`AGENTS.md` states: "Raw `useQuery` and `useMutation` hooks are not used. Instead create custom hooks that wrap `useQuery` and `useMutation`."
+
+### Identified Inconsistencies:
+- `cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx`: Uses `useQuery` directly to fetch `userId`.
+
+### Suggested Fixes:
+- Create a new hook `useUserId` in `cat-launcher/src/hooks/useUserId.ts` and use it in `PostHogProviderWithIdentifiedUser.tsx`.
+
+---
+
+## 3. Directory Structure
+
+`AGENTS.md` specifies a directory structure for features:
+`cat-launcher/src/pages/{feature_name}/hooks`: Hooks specific to this feature.
+
+### Identified Inconsistencies:
+- `cat-launcher/src/pages/SoundpacksPage/hooks.ts`: Should be in a `hooks/` directory and potentially split if it contains multiple hooks.
+- `cat-launcher/src/pages/TilesetsPage/hooks.ts`: Should be in a `hooks/` directory and potentially split.
+
+### Suggested Fixes:
+- Move `cat-launcher/src/pages/SoundpacksPage/hooks.ts` to `cat-launcher/src/pages/SoundpacksPage/hooks/index.ts` (or individual files).
+- Move `cat-launcher/src/pages/TilesetsPage/hooks.ts` to `cat-launcher/src/pages/TilesetsPage/hooks/index.ts` (or individual files).

--- a/cat-launcher/src/hooks/useBackups.ts
+++ b/cat-launcher/src/hooks/useBackups.ts
@@ -1,10 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { listBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
-export function useBackups(variant: GameVariant) {
+export function useBackups(
+  variant: GameVariant,
+  onBackupsError?: (error: Error) => void,
+) {
+  const onBackupsErrorRef = useRef(onBackupsError);
+
+  useEffect(() => {
+    onBackupsErrorRef.current = onBackupsError;
+  }, [onBackupsError]);
+
   const {
     data: backups = [],
     isLoading,
@@ -14,6 +24,12 @@ export function useBackups(variant: GameVariant) {
     queryKey: queryKeys.backups(variant),
     queryFn: () => listBackupsForVariant(variant),
   });
+
+  useEffect(() => {
+    if (error && onBackupsErrorRef.current) {
+      onBackupsErrorRef.current(error as Error);
+    }
+  }, [error]);
 
   return {
     backups,

--- a/cat-launcher/src/hooks/useCreateManualBackup.ts
+++ b/cat-launcher/src/hooks/useCreateManualBackup.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { createManualBackupForVariant } from "@/lib/commands";
@@ -13,8 +14,15 @@ export function useCreateManualBackup(
   } = {},
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(options.onSuccess);
+  const onErrorRef = useRef(options.onError);
 
-  const { mutate, isPending } = useMutation({
+  useEffect(() => {
+    onSuccessRef.current = options.onSuccess;
+    onErrorRef.current = options.onError;
+  }, [options.onSuccess, options.onError]);
+
+  const { mutate, isPending, error } = useMutation({
     mutationFn: async (values: { name: string; notes?: string }) => {
       await createManualBackupForVariant(
         variant,
@@ -47,20 +55,27 @@ export function useCreateManualBackup(
 
       return { previousBackups };
     },
-    onError: (err, _newBackup, context) => {
+    onError: (_err, _newBackup, context) => {
       queryClient.setQueryData(
         queryKeys.manualBackups(variant),
         context?.previousBackups,
       );
-      options.onError?.(err);
     },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.manualBackups(variant),
       });
     },
-    onSuccess: options.onSuccess,
+    onSuccess: () => {
+      onSuccessRef.current?.();
+    },
   });
+
+  useEffect(() => {
+    if (error && onErrorRef.current) {
+      onErrorRef.current(error);
+    }
+  }, [error]);
 
   return {
     createManualBackup: mutate,

--- a/cat-launcher/src/hooks/useDeleteBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteBackup.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { deleteBackupById } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
@@ -15,8 +16,19 @@ export function useDeleteBackup(
   { onSuccess, onError }: UseDeleteBackupOptions = {},
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
 
-  const { mutate: deleteBackup } = useMutation({
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
+
+  const {
+    mutate: deleteBackup,
+    error,
+    isSuccess,
+  } = useMutation({
     mutationFn: (id: bigint) => deleteBackupById(id),
     onMutate: async (id: bigint) => {
       await queryClient.cancelQueries({
@@ -34,15 +46,16 @@ export function useDeleteBackup(
 
       return { previousBackups };
     },
-    onSuccess,
-    onError: (error, _variables, context) => {
+    onSuccess: () => {
+      onSuccessRef.current?.();
+    },
+    onError: (_error, _variables, context) => {
       if (context?.previousBackups) {
         queryClient.setQueryData(
           queryKeys.backups(variant),
           context.previousBackups,
         );
       }
-      onError?.(error);
     },
     onSettled: () => {
       queryClient.invalidateQueries({
@@ -51,5 +64,11 @@ export function useDeleteBackup(
     },
   });
 
-  return { deleteBackup };
+  useEffect(() => {
+    if (error && onErrorRef.current) {
+      onErrorRef.current(error);
+    }
+  }, [error]);
+
+  return { deleteBackup, isSuccess, error };
 }

--- a/cat-launcher/src/hooks/useDeleteManualBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteManualBackup.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { deleteManualBackupById } from "@/lib/commands";
@@ -13,8 +14,15 @@ export function useDeleteManualBackup(
   } = {},
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(options.onSuccess);
+  const onErrorRef = useRef(options.onError);
 
-  const { mutate } = useMutation({
+  useEffect(() => {
+    onSuccessRef.current = options.onSuccess;
+    onErrorRef.current = options.onError;
+  }, [options.onSuccess, options.onError]);
+
+  const { mutate, error } = useMutation({
     mutationFn: async (id: bigint) => {
       await deleteManualBackupById(id);
     },
@@ -34,20 +42,27 @@ export function useDeleteManualBackup(
 
       return { previousBackups };
     },
-    onError: (err, _id, context) => {
+    onError: (_err, _id, context) => {
       queryClient.setQueryData(
         queryKeys.manualBackups(variant),
         context?.previousBackups,
       );
-      options.onError?.(err);
     },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.manualBackups(variant),
       });
     },
-    onSuccess: options.onSuccess,
+    onSuccess: () => {
+      onSuccessRef.current?.();
+    },
   });
+
+  useEffect(() => {
+    if (error && onErrorRef.current) {
+      onErrorRef.current(error);
+    }
+  }, [error]);
 
   return { deleteManualBackup: mutate };
 }

--- a/cat-launcher/src/hooks/useManualBackups.ts
+++ b/cat-launcher/src/hooks/useManualBackups.ts
@@ -1,14 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { listManualBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
-export function useManualBackups(variant: GameVariant) {
-  const { data: manualBackups, isLoading } = useQuery({
+export function useManualBackups(
+  variant: GameVariant,
+  onManualBackupsError?: (error: Error) => void,
+) {
+  const onManualBackupsErrorRef = useRef(onManualBackupsError);
+
+  useEffect(() => {
+    onManualBackupsErrorRef.current = onManualBackupsError;
+  }, [onManualBackupsError]);
+
+  const {
+    data: manualBackups,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: queryKeys.manualBackups(variant),
     queryFn: () => listManualBackupsForVariant(variant),
   });
 
-  return { manualBackups: manualBackups ?? [], isLoading };
+  useEffect(() => {
+    if (error && onManualBackupsErrorRef.current) {
+      onManualBackupsErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  return { manualBackups: manualBackups ?? [], isLoading, error };
 }

--- a/cat-launcher/src/hooks/useRestoreBackup.ts
+++ b/cat-launcher/src/hooks/useRestoreBackup.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { restoreBackupById } from "@/lib/commands";
 
@@ -11,11 +12,30 @@ export function useRestoreBackup({
   onSuccess,
   onError,
 }: UseRestoreBackupOptions = {}) {
-  const { mutate: restoreBackup } = useMutation({
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
+
+  const {
+    mutate: restoreBackup,
+    error,
+    isSuccess,
+  } = useMutation({
     mutationFn: (id: bigint) => restoreBackupById(id),
-    onSuccess,
-    onError,
+    onSuccess: () => {
+      onSuccessRef.current?.();
+    },
   });
 
-  return { restoreBackup };
+  useEffect(() => {
+    if (error && onErrorRef.current) {
+      onErrorRef.current(error);
+    }
+  }, [error]);
+
+  return { restoreBackup, isSuccess };
 }

--- a/cat-launcher/src/hooks/useRestoreManualBackup.ts
+++ b/cat-launcher/src/hooks/useRestoreManualBackup.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { restoreManualBackupById } from "@/lib/commands";
 
@@ -8,13 +9,28 @@ export function useRestoreManualBackup(
     onError?: (error: unknown) => void;
   } = {},
 ) {
-  const { mutate } = useMutation({
+  const onSuccessRef = useRef(options.onSuccess);
+  const onErrorRef = useRef(options.onError);
+
+  useEffect(() => {
+    onSuccessRef.current = options.onSuccess;
+    onErrorRef.current = options.onError;
+  }, [options.onSuccess, options.onError]);
+
+  const { mutate, error } = useMutation({
     mutationFn: async (id: bigint) => {
       await restoreManualBackupById(id);
     },
-    onSuccess: options.onSuccess,
-    onError: options.onError,
+    onSuccess: () => {
+      onSuccessRef.current?.();
+    },
   });
+
+  useEffect(() => {
+    if (error && onErrorRef.current) {
+      onErrorRef.current(error);
+    }
+  }, [error]);
 
   return { restoreManualBackup: mutate };
 }

--- a/cat-launcher/src/hooks/useUserId.ts
+++ b/cat-launcher/src/hooks/useUserId.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { queryKeys } from "@/lib/queryKeys";
+import { getUserId } from "@/lib/commands";
+
+export function useUserId(onUserIdError?: (error: Error) => void) {
+  const onUserIdErrorRef = useRef(onUserIdError);
+
+  useEffect(() => {
+    onUserIdErrorRef.current = onUserIdError;
+  }, [onUserIdError]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.userId(),
+    queryFn: getUserId,
+  });
+
+  useEffect(() => {
+    if (error && onUserIdErrorRef.current) {
+      onUserIdErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  return { userId: data, isLoading };
+}

--- a/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { getThirdPartyModInstallationStatus } from "@/lib/commands";
@@ -7,11 +8,26 @@ import { queryKeys } from "@/lib/queryKeys";
 export function useGetThirdPartyModInstallationStatus(
   modId: string,
   variant: GameVariant,
+  onInstallationStatusError?: (error: Error) => void,
 ) {
+  const onInstallationStatusErrorRef = useRef(
+    onInstallationStatusError,
+  );
+
+  useEffect(() => {
+    onInstallationStatusErrorRef.current = onInstallationStatusError;
+  }, [onInstallationStatusError]);
+
   const query = useQuery({
     queryKey: queryKeys.mods.installationStatus(variant, modId),
     queryFn: () => getThirdPartyModInstallationStatus(modId, variant),
   });
+
+  useEffect(() => {
+    if (query.error && onInstallationStatusErrorRef.current) {
+      onInstallationStatusErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
 
   return {
     installationStatus: query.data,

--- a/cat-launcher/src/pages/ModsPage/hooks/useUninstallThirdPartyMod.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useUninstallThirdPartyMod.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { uninstallThirdPartyMod } from "@/lib/commands";
@@ -10,6 +11,13 @@ export function useUninstallThirdPartyMod(
   onError?: (error: unknown) => void,
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
 
   const mutation = useMutation({
     mutationFn: (modId: string) =>
@@ -18,10 +26,15 @@ export function useUninstallThirdPartyMod(
       queryClient.invalidateQueries({
         queryKey: queryKeys.mods.installationStatus(variant, modId),
       });
-      onSuccess?.();
+      onSuccessRef.current?.();
     },
-    onError,
   });
+
+  useEffect(() => {
+    if (mutation.error && onErrorRef.current) {
+      onErrorRef.current(mutation.error);
+    }
+  }, [mutation.error]);
 
   return {
     isUninstalling: mutation.isPending,

--- a/cat-launcher/src/pages/PlayPage/hooks/useLaunchGame.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useLaunchGame.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { launchGame } from "@/lib/commands";
@@ -19,8 +20,17 @@ export function useLaunchGame(
 ) {
   const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
+  const onErrorRef = useRef(onError);
 
-  const { mutate: launch, isPending: isStartingGame } = useMutation({
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  const {
+    mutate: launch,
+    isPending: isStartingGame,
+    error,
+  } = useMutation({
     mutationFn: (releaseId: string | undefined) => {
       if (!releaseId) {
         throw new Error("No release selected");
@@ -39,14 +49,17 @@ export function useLaunchGame(
         () => releaseId!,
       );
     },
-    onError: (e) => {
-      if (onError) {
-        onError(e as Error);
-      } else {
-        toastCL("error", "Failed to launch game.", e);
-      }
-    },
   });
+
+  useEffect(() => {
+    if (error) {
+      if (onErrorRef.current) {
+        onErrorRef.current(error as Error);
+      } else {
+        toastCL("error", "Failed to launch game.", error);
+      }
+    }
+  }, [error]);
 
   return { launch, isStartingGame };
 }

--- a/cat-launcher/src/pages/SoundpacksPage/hooks/index.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks/index.ts
@@ -3,6 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { useInstallAndMonitor } from "@/hooks/useInstallAndMonitor";
 import type { GameVariant } from "@/generated-types/GameVariant";
@@ -56,7 +57,14 @@ export function useInstallThirdPartySoundpack(
 export function useGetThirdPartySoundpackInstallationStatus(
   soundpackId: string,
   variant: GameVariant,
+  onStatusError?: (error: Error) => void,
 ) {
+  const onStatusErrorRef = useRef(onStatusError);
+
+  useEffect(() => {
+    onStatusErrorRef.current = onStatusError;
+  }, [onStatusError]);
+
   const query = useQuery({
     queryKey: queryKeys.soundpacks.installationStatus(
       variant,
@@ -65,6 +73,12 @@ export function useGetThirdPartySoundpackInstallationStatus(
     queryFn: () =>
       getThirdPartySoundpackInstallationStatus(soundpackId, variant),
   });
+
+  useEffect(() => {
+    if (query.error && onStatusErrorRef.current) {
+      onStatusErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
 
   return {
     installationStatus: query.data,
@@ -78,6 +92,13 @@ export function useUninstallThirdPartySoundpack(
   onError?: (error: unknown) => void,
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
 
   const mutation = useMutation({
     mutationFn: (soundpackId: string) =>
@@ -92,10 +113,15 @@ export function useUninstallThirdPartySoundpack(
           soundpackId,
         ),
       });
-      onSuccess?.();
+      onSuccessRef.current?.();
     },
-    onError,
   });
+
+  useEffect(() => {
+    if (mutation.error && onErrorRef.current) {
+      onErrorRef.current(mutation.error);
+    }
+  }, [mutation.error]);
 
   return {
     isUninstalling: mutation.isPending,
@@ -103,11 +129,26 @@ export function useUninstallThirdPartySoundpack(
   };
 }
 
-export function useListAllSoundpacks(variant: GameVariant) {
+export function useListAllSoundpacks(
+  variant: GameVariant,
+  onListError?: (error: Error) => void,
+) {
+  const onListErrorRef = useRef(onListError);
+
+  useEffect(() => {
+    onListErrorRef.current = onListError;
+  }, [onListError]);
+
   const query = useQuery({
     queryKey: queryKeys.soundpacks.listAll(variant),
     queryFn: () => listAllSoundpacks(variant),
   });
+
+  useEffect(() => {
+    if (query.error && onListErrorRef.current) {
+      onListErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
 
   return {
     soundpacks: query.data,

--- a/cat-launcher/src/pages/TilesetsPage/hooks/index.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks/index.ts
@@ -3,6 +3,7 @@ import {
   useQueryClient,
   useMutation,
 } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { useInstallAndMonitor } from "@/hooks/useInstallAndMonitor";
 import type { GameVariant } from "@/generated-types/GameVariant";
@@ -56,7 +57,14 @@ export function useInstallAndMonitorThirdPartyTileset(
 export function useGetThirdPartyTilesetInstallationStatus(
   tilesetId: string,
   variant: GameVariant,
+  onStatusError?: (error: Error) => void,
 ) {
+  const onStatusErrorRef = useRef(onStatusError);
+
+  useEffect(() => {
+    onStatusErrorRef.current = onStatusError;
+  }, [onStatusError]);
+
   const query = useQuery({
     queryKey: queryKeys.tilesets.installationStatus(
       variant,
@@ -65,6 +73,12 @@ export function useGetThirdPartyTilesetInstallationStatus(
     queryFn: () =>
       getThirdPartyTilesetInstallationStatus(tilesetId, variant),
   });
+
+  useEffect(() => {
+    if (query.error && onStatusErrorRef.current) {
+      onStatusErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
 
   return {
     installationStatus: query.data,
@@ -78,6 +92,13 @@ export function useUninstallThirdPartyTileset(
   onError?: (error: unknown) => void,
 ) {
   const queryClient = useQueryClient();
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
 
   const mutation = useMutation({
     mutationFn: (tilesetId: string) =>
@@ -92,10 +113,15 @@ export function useUninstallThirdPartyTileset(
           tilesetId,
         ),
       });
-      onSuccess?.();
+      onSuccessRef.current?.();
     },
-    onError,
   });
+
+  useEffect(() => {
+    if (mutation.error && onErrorRef.current) {
+      onErrorRef.current(mutation.error);
+    }
+  }, [mutation.error]);
 
   return {
     isUninstalling: mutation.isPending,
@@ -103,11 +129,26 @@ export function useUninstallThirdPartyTileset(
   };
 }
 
-export function useListAllTilesets(variant: GameVariant) {
+export function useListAllTilesets(
+  variant: GameVariant,
+  onListError?: (error: Error) => void,
+) {
+  const onListErrorRef = useRef(onListError);
+
+  useEffect(() => {
+    onListErrorRef.current = onListError;
+  }, [onListError]);
+
   const query = useQuery({
     queryKey: queryKeys.tilesets.listAll(variant),
     queryFn: () => listAllTilesets(variant),
   });
+
+  useEffect(() => {
+    if (query.error && onListErrorRef.current) {
+      onListErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
 
   return {
     tilesets: query.data,

--- a/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
+++ b/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
@@ -35,16 +35,16 @@ interface TipOfTheDayProps {
 }
 
 export function TipOfTheDay({ variant }: TipOfTheDayProps) {
-  const { data, status } = useGetTips(variant);
+  const { tips: data, isLoading } = useGetTips(variant);
 
   const [randomIndex, setRandomIndex] = useState(0);
 
   const tips = useMemo(() => {
-    if (status !== "success" || data.length === 0) {
+    if (isLoading || !data || data.length === 0) {
       return [];
     }
     return data;
-  }, [data, status]);
+  }, [data, isLoading]);
 
   const shuffleTips = useCallback(() => {
     if (tips.length === 0) {

--- a/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
+++ b/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
@@ -1,12 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { queryKeys } from "@/lib/queryKeys";
 import { getTips } from "@/lib/commands";
 import type { GameVariant } from "@/generated-types/GameVariant";
 
-export function useGetTips(variant: GameVariant) {
-  return useQuery({
+export function useGetTips(
+  variant: GameVariant,
+  onTipsError?: (error: Error) => void,
+) {
+  const onTipsErrorRef = useRef(onTipsError);
+
+  useEffect(() => {
+    onTipsErrorRef.current = onTipsError;
+  }, [onTipsError]);
+
+  const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.tips(variant),
     queryFn: async () => getTips(variant),
   });
+
+  useEffect(() => {
+    if (error && onTipsErrorRef.current) {
+      onTipsErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  return { tips: data, isLoading, error };
 }

--- a/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
+++ b/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
@@ -1,9 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { PostHogProvider } from "posthog-js/react";
 import { ReactNode } from "react";
 
-import { queryKeys } from "@/lib/queryKeys";
-import { getUserId } from "@/lib/commands";
+import { useUserId } from "@/hooks/useUserId";
 
 const posthogOptions = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
@@ -18,10 +16,7 @@ export interface PostHogProviderWithIdentifiedUserProps {
 export default function PostHogProviderWithIdentifiedUser({
   children,
 }: PostHogProviderWithIdentifiedUserProps) {
-  const { data: userId } = useQuery({
-    queryKey: queryKeys.userId(),
-    queryFn: getUserId,
-  });
+  const { userId } = useUserId();
 
   if (!userId) {
     return null;


### PR DESCRIPTION
Audited every file in the project against the coding standards mentioned in AGENTS.md. Refactored frontend hooks to follow the specified error-handling pattern, moved hooks to their respective feature directories, and wrapped raw useQuery usage in a custom hook. Created RefactoringReport.md documenting the inconsistencies and fixes.

---
*PR created automatically by Jules for task [6792061798557205641](https://jules.google.com/task/6792061798557205641) started by @abhi-kr-2100*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized hooks to follow `AGENTS.md`: wrapped all `@tanstack/react-query` usage in custom hooks with consistent error handling, and aligned feature folder structure. This reduces direct `useQuery`/`useMutation` usage and makes errors easier to handle.

- **Refactors**
  - Applied `useRef`/`useEffect` error-callback pattern to backups, manual backups, restore, uninstall, installation-status, tips, and game launch hooks.
  - Replaced raw `useQuery` in `PostHogProviderWithIdentifiedUser` with new `useUserId`.
  - Moved `SoundpacksPage` and `TilesetsPage` hooks to `pages/.../hooks/index.ts`.
  - Updated `useGetTips` to return `{ tips, isLoading, error }` and adjusted `TipOfTheDay`.
  - Added `RefactoringReport.md` summarizing gaps and fixes.

- **Migration**
  - Use custom hooks only; avoid calling `useQuery`/`useMutation` directly.
  - Hooks now support optional `onError`/`onSuccess` callbacks; pass them if you need side effects.
  - Update any code using `useGetTips` to read `tips` and `isLoading` instead of the raw query object.

<sup>Written for commit ffedf92dd314bea592f5b73f0bfc82c33729bce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

