### PR TITLE
Align codebase with AGENTS.md standards

### DIFF
--- a/RefactoringReport.md
+++ b/RefactoringReport.md
@@ -1,0 +1,50 @@
+# Refactoring Report
+
+This report identifies inconsistencies in the CatLauncher codebase based on the standards defined in `AGENTS.md`.
+
+## Frontend Inconsistencies
+
+### 1. Direct use of `useQuery` in Components
+- **File:** `cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx`
+- **Issue:** The `useQuery` hook is used directly to fetch `userId`. `AGENTS.md` states that raw `useQuery` and `useMutation` hooks should not be used; instead, custom hooks should wrap them.
+- **Suggested Fix:** Create a `useUserId` hook in `cat-launcher/src/hooks/useUserId.ts` and use it in the provider.
+
+### 2. Custom Hooks Lacking Standard Error Callback Pattern
+- **Files:**
+    - `cat-launcher/src/hooks/useManualBackups.ts`
+    - `cat-launcher/src/hooks/useBackups.ts`
+    - `cat-launcher/src/hooks/useGameVariants.ts`
+    - `cat-launcher/src/pages/game-tips/hooks/useGetTips.ts`
+    - `cat-launcher/src/pages/SettingsPage/hooks/useColorThemes.ts`
+    - `cat-launcher/src/pages/SettingsPage/hooks/useSettingsForm.ts`
+    - `cat-launcher/src/pages/SettingsPage/hooks/useFonts.ts`
+    - `cat-launcher/src/pages/PlayPage/hooks/usePlayTime.ts`
+    - `cat-launcher/src/pages/PlayPage/hooks/useReleaseNotes.ts`
+    - `cat-launcher/src/pages/AchievementsPage/hooks/useAchievements.ts`
+    - `cat-launcher/src/theme/useTheme.ts`
+    - `cat-launcher/src/pages/TilesetsPage/hooks.ts`
+    - `cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts`
+    - `cat-launcher/src/pages/ModsPage/hooks/useGetLastModActivity.ts`
+    - `cat-launcher/src/pages/SoundpacksPage/hooks.ts`
+- **Issue:** These hooks do not implement the `useRef` and `useEffect` pattern for error callbacks as specified in `AGENTS.md`.
+- **Suggested Fix:** Refactor these hooks to accept optional error callbacks and use the standard pattern to trigger them.
+
+### 3. Non-Standard Directory Structure
+- **File:** `cat-launcher/src/pages/AboutPage.tsx`
+- **Issue:** `AGENTS.md` specifies that each feature should be in its own directory with an `index.tsx` file.
+- **Suggested Fix:** Move `AboutPage.tsx` to `cat-launcher/src/pages/AboutPage/index.tsx` and update relevant imports.
+
+## Backend Inconsistencies
+
+### 1. Command Error Naming Conventions
+- **Files:**
+    - `cat-launcher/src-tauri/src/game_tips/commands.rs` (`GetTipsCommandError`)
+    - `cat-launcher/src-tauri/src/fetch_releases/commands.rs` (`FetchReleasesCommandError`, `FetchReleaseNotesCommandError`)
+    - `cat-launcher/src-tauri/src/active_release/commands.rs` (`ActiveReleaseCommandError`)
+- **Issue:** Error names for commands do not follow the `{FunctionName}Error` convention.
+- **Suggested Fix:** Rename these error enums to match the command function names (e.g., `GetTipsError`, `FetchReleasesForVariantError`).
+
+### 2. Potential Business Logic in Commands
+- **File:** `cat-launcher/src-tauri/src/game_tips/commands.rs`
+- **Issue:** The `get_tips` command performs OS enum detection and path resolution.
+- **Suggested Fix:** While it prepares arguments, ensuring all logic is moved to the business logic layer where possible is preferred.

--- a/cat-launcher/src-tauri/src/active_release/commands.rs
+++ b/cat-launcher/src-tauri/src/active_release/commands.rs
@@ -10,7 +10,7 @@ use crate::variants::GameVariant;
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
-pub enum ActiveReleaseCommandError {
+pub enum GetActiveReleaseError {
   #[error("failed to get active release: {0}")]
   GetActiveRelease(#[from] ActiveReleaseError),
 
@@ -22,7 +22,7 @@ pub enum ActiveReleaseCommandError {
 pub async fn get_active_release(
   variant: GameVariant,
   repository: State<'_, SqliteActiveReleaseRepository>,
-) -> Result<Option<String>, ActiveReleaseCommandError> {
+) -> Result<Option<String>, GetActiveReleaseError> {
   let active_release =
     variant.get_active_release(&*repository).await?;
 

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -7,7 +7,8 @@ use tauri::{command, AppHandle, Emitter, Manager, State};
 use cat_macros::CommandErrorSerialize;
 
 use crate::fetch_releases::fetch_releases::{
-  FetchReleaseNotesError, FetchReleasesError, ReleasesUpdatePayload,
+  FetchReleaseNotesInternalError, FetchReleasesError,
+  ReleasesUpdatePayload,
 };
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::infra::utils::{
@@ -19,7 +20,7 @@ use crate::variants::GameVariant;
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
-pub enum FetchReleasesCommandError {
+pub enum FetchReleasesForVariantError {
   #[error("system directory not found: {0}")]
   SystemDir(#[from] tauri::Error),
 
@@ -39,7 +40,7 @@ pub async fn fetch_releases_for_variant(
   variant: GameVariant,
   releases_repository: State<'_, SqliteReleasesRepository>,
   client: State<'_, Client>,
-) -> Result<(), FetchReleasesCommandError> {
+) -> Result<(), FetchReleasesForVariantError> {
   let resources_dir = app_handle.path().resource_dir()?;
   let os = get_os_enum(OS)?;
   let arch = get_arch_enum(ARCH)?;
@@ -66,9 +67,9 @@ pub async fn fetch_releases_for_variant(
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
-pub enum FetchReleaseNotesCommandError {
+pub enum FetchReleaseNotesError {
   #[error("failed to fetch release notes: {0}")]
-  Fetch(#[from] FetchReleaseNotesError),
+  Fetch(#[from] FetchReleaseNotesInternalError),
 }
 
 #[command]
@@ -77,7 +78,7 @@ pub async fn fetch_release_notes(
   release_id: String,
   releases_repository: State<'_, SqliteReleasesRepository>,
   client: State<'_, Client>,
-) -> Result<Option<String>, FetchReleaseNotesCommandError> {
+) -> Result<Option<String>, FetchReleaseNotesError> {
   let notes = variant
     .fetch_release_notes(&release_id, &client, &*releases_repository)
     .await?;

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -48,7 +48,7 @@ pub enum ReleasesUpdateStatus {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum FetchReleaseNotesError {
+pub enum FetchReleaseNotesInternalError {
   #[error("failed to get release from github: {0}")]
   Fetch(#[from] FetchGitHubReleaseByTagError),
 
@@ -124,7 +124,7 @@ impl GameVariant {
     release_id: &str,
     client: &Client,
     releases_repository: &dyn ReleasesRepository,
-  ) -> Result<Option<String>, FetchReleaseNotesError> {
+  ) -> Result<Option<String>, FetchReleaseNotesInternalError> {
     let cached_release = releases_repository
       .get_cached_release_by_tag(self, release_id)
       .await?;

--- a/cat-launcher/src-tauri/src/game_tips/commands.rs
+++ b/cat-launcher/src-tauri/src/game_tips/commands.rs
@@ -1,25 +1,18 @@
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{command, AppHandle, State};
 
 use cat_macros::CommandErrorSerialize;
 
+use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
+use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::game_tips::lib::get_all_tips_for_variant;
 use crate::game_tips::lib::GetAllTipsForVariantError;
-use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::variants::GameVariant;
-use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
-use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
-pub enum GetTipsCommandError {
-  #[error("failed to get data directory: {0}")]
-  DataDir(#[from] tauri::Error),
-
-  #[error("unsupported OS: {0}")]
-  UnsupportedOS(#[from] OSNotSupportedError),
-
+pub enum GetTipsError {
   #[error("failed to get tips for variant: {0}")]
   GetForVariant(#[from] GetAllTipsForVariantError),
 }
@@ -30,14 +23,10 @@ pub async fn get_tips(
   variant: GameVariant,
   active_release_repository: State<'_, SqliteActiveReleaseRepository>,
   releases_repository: State<'_, SqliteReleasesRepository>,
-) -> Result<Vec<String>, GetTipsCommandError> {
-  let data_dir = app_handle.path().app_local_data_dir()?;
-  let os = get_os_enum(std::env::consts::OS)?;
-
+) -> Result<Vec<String>, GetTipsError> {
   let tips = get_all_tips_for_variant(
+    &app_handle,
     &variant,
-    &data_dir,
-    &os,
     &*active_release_repository,
     &*releases_repository,
   )

--- a/cat-launcher/src-tauri/src/game_tips/lib.rs
+++ b/cat-launcher/src-tauri/src/game_tips/lib.rs
@@ -1,3 +1,4 @@
+use tauri::Manager;
 use thiserror::Error;
 
 use crate::active_release::repository::{
@@ -14,7 +15,7 @@ use crate::game_release::game_release::{
 };
 use crate::game_release::utils::gh_release_to_game_release;
 use crate::game_tips::types::Tip;
-use crate::infra::utils::OS;
+use crate::infra::utils::{get_os_enum, OSNotSupportedError, OS};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
@@ -37,6 +38,12 @@ pub enum GetAllTipsForVariantError {
 
   #[error("failed to get cached releases: {0}")]
   GetCachedReleases(#[from] ReleasesRepositoryError),
+
+  #[error("unsupported OS: {0}")]
+  UnsupportedOS(#[from] OSNotSupportedError),
+
+  #[error("failed to get data directory: {0}")]
+  DataDir(#[from] tauri::Error),
 }
 
 async fn get_tips_from_version(
@@ -69,20 +76,22 @@ async fn get_tips_from_version(
 }
 
 pub async fn get_all_tips_for_variant(
+  app_handle: &tauri::AppHandle,
   variant: &GameVariant,
-  data_dir: &std::path::Path,
-  os: &OS,
   active_release_repository: &(dyn ActiveReleaseRepository
       + Send
       + Sync),
   releases_repository: &(dyn ReleasesRepository + Send + Sync),
 ) -> Result<Vec<String>, GetAllTipsForVariantError> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  let os = get_os_enum(std::env::consts::OS)?;
+
   if let Some(active_release) = active_release_repository
     .get_active_release(variant)
     .await?
   {
     let tips =
-      get_tips_from_version(variant, &active_release, data_dir, os)
+      get_tips_from_version(variant, &active_release, &data_dir, &os)
         .await?;
     return Ok(tips);
   }
@@ -95,14 +104,14 @@ pub async fn get_all_tips_for_variant(
     .collect();
 
   for release in releases {
-    if release.get_installation_status(os, data_dir).await?
+    if release.get_installation_status(&os, &data_dir).await?
       == GameReleaseStatus::ReadyToPlay
     {
       let tips = get_tips_from_version(
         variant,
         &release.version,
-        data_dir,
-        os,
+        &data_dir,
+        &os,
       )
       .await?;
       return Ok(tips);

--- a/cat-launcher/src/hooks/useBackups.ts
+++ b/cat-launcher/src/hooks/useBackups.ts
@@ -1,24 +1,33 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { listBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
-export function useBackups(variant: GameVariant) {
-  const {
-    data: backups = [],
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
+export function useBackups(
+  variant: GameVariant,
+  onLoadError?: (error: Error) => void,
+) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
+  const query = useQuery({
     queryKey: queryKeys.backups(variant),
     queryFn: () => listBackupsForVariant(variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
-    backups,
-    isLoading,
-    isError,
-    error,
+    ...query,
+    backups: query.data ?? [],
   };
 }

--- a/cat-launcher/src/hooks/useGameVariants.ts
+++ b/cat-launcher/src/hooks/useGameVariants.ts
@@ -11,11 +11,11 @@ import {
   updateGameVariantOrder,
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface UseGameVariantsOptions {
-  onOrderUpdateError?: (error: unknown) => void;
-  onFetchError?: (error: unknown) => void;
+  onOrderUpdateError?: (error: Error) => void;
+  onFetchError?: (error: Error) => void;
 }
 
 export function useGameVariants({
@@ -23,6 +23,16 @@ export function useGameVariants({
   onFetchError,
 }: UseGameVariantsOptions = {}) {
   const queryClient = useQueryClient();
+
+  const onFetchErrorRef = useRef(onFetchError);
+  useEffect(() => {
+    onFetchErrorRef.current = onFetchError;
+  }, [onFetchError]);
+
+  const onOrderUpdateErrorRef = useRef(onOrderUpdateError);
+  useEffect(() => {
+    onOrderUpdateErrorRef.current = onOrderUpdateError;
+  }, [onOrderUpdateError]);
 
   const {
     data: gameVariants = [],
@@ -35,10 +45,10 @@ export function useGameVariants({
   });
 
   useEffect(() => {
-    if (isError) {
-      onFetchError?.(error);
+    if (isError && onFetchErrorRef.current) {
+      onFetchErrorRef.current(error as Error);
     }
-  }, [isError, error, onFetchError]);
+  }, [isError, error]);
 
   const { mutate } = useMutation({
     mutationFn: ({
@@ -70,7 +80,9 @@ export function useGameVariants({
           context.previousGameVariants,
         );
       }
-      onOrderUpdateError?.(error);
+      if (onOrderUpdateErrorRef.current) {
+        onOrderUpdateErrorRef.current(error as Error);
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/cat-launcher/src/hooks/useManualBackups.ts
+++ b/cat-launcher/src/hooks/useManualBackups.ts
@@ -1,14 +1,33 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 import { listManualBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
-export function useManualBackups(variant: GameVariant) {
-  const { data: manualBackups, isLoading } = useQuery({
+export function useManualBackups(
+  variant: GameVariant,
+  onLoadError?: (error: Error) => void,
+) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
+  const query = useQuery({
     queryKey: queryKeys.manualBackups(variant),
     queryFn: () => listManualBackupsForVariant(variant),
   });
 
-  return { manualBackups: manualBackups ?? [], isLoading };
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
+  return {
+    ...query,
+    manualBackups: query.data ?? [],
+  };
 }

--- a/cat-launcher/src/hooks/useUserId.ts
+++ b/cat-launcher/src/hooks/useUserId.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { getUserId } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useUserId(
+  onUserIdFetchError?: (error: Error) => void,
+) {
+  const onUserIdFetchErrorRef = useRef(onUserIdFetchError);
+
+  useEffect(() => {
+    onUserIdFetchErrorRef.current = onUserIdFetchError;
+  }, [onUserIdFetchError]);
+
+  const query = useQuery({
+    queryKey: queryKeys.userId(),
+    queryFn: getUserId,
+  });
+
+  useEffect(() => {
+    if (query.error && onUserIdFetchErrorRef.current) {
+      onUserIdFetchErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
+  return {
+    ...query,
+    userId: query.data,
+  };
+}

--- a/cat-launcher/src/pages/AboutPage/index.tsx
+++ b/cat-launcher/src/pages/AboutPage/index.tsx
@@ -1,4 +1,4 @@
-import pkg from "../../package.json";
+import pkg from "../../../package.json";
 import { openLink } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 

--- a/cat-launcher/src/pages/ModsPage/hooks/useGetLastModActivity.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useGetLastModActivity.ts
@@ -9,7 +9,7 @@ export function useGetLastModActivity(
   enabled: boolean,
   modId: string,
   variant: GameVariant,
-  onError?: (error: unknown) => void,
+  onError?: (error: Error) => void,
 ) {
   const onErrorRef = useRef(onError);
 
@@ -25,7 +25,7 @@ export function useGetLastModActivity(
 
   useEffect(() => {
     if (query.error && onErrorRef.current) {
-      onErrorRef.current(query.error);
+      onErrorRef.current(query.error as Error);
     }
   }, [query.error]);
 

--- a/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { getThirdPartyModInstallationStatus } from "@/lib/commands";
@@ -7,13 +8,27 @@ import { queryKeys } from "@/lib/queryKeys";
 export function useGetThirdPartyModInstallationStatus(
   modId: string,
   variant: GameVariant,
+  onLoadError?: (error: Error) => void,
 ) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
   const query = useQuery({
     queryKey: queryKeys.mods.installationStatus(variant, modId),
     queryFn: () => getThirdPartyModInstallationStatus(modId, variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
+    ...query,
     installationStatus: query.data,
   };
 }

--- a/cat-launcher/src/pages/PlayPage/PlayTime.tsx
+++ b/cat-launcher/src/pages/PlayPage/PlayTime.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
-import { cn } from "@/lib/utils";
+import { cn, toastCL } from "@/lib/utils";
 import { usePlayTime } from "./hooks";
 
 interface PlayTimeProps extends HTMLAttributes<HTMLDivElement> {
@@ -32,6 +32,20 @@ export function PlayTime({
   const { totalPlayTime, versionPlayTime } = usePlayTime(
     variant,
     releaseId,
+    (error) => {
+      toastCL(
+        "error",
+        `Failed to get total play time for ${variant}.`,
+        error,
+      );
+    },
+    (error) => {
+      toastCL(
+        "error",
+        `Failed to get version play time for ${variant}.`,
+        error,
+      );
+    },
   );
 
   const formattedVersionPlayTime = formatPlayTime(versionPlayTime);

--- a/cat-launcher/src/pages/PlayPage/hooks/usePlayTime.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/usePlayTime.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { GameEvent } from "@/generated-types/GameEvent";
 import type { GameVariant } from "@/generated-types/GameVariant";
@@ -9,13 +9,24 @@ import {
   listenToGameEvent,
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
-import { setupEventListener, toastCL } from "@/lib/utils";
+import { setupEventListener } from "@/lib/utils";
 
 export function usePlayTime(
   variant: GameVariant,
   releaseId?: string,
+  onTotalPlayTimeError?: (error: Error) => void,
+  onVersionPlayTimeError?: (error: Error) => void,
 ) {
   const queryClient = useQueryClient();
+
+  const onTotalPlayTimeErrorRef = useRef(onTotalPlayTimeError);
+  const onVersionPlayTimeErrorRef = useRef(onVersionPlayTimeError);
+
+  useEffect(() => {
+    onTotalPlayTimeErrorRef.current = onTotalPlayTimeError;
+    onVersionPlayTimeErrorRef.current = onVersionPlayTimeError;
+  }, [onTotalPlayTimeError, onVersionPlayTimeError]);
+
   const { data: totalPlayTime, error: totalPlayTimeError } = useQuery(
     {
       queryKey: queryKeys.playTimeForVariant(variant),
@@ -38,24 +49,18 @@ export function usePlayTime(
     });
 
   useEffect(() => {
-    if (totalPlayTimeError) {
-      toastCL(
-        "error",
-        `Failed to get total play time for ${variant}.`,
-        totalPlayTimeError,
-      );
+    if (totalPlayTimeError && onTotalPlayTimeErrorRef.current) {
+      onTotalPlayTimeErrorRef.current(totalPlayTimeError as Error);
     }
-  }, [totalPlayTimeError, variant]);
+  }, [totalPlayTimeError]);
 
   useEffect(() => {
-    if (versionPlayTimeError) {
-      toastCL(
-        "error",
-        `Failed to get version play time for ${variant}.`,
-        versionPlayTimeError,
+    if (versionPlayTimeError && onVersionPlayTimeErrorRef.current) {
+      onVersionPlayTimeErrorRef.current(
+        versionPlayTimeError as Error,
       );
     }
-  }, [versionPlayTimeError, variant]);
+  }, [versionPlayTimeError]);
 
   useEffect(() => {
     const gameEventHandler = (event: GameEvent) => {

--- a/cat-launcher/src/pages/SettingsPage/hooks/useColorThemes.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useColorThemes.ts
@@ -24,7 +24,7 @@ export function useColorThemes(
 
   useEffect(() => {
     if (error && onThemesErrorRef.current) {
-      onThemesErrorRef.current(error);
+      onThemesErrorRef.current(error as Error);
     }
   }, [error]);
 

--- a/cat-launcher/src/pages/SettingsPage/hooks/useFonts.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useFonts.ts
@@ -22,7 +22,7 @@ export function useFonts(onFontsError?: (error: Error) => void) {
 
   useEffect(() => {
     if (error && onFontsErrorRef.current) {
-      onFontsErrorRef.current(error);
+      onFontsErrorRef.current(error as Error);
     }
   }, [error]);
 

--- a/cat-launcher/src/pages/SoundpacksPage/hooks.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks.ts
@@ -3,6 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { useInstallAndMonitor } from "@/hooks/useInstallAndMonitor";
 import type { GameVariant } from "@/generated-types/GameVariant";
@@ -56,7 +57,14 @@ export function useInstallThirdPartySoundpack(
 export function useGetThirdPartySoundpackInstallationStatus(
   soundpackId: string,
   variant: GameVariant,
+  onLoadError?: (error: Error) => void,
 ) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
   const query = useQuery({
     queryKey: queryKeys.soundpacks.installationStatus(
       variant,
@@ -66,18 +74,29 @@ export function useGetThirdPartySoundpackInstallationStatus(
       getThirdPartySoundpackInstallationStatus(soundpackId, variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
+    ...query,
     installationStatus: query.data,
-    isLoading: query.isLoading,
   };
 }
 
 export function useUninstallThirdPartySoundpack(
   variant: GameVariant,
   onSuccess?: () => void,
-  onError?: (error: unknown) => void,
+  onError?: (error: Error) => void,
 ) {
   const queryClient = useQueryClient();
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
 
   const mutation = useMutation({
     mutationFn: (soundpackId: string) =>
@@ -94,7 +113,11 @@ export function useUninstallThirdPartySoundpack(
       });
       onSuccess?.();
     },
-    onError,
+    onError: (error) => {
+      if (onErrorRef.current) {
+        onErrorRef.current(error as Error);
+      }
+    },
   });
 
   return {
@@ -103,15 +126,29 @@ export function useUninstallThirdPartySoundpack(
   };
 }
 
-export function useListAllSoundpacks(variant: GameVariant) {
+export function useListAllSoundpacks(
+  variant: GameVariant,
+  onLoadError?: (error: Error) => void,
+) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
   const query = useQuery({
     queryKey: queryKeys.soundpacks.listAll(variant),
     queryFn: () => listAllSoundpacks(variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
+    ...query,
     soundpacks: query.data,
-    isLoading: query.isLoading,
-    error: query.error,
   };
 }

--- a/cat-launcher/src/pages/TilesetsPage/hooks.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks.ts
@@ -3,6 +3,7 @@ import {
   useQueryClient,
   useMutation,
 } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { useInstallAndMonitor } from "@/hooks/useInstallAndMonitor";
 import type { GameVariant } from "@/generated-types/GameVariant";
@@ -56,7 +57,14 @@ export function useInstallAndMonitorThirdPartyTileset(
 export function useGetThirdPartyTilesetInstallationStatus(
   tilesetId: string,
   variant: GameVariant,
+  onLoadError?: (error: Error) => void,
 ) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
   const query = useQuery({
     queryKey: queryKeys.tilesets.installationStatus(
       variant,
@@ -66,18 +74,29 @@ export function useGetThirdPartyTilesetInstallationStatus(
       getThirdPartyTilesetInstallationStatus(tilesetId, variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
+    ...query,
     installationStatus: query.data,
-    isLoading: query.isLoading,
   };
 }
 
 export function useUninstallThirdPartyTileset(
   variant: GameVariant,
   onSuccess?: () => void,
-  onError?: (error: unknown) => void,
+  onError?: (error: Error) => void,
 ) {
   const queryClient = useQueryClient();
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
 
   const mutation = useMutation({
     mutationFn: (tilesetId: string) =>
@@ -94,7 +113,11 @@ export function useUninstallThirdPartyTileset(
       });
       onSuccess?.();
     },
-    onError,
+    onError: (error) => {
+      if (onErrorRef.current) {
+        onErrorRef.current(error as Error);
+      }
+    },
   });
 
   return {
@@ -103,15 +126,29 @@ export function useUninstallThirdPartyTileset(
   };
 }
 
-export function useListAllTilesets(variant: GameVariant) {
+export function useListAllTilesets(
+  variant: GameVariant,
+  onLoadError?: (error: Error) => void,
+) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
   const query = useQuery({
     queryKey: queryKeys.tilesets.listAll(variant),
     queryFn: () => listAllTilesets(variant),
   });
 
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
   return {
+    ...query,
     tilesets: query.data,
-    isLoading: query.isLoading,
-    error: query.error,
   };
 }

--- a/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
+++ b/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
@@ -35,16 +35,16 @@ interface TipOfTheDayProps {
 }
 
 export function TipOfTheDay({ variant }: TipOfTheDayProps) {
-  const { data, status } = useGetTips(variant);
+  const { data, error, status } = useGetTips(variant);
 
   const [randomIndex, setRandomIndex] = useState(0);
 
   const tips = useMemo(() => {
-    if (status !== "success" || data.length === 0) {
+    if (error || status !== "success" || !data || data.length === 0) {
       return [];
     }
     return data;
-  }, [data, status]);
+  }, [data, error, status]);
 
   const shuffleTips = useCallback(() => {
     if (tips.length === 0) {

--- a/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
+++ b/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
@@ -1,12 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 
 import { queryKeys } from "@/lib/queryKeys";
 import { getTips } from "@/lib/commands";
 import type { GameVariant } from "@/generated-types/GameVariant";
 
-export function useGetTips(variant: GameVariant) {
-  return useQuery({
+export function useGetTips(
+  variant: GameVariant,
+  onLoadError?: (error: Error) => void,
+) {
+  const onLoadErrorRef = useRef(onLoadError);
+
+  useEffect(() => {
+    onLoadErrorRef.current = onLoadError;
+  }, [onLoadError]);
+
+  const query = useQuery({
     queryKey: queryKeys.tips(variant),
     queryFn: async () => getTips(variant),
   });
+
+  useEffect(() => {
+    if (query.error && onLoadErrorRef.current) {
+      onLoadErrorRef.current(query.error as Error);
+    }
+  }, [query.error]);
+
+  return query;
 }

--- a/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
+++ b/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
@@ -1,9 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { PostHogProvider } from "posthog-js/react";
 import { ReactNode } from "react";
 
-import { queryKeys } from "@/lib/queryKeys";
-import { getUserId } from "@/lib/commands";
+import { useUserId } from "@/hooks/useUserId";
 
 const posthogOptions = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
@@ -18,10 +16,7 @@ export interface PostHogProviderWithIdentifiedUserProps {
 export default function PostHogProviderWithIdentifiedUser({
   children,
 }: PostHogProviderWithIdentifiedUserProps) {
-  const { data: userId } = useQuery({
-    queryKey: queryKeys.userId(),
-    queryFn: getUserId,
-  });
+  const { userId } = useUserId();
 
   if (!userId) {
     return null;

--- a/cat-launcher/src/theme/useTheme.ts
+++ b/cat-launcher/src/theme/useTheme.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   useMutation,
   useQuery,
@@ -26,8 +26,13 @@ export function applyThemeToDom(theme: Theme): void {
   root.style.colorScheme = theme === "Light" ? "light" : "dark";
 }
 
-export function useTheme(onError?: (error: unknown) => void) {
+export function useTheme(onError?: (error: Error) => void) {
   const queryClient = useQueryClient();
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
 
   const { data: themePreference, error: fetchError } = useQuery({
     queryKey: queryKeys.themePreference(),
@@ -49,10 +54,10 @@ export function useTheme(onError?: (error: unknown) => void) {
   );
 
   useEffect(() => {
-    if (fetchError && onError) {
-      onError(fetchError);
+    if (fetchError && onErrorRef.current) {
+      onErrorRef.current(fetchError as Error);
     }
-  }, [fetchError, onError]);
+  }, [fetchError]);
 
   useEffect(() => {
     applyThemeToDom(currentTheme);
@@ -74,8 +79,8 @@ export function useTheme(onError?: (error: unknown) => void) {
       // Don't revert the theme change even if the update fails.
       // Just call the error handler if provided
 
-      if (onError) {
-        onError(error);
+      if (onErrorRef.current) {
+        onErrorRef.current(error as Error);
       }
     },
   });


### PR DESCRIPTION
I have reviewed the entire codebase against the standards mentioned in `AGENTS.md` and applied several refactors to ensure compliance. This includes standardizing the custom hook pattern for data fetching, organizing frontend features into their own directories, and aligning backend command error naming with the required convention. I also moved business logic out of the `get_tips` command and into the library layer. A `RefactoringReport.md` has been created to document these changes. All verification tests and linting checks pass.

---
*PR created automatically by Jules for task [6846554845641597227](https://jules.google.com/task/6846554845641597227) started by @abhi-kr-2100*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the codebase to meet `AGENTS.md` standards. Standardizes hook patterns and error handling, cleans up the directory structure, and aligns backend command error names while moving tip logic to the lib layer.

- **Refactors**
  - Frontend hooks now use a stable error callback pattern (`useRef` + `useEffect`), return full query objects, and expose data aliases; added `useUserId` and updated `PostHogProviderWithIdentifiedUser`.
  - Moved `AboutPage` to `pages/AboutPage/index.tsx` per feature directory convention.
  - Backend command errors renamed to `{FunctionName}Error` (`GetActiveReleaseError`, `FetchReleasesForVariantError`, `FetchReleaseNotesError`); internal notes error renamed to `FetchReleaseNotesInternalError`.
  - Moved OS detection and data-dir resolution from the `get_tips` command into `game_tips/lib.rs`; command now exposes `GetTipsError`.
  - Updated consumers to use error callbacks (e.g., `PlayTime`, game tips, tilesets, soundpacks, mods).
  - Added `RefactoringReport.md` documenting inconsistencies and fixes.

<sup>Written for commit f7d8d245cce6fc81a0f2e7dba31829319b17a02b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

