### PR TITLE
style(ui): centralize page layout and reduce button sizes

### DIFF
--- a/cat-launcher/src/App.tsx
+++ b/cat-launcher/src/App.tsx
@@ -14,7 +14,15 @@ function App() {
               <Route
                 key={route.path}
                 path={route.path}
-                element={route.element}
+                element={
+                  route.layout === "sidebar" ? (
+                    route.element
+                  ) : (
+                    <div className="flex-1 overflow-y-auto p-2 flex flex-col">
+                      {route.element}
+                    </div>
+                  )
+                }
               />
             ))}
           </Routes>

--- a/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
@@ -93,7 +93,7 @@ export default function InteractionButton({
   const button = (
     <div className="flex gap-1 w-full">
       <Button
-        className="grow w-[30%]"
+        className="grow"
         onClick={() =>
           installationStatus === "ReadyToPlay"
             ? play(selectedReleaseId)
@@ -105,16 +105,16 @@ export default function InteractionButton({
       </Button>
       {selectedReleaseId && installationStatus === "ReadyToPlay" && (
         <Button
-          className="grow w-[40%]"
+          className="grow"
           onClick={() => resume(selectedReleaseId)}
           disabled={isActionButtonDisabled || !lastPlayedWorld}
         >
-          Resume Last World
+          Resume
         </Button>
       )}
       {shouldAllowUpgrading && (
         <DropdownButton
-          className="grow w-[30%]"
+          className="grow"
           onClick={() => {
             if (latestReleaseId) {
               setSelectedReleaseId(latestReleaseId);

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -24,6 +24,7 @@ export interface BaseRoute {
   element: ReactNode;
   label: string;
   icon: LucideIcon;
+  layout?: "sidebar" | "default";
 }
 
 export const routes: BaseRoute[] = [
@@ -38,12 +39,14 @@ export const routes: BaseRoute[] = [
     element: <AchievementsPage />,
     label: "Achievements",
     icon: Award,
+    layout: "sidebar",
   },
   {
     path: "/tools/*",
     element: <ToolsPage />,
     label: "Tools",
     icon: Wrench,
+    layout: "sidebar",
   },
   {
     path: "/backups",


### PR DESCRIPTION
Motivation:
- To ensure consistent spacing and scrolling across all pages.
- To provide a more compact and consistent button design throughout the app.

Changes:
- Add a layout property to routes to handle sidebar vs default pages.
- Implement central padding and scrolling in App.tsx.
- Remove redundant layout wrappers from individual page components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized page layout and tightened button sizes to make spacing and scrolling consistent across the app. Non-sidebar pages now share a common wrapper; buttons are smaller and uniform.

- **Refactors**
  - Added `layout` to routes to switch between "sidebar" and "default" pages.
  - Centralized padding and vertical scrolling in App.tsx for non-sidebar routes; removed page-level layout wrappers.
  - Reduced default button sizes in `components/ui/button.tsx`; simplified `InteractionButton` to use flex grow and shortened "Resume Last World" to "Resume".

<sup>Written for commit 27e87c7db3fb87c0dcbbc95f5068d8f127669914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

