### PR TITLE
feat(routes): hide tools route

### DIFF
--- a/cat-launcher/src/components/NavBar.tsx
+++ b/cat-launcher/src/components/NavBar.tsx
@@ -32,10 +32,12 @@ function NavItem({ route }: NavItemProps) {
 }
 
 export default function NavBar() {
+  const visibleRoutes = routes.filter((route) => !route.hidden);
+
   return (
     <nav className="flex shrink-0 items-center justify-between gap-4 border-b bg-background px-4 py-3">
       <div className="flex flex-1 items-center justify-center gap-4">
-        {routes.map((route) => (
+        {visibleRoutes.map((route) => (
           <NavItem key={route.path} route={route} />
         ))}
       </div>

--- a/cat-launcher/src/components/Sidebar.tsx
+++ b/cat-launcher/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ export interface SidebarItem {
   path: string;
   label: string;
   icon: LucideIcon;
+  hidden?: boolean;
 }
 
 export interface SidebarProps {
@@ -91,14 +92,16 @@ export function Sidebar({
 
       <nav className="flex-1 overflow-y-auto p-2">
         <div className="flex flex-col gap-2">
-          {items.map((item) => (
-            <SidebarNavItem
-              key={item.path}
-              item={item}
-              isCollapsed={isCollapsed}
-              basePath={basePath}
-            />
-          ))}
+          {items
+            .filter((item) => !item.hidden)
+            .map((item) => (
+              <SidebarNavItem
+                key={item.path}
+                item={item}
+                isCollapsed={isCollapsed}
+                basePath={basePath}
+              />
+            ))}
         </div>
       </nav>
     </aside>

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -25,6 +25,7 @@ export interface BaseRoute {
   label: string;
   icon: LucideIcon;
   layout?: "sidebar" | "default";
+  hidden?: boolean;
 }
 
 export const routes: BaseRoute[] = [
@@ -47,6 +48,7 @@ export const routes: BaseRoute[] = [
     label: "Tools",
     icon: Wrench,
     layout: "sidebar",
+    hidden: true,
   },
   {
     path: "/backups",


### PR DESCRIPTION
Motivation:
- The tools feature is currently under development and should not be visible to users yet.

Changes:
- Add `hidden` field to `BaseRoute` interface in `routes.tsx`.
- Mark the tools route as `hidden: true`.
- Filter out hidden routes in `NavBar` and `Sidebar` components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Tools route by adding a `hidden` flag to routes and filtering it out in the NavBar and Sidebar. This prevents unfinished features from appearing in the UI.

- **New Features**
  - Added `hidden?: boolean` to `BaseRoute` and `SidebarItem`.
  - Set Tools route to `hidden: true` and filter hidden items in NavBar and Sidebar.

<sup>Written for commit 69c785767d6bea45dc6208ece8b2bd47c438db43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

