### PR TITLE
Implement World Options tool

### DIFF
--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod tilesets;
 mod users;
 mod utils;
 mod variants;
+mod world_options;
 
 use crate::achievements::commands::get_achievements_for_variant;
 use crate::active_release::commands::get_active_release;
@@ -76,6 +77,9 @@ use crate::utils::{
 };
 use crate::variants::commands::get_game_variants_info;
 use crate::variants::commands::update_game_variant_order;
+use crate::world_options::commands::{
+  get_world_options, list_worlds, update_world_options,
+};
 use tauri::{command, AppHandle};
 
 #[command]
@@ -148,6 +152,9 @@ pub fn run() {
       confirm_quit,
       master_reset,
       get_achievements_for_variant,
+      list_worlds,
+      get_world_options,
+      update_world_options,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/cat-launcher/src-tauri/src/world_options/commands.rs
+++ b/cat-launcher/src-tauri/src/world_options/commands.rs
@@ -1,0 +1,69 @@
+use cat_macros::CommandErrorSerialize;
+use strum::IntoStaticStr;
+use tauri::{command, AppHandle, Manager};
+
+use crate::variants::GameVariant;
+use crate::world_options::types::{World, WorldOption};
+use crate::world_options::world_options::{
+  get_world_options as get_world_options_impl,
+  list_worlds as list_worlds_impl,
+  update_world_options as update_world_options_impl,
+  GetWorldOptionsError, ListWorldsError, UpdateWorldOptionsError,
+};
+
+#[derive(
+  thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
+)]
+pub enum WorldOptionsCommandError {
+  #[error("failed to list worlds: {0}")]
+  ListWorlds(#[from] ListWorldsError),
+
+  #[error("failed to get world options: {0}")]
+  GetWorldOptions(#[from] GetWorldOptionsError),
+
+  #[error("failed to update world options: {0}")]
+  UpdateWorldOptions(#[from] UpdateWorldOptionsError),
+
+  #[error("failed to get app directory: {0}")]
+  Tauri(#[from] tauri::Error),
+}
+
+#[command]
+pub async fn list_worlds(
+  variant: GameVariant,
+  app_handle: AppHandle,
+) -> Result<Vec<World>, WorldOptionsCommandError> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  let worlds = list_worlds_impl(&variant, &data_dir).await?;
+  Ok(worlds)
+}
+
+#[command]
+pub async fn get_world_options(
+  variant: GameVariant,
+  world_name: String,
+  app_handle: AppHandle,
+) -> Result<Vec<WorldOption>, WorldOptionsCommandError> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  let options =
+    get_world_options_impl(&variant, &world_name, &data_dir).await?;
+  Ok(options)
+}
+
+#[command]
+pub async fn update_world_options(
+  variant: GameVariant,
+  world_name: String,
+  options: Vec<WorldOption>,
+  app_handle: AppHandle,
+) -> Result<(), WorldOptionsCommandError> {
+  let data_dir = app_handle.path().app_local_data_dir()?;
+  update_world_options_impl(
+    &variant,
+    &world_name,
+    options,
+    &data_dir,
+  )
+  .await?;
+  Ok(())
+}

--- a/cat-launcher/src-tauri/src/world_options/mod.rs
+++ b/cat-launcher/src-tauri/src/world_options/mod.rs
@@ -1,0 +1,4 @@
+pub mod commands;
+pub mod schema;
+pub mod types;
+pub mod world_options;

--- a/cat-launcher/src-tauri/src/world_options/schema.rs
+++ b/cat-launcher/src-tauri/src/world_options/schema.rs
@@ -1,0 +1,256 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OptionType {
+  Boolean,
+  Integer,
+  Float,
+  String,
+  Enum(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptionSchema {
+  pub name: String,
+  pub option_type: OptionType,
+  pub min: Option<f64>,
+  pub max: Option<f64>,
+}
+
+pub fn get_known_options() -> Vec<OptionSchema> {
+  vec![
+    OptionSchema {
+      name: "BLACK_ROAD".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "ETERNAL_SEASON".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "CONSTRUCTION_SCALING".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(1000.0),
+    },
+    OptionSchema {
+      name: "SEASON_LENGTH".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(14.0),
+      max: Some(127.0),
+    },
+    OptionSchema {
+      name: "WORLD_END".to_string(),
+      option_type: OptionType::Enum(vec![
+        "reset".to_string(),
+        "delete".to_string(),
+        "query".to_string(),
+        "keep".to_string(),
+      ]),
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "ITEM_SPAWNRATE".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.01),
+      max: Some(10.0),
+    },
+    OptionSchema {
+      name: "SPAWN_DENSITY".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(50.0),
+    },
+    OptionSchema {
+      name: "EVOLUTION_INVERSE_MULTIPLIER".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(100.0),
+    },
+    OptionSchema {
+      name: "ETERNAL_TIME_OF_DAY".to_string(),
+      option_type: OptionType::Enum(vec![
+        "normal".to_string(),
+        "day".to_string(),
+        "night".to_string(),
+      ]),
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "NPC_SPAWNTIME".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(100.0),
+    },
+    OptionSchema {
+      name: "MONSTER_RESILIENCE".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(1.0),
+      max: Some(1000.0),
+    },
+    OptionSchema {
+      name: "META_PROGRESS".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "MONSTER_SPEED".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(1.0),
+      max: Some(1000.0),
+    },
+    OptionSchema {
+      name: "INITIAL_DAY".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(-1.0),
+      max: Some(999.0),
+    },
+    OptionSchema {
+      name: "VEHICLE_SPAWNRATE".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(5.0),
+    },
+    OptionSchema {
+      name: "CARRION_SPAWNRATE".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(10.0),
+    },
+    OptionSchema {
+      name: "SPECIALS_DENSITY".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.01),
+      max: Some(10.0),
+    },
+    OptionSchema {
+      name: "SPAWN_DELAY".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(9999.0),
+    },
+    OptionSchema {
+      name: "SPAWN_ANIMAL_DENSITY".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(50.0),
+    },
+    OptionSchema {
+      name: "CITY_SIZE".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(16.0),
+    },
+    OptionSchema {
+      name: "MONSTER_UPGRADE_FACTOR".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(100.0),
+    },
+    OptionSchema {
+      name: "STARTING_NPC".to_string(),
+      option_type: OptionType::Enum(vec![
+        "never".to_string(),
+        "always".to_string(),
+        "scenario".to_string(),
+      ]),
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "SPECIALS_SPACING".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(-1.0),
+      max: Some(72.0),
+    },
+    OptionSchema {
+      name: "CITY_SPACING".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(8.0),
+    },
+    OptionSchema {
+      name: "WANDER_SPAWNS".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "VEHICLE_DAMAGE".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(10.0),
+    },
+    OptionSchema {
+      name: "CRAFTING_SPEED_MULT".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(1000.0),
+    },
+    OptionSchema {
+      name: "GROWTH_SCALING".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(1000.0),
+    },
+    OptionSchema {
+      name: "DEFAULT_REGION".to_string(),
+      option_type: OptionType::Enum(vec!["default".to_string()]),
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "RANDOM_NPC".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "INITIAL_TIME".to_string(),
+      option_type: OptionType::Integer,
+      min: Some(0.0),
+      max: Some(23.0),
+    },
+    OptionSchema {
+      name: "VEHICLE_LOCKS".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "RAD_MUTATION".to_string(),
+      option_type: OptionType::Boolean,
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "NPC_DENSITY".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.0),
+      max: Some(100.0),
+    },
+    OptionSchema {
+      name: "CHARACTER_POINT_POOLS".to_string(),
+      option_type: OptionType::Enum(vec![
+        "any".to_string(),
+        "multi_pool".to_string(),
+        "no_freeform".to_string(),
+      ]),
+      min: None,
+      max: None,
+    },
+    OptionSchema {
+      name: "RESTOCK_DELAY_MULT".to_string(),
+      option_type: OptionType::Float,
+      min: Some(0.01),
+      max: Some(10.0),
+    },
+  ]
+}

--- a/cat-launcher/src-tauri/src/world_options/types.rs
+++ b/cat-launcher/src-tauri/src/world_options/types.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct World {
+  pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct WorldOption {
+  pub name: String,
+  pub value: String,
+  pub info: String,
+  pub default: String,
+}

--- a/cat-launcher/src-tauri/src/world_options/world_options.rs
+++ b/cat-launcher/src-tauri/src/world_options/world_options.rs
@@ -1,0 +1,228 @@
+use std::io;
+use std::path::Path;
+use tokio::fs::{read_dir, File};
+use tokio::io::AsyncReadExt;
+
+use crate::filesystem::paths::{
+  get_or_create_user_game_data_dir, GetUserGameDataDirError,
+};
+use crate::variants::GameVariant;
+use crate::world_options::schema::{get_known_options, OptionType};
+use crate::world_options::types::{World, WorldOption};
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListWorldsError {
+  #[error("failed to get user game data directory: {0}")]
+  UserDataDir(#[from] GetUserGameDataDirError),
+
+  #[error("failed to read save directory: {0}")]
+  ReadSaveDir(io::Error),
+}
+
+pub async fn list_worlds(
+  variant: &GameVariant,
+  data_dir: &Path,
+) -> Result<Vec<World>, ListWorldsError> {
+  let user_data_dir =
+    get_or_create_user_game_data_dir(variant, data_dir).await?;
+  let save_dir = user_data_dir.join("save");
+
+  if !save_dir.exists() {
+    return Ok(vec![]);
+  }
+
+  let mut worlds = vec![];
+  let mut entries = read_dir(save_dir)
+    .await
+    .map_err(ListWorldsError::ReadSaveDir)?;
+
+  while let Some(entry) = entries
+    .next_entry()
+    .await
+    .map_err(ListWorldsError::ReadSaveDir)?
+  {
+    if entry
+      .file_type()
+      .await
+      .map_err(ListWorldsError::ReadSaveDir)?
+      .is_dir()
+    {
+      let world_dir = entry.path();
+      if world_dir.join("worldoptions.json").exists() {
+        worlds.push(World {
+          name: entry.file_name().to_string_lossy().into_owned(),
+        });
+      }
+    }
+  }
+
+  Ok(worlds)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetWorldOptionsError {
+  #[error("failed to get user game data directory: {0}")]
+  UserDataDir(#[from] GetUserGameDataDirError),
+
+  #[error("failed to read world options file: {0}")]
+  Read(io::Error),
+
+  #[error("failed to parse world options file: {0}")]
+  Parse(#[from] serde_json::Error),
+}
+
+pub async fn get_world_options(
+  variant: &GameVariant,
+  world_name: &str,
+  data_dir: &Path,
+) -> Result<Vec<WorldOption>, GetWorldOptionsError> {
+  let user_data_dir =
+    get_or_create_user_game_data_dir(variant, data_dir).await?;
+  let options_path = user_data_dir
+    .join("save")
+    .join(world_name)
+    .join("worldoptions.json");
+
+  let mut file = File::open(options_path)
+    .await
+    .map_err(GetWorldOptionsError::Read)?;
+  let mut content = String::new();
+  file
+    .read_to_string(&mut content)
+    .await
+    .map_err(GetWorldOptionsError::Read)?;
+
+  let options: Vec<WorldOption> = serde_json::from_str(&content)?;
+  Ok(options)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UpdateWorldOptionsError {
+  #[error("failed to get user game data directory: {0}")]
+  UserDataDir(#[from] GetUserGameDataDirError),
+
+  #[error("failed to write world options file: {0}")]
+  Write(io::Error),
+
+  #[error("failed to serialize world options: {0}")]
+  Serialize(#[from] serde_json::Error),
+
+  #[error("validation failed for option '{name}': {message}")]
+  Validation { name: String, message: String },
+}
+
+pub async fn update_world_options(
+  variant: &GameVariant,
+  world_name: &str,
+  options: Vec<WorldOption>,
+  data_dir: &Path,
+) -> Result<(), UpdateWorldOptionsError> {
+  // Validate options
+  let known_options = get_known_options();
+  for option in &options {
+    if let Some(schema) =
+      known_options.iter().find(|s| s.name == option.name)
+    {
+      match &schema.option_type {
+        OptionType::Boolean => {
+          if option.value != "true" && option.value != "false" {
+            return Err(UpdateWorldOptionsError::Validation {
+              name: option.name.clone(),
+              message: "must be 'true' or 'false'".to_string(),
+            });
+          }
+        }
+        OptionType::Integer => {
+          let val = option
+            .value
+            .trim_end_matches('%')
+            .parse::<f64>()
+            .map_err(|_| UpdateWorldOptionsError::Validation {
+              name: option.name.clone(),
+              message: "must be an integer".to_string(),
+            })?;
+          if let Some(min) = schema.min {
+            if val < min {
+              return Err(UpdateWorldOptionsError::Validation {
+                name: option.name.clone(),
+                message: format!("must be at least {}", min),
+              });
+            }
+          }
+          if let Some(max) = schema.max {
+            if val > max {
+              return Err(UpdateWorldOptionsError::Validation {
+                name: option.name.clone(),
+                message: format!("must be at most {}", max),
+              });
+            }
+          }
+        }
+        OptionType::Float => {
+          let val = option.value.parse::<f64>().map_err(|_| {
+            UpdateWorldOptionsError::Validation {
+              name: option.name.clone(),
+              message: "must be a float".to_string(),
+            }
+          })?;
+          if let Some(min) = schema.min {
+            if val < min {
+              return Err(UpdateWorldOptionsError::Validation {
+                name: option.name.clone(),
+                message: format!("must be at least {}", min),
+              });
+            }
+          }
+          if let Some(max) = schema.max {
+            if val > max {
+              return Err(UpdateWorldOptionsError::Validation {
+                name: option.name.clone(),
+                message: format!("must be at most {}", max),
+              });
+            }
+          }
+        }
+        OptionType::Enum(values) => {
+          if !values.contains(&option.value) {
+            return Err(UpdateWorldOptionsError::Validation {
+              name: option.name.clone(),
+              message: format!(
+                "must be one of: {}",
+                values.join(", ")
+              ),
+            });
+          }
+        }
+        OptionType::String => {}
+      }
+    } else if option.name.starts_with("SPAWN_RATE_") {
+      // Validate spawn rates as floats
+      let val = option.value.parse::<f64>().map_err(|_| {
+        UpdateWorldOptionsError::Validation {
+          name: option.name.clone(),
+          message: "must be a float".to_string(),
+        }
+      })?;
+      if !(0.0..=20.0).contains(&val) {
+        return Err(UpdateWorldOptionsError::Validation {
+          name: option.name.clone(),
+          message: "must be between 0.0 and 20.0".to_string(),
+        });
+      }
+    }
+  }
+
+  let user_data_dir =
+    get_or_create_user_game_data_dir(variant, data_dir).await?;
+  let options_path = user_data_dir
+    .join("save")
+    .join(world_name)
+    .join("worldoptions.json");
+
+  let content = serde_json::to_string_pretty(&options)?;
+  tokio::fs::write(options_path, content)
+    .await
+    .map_err(UpdateWorldOptionsError::Write)?;
+
+  Ok(())
+}

--- a/cat-launcher/src-tauri/src/world_options/world_options.rs
+++ b/cat-launcher/src-tauri/src/world_options/world_options.rs
@@ -107,7 +107,7 @@ pub enum UpdateWorldOptionsError {
   #[error("failed to serialize world options: {0}")]
   Serialize(#[from] serde_json::Error),
 
-  #[error("validation failed for option '{name}': {message}")]
+  #[error("invalid value for option '{name}': {message}")]
   Validation { name: String, message: String },
 }
 
@@ -128,7 +128,7 @@ pub async fn update_world_options(
           if option.value != "true" && option.value != "false" {
             return Err(UpdateWorldOptionsError::Validation {
               name: option.name.clone(),
-              message: "must be 'true' or 'false'".to_string(),
+              message: "Value must be 'true' or 'false'".to_string(),
             });
           }
         }
@@ -139,13 +139,15 @@ pub async fn update_world_options(
             .parse::<f64>()
             .map_err(|_| UpdateWorldOptionsError::Validation {
               name: option.name.clone(),
-              message: "must be an integer".to_string(),
+              message:
+                "Value must be a valid integer (optionally with %)"
+                  .to_string(),
             })?;
           if let Some(min) = schema.min {
             if val < min {
               return Err(UpdateWorldOptionsError::Validation {
                 name: option.name.clone(),
-                message: format!("must be at least {}", min),
+                message: format!("Value must be at least {}", min),
               });
             }
           }
@@ -153,7 +155,7 @@ pub async fn update_world_options(
             if val > max {
               return Err(UpdateWorldOptionsError::Validation {
                 name: option.name.clone(),
-                message: format!("must be at most {}", max),
+                message: format!("Value must be at most {}", max),
               });
             }
           }
@@ -162,14 +164,14 @@ pub async fn update_world_options(
           let val = option.value.parse::<f64>().map_err(|_| {
             UpdateWorldOptionsError::Validation {
               name: option.name.clone(),
-              message: "must be a float".to_string(),
+              message: "Value must be a valid number".to_string(),
             }
           })?;
           if let Some(min) = schema.min {
             if val < min {
               return Err(UpdateWorldOptionsError::Validation {
                 name: option.name.clone(),
-                message: format!("must be at least {}", min),
+                message: format!("Value must be at least {}", min),
               });
             }
           }
@@ -177,7 +179,7 @@ pub async fn update_world_options(
             if val > max {
               return Err(UpdateWorldOptionsError::Validation {
                 name: option.name.clone(),
-                message: format!("must be at most {}", max),
+                message: format!("Value must be at most {}", max),
               });
             }
           }
@@ -187,7 +189,7 @@ pub async fn update_world_options(
             return Err(UpdateWorldOptionsError::Validation {
               name: option.name.clone(),
               message: format!(
-                "must be one of: {}",
+                "Value must be one of: {}",
                 values.join(", ")
               ),
             });
@@ -200,13 +202,14 @@ pub async fn update_world_options(
       let val = option.value.parse::<f64>().map_err(|_| {
         UpdateWorldOptionsError::Validation {
           name: option.name.clone(),
-          message: "must be a float".to_string(),
+          message: "Spawn rate must be a valid number".to_string(),
         }
       })?;
       if !(0.0..=20.0).contains(&val) {
         return Err(UpdateWorldOptionsError::Validation {
           name: option.name.clone(),
-          message: "must be between 0.0 and 20.0".to_string(),
+          message: "Spawn rate must be between 0.0 and 20.0"
+            .to_string(),
         });
       }
     }

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -24,6 +24,8 @@ import type { ThemePreference } from "@/generated-types/ThemePreference";
 import type { Tileset } from "@/generated-types/Tileset";
 import type { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
 import type { UpdateStatus } from "@/generated-types/UpdateStatus";
+import type { World } from "@/generated-types/World";
+import type { WorldOption } from "@/generated-types/WorldOption";
 
 export async function listenToQuitRequested(
   onQuitRequested: () => void,
@@ -87,6 +89,38 @@ export async function fetchGameVariantsInfo(): Promise<
     "get_game_variants_info",
   );
   return response;
+}
+
+export async function listWorlds(
+  variant: GameVariant,
+): Promise<World[]> {
+  const response = await invoke<World[]>("list_worlds", {
+    variant,
+  });
+  return response;
+}
+
+export async function getWorldOptions(
+  variant: GameVariant,
+  worldName: string,
+): Promise<WorldOption[]> {
+  const response = await invoke<WorldOption[]>("get_world_options", {
+    variant,
+    worldName,
+  });
+  return response;
+}
+
+export async function updateWorldOptions(
+  variant: GameVariant,
+  worldName: string,
+  options: WorldOption[],
+): Promise<void> {
+  await invoke("update_world_options", {
+    variant,
+    worldName,
+    options,
+  });
 }
 
 export async function deleteBackupById(id: bigint): Promise<void> {

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -77,4 +77,9 @@ export const queryKeys = {
 
   achievements: (variant: GameVariant) =>
     ["achievements", variant] as const,
+
+  worlds: (variant: GameVariant) => ["worlds", variant] as const,
+
+  worldOptions: (variant: GameVariant, worldName: string) =>
+    ["world_options", variant, worldName] as const,
 };

--- a/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
@@ -1,14 +1,8 @@
 import { useMemo, useState } from "react";
 import { Controller, useFieldArray } from "react-hook-form";
-import { AlertTriangle, Save, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -18,6 +12,7 @@ import { toastCL } from "@/lib/utils";
 import { useGameVariants } from "@/hooks/useGameVariants";
 import { useWorlds } from "../hooks/useWorlds";
 import { useWorldOptionsForm } from "../hooks/useWorldOptionsForm";
+import { WorldOptionsFooter } from "./WorldOptionsFooter";
 
 type OptionType = "Boolean" | "Integer" | "Float" | "String" | "Enum";
 
@@ -114,6 +109,62 @@ const SCHEMA: OptionSchema[] = [
   { name: "RESTOCK_DELAY_MULT", type: "Float", min: 0.01, max: 10.0 },
 ];
 
+const OPTION_NAME_MAPPING: Record<string, string> = {
+  BLACK_ROAD: "Black Road",
+  ETERNAL_SEASON: "Eternal Season",
+  CONSTRUCTION_SCALING: "Construction Scaling",
+  SEASON_LENGTH: "Season Length",
+  WORLD_END: "World End Handling",
+  ITEM_SPAWNRATE: "Item Spawn Rate",
+  SPAWN_DENSITY: "Monster Spawn Density",
+  EVOLUTION_INVERSE_MULTIPLIER: "Monster Evolution Multiplier",
+  ETERNAL_TIME_OF_DAY: "Eternal Time of Day",
+  NPC_SPAWNTIME: "NPC Spawn Delay",
+  MONSTER_RESILIENCE: "Monster Resilience",
+  META_PROGRESS: "Meta Progression",
+  MONSTER_SPEED: "Monster Speed",
+  INITIAL_DAY: "Initial Day",
+  VEHICLE_SPAWNRATE: "Vehicle Spawn Density",
+  CARRION_SPAWNRATE: "Carrion Spawn Density",
+  SPECIALS_DENSITY: "Overmap Specials Density",
+  SPAWN_DELAY: "Spawn Delay",
+  SPAWN_ANIMAL_DENSITY: "Animal Spawn Density",
+  CITY_SIZE: "City Size",
+  MONSTER_UPGRADE_FACTOR: "Monster Upgrade Factor",
+  STARTING_NPC: "Starting NPC Spawn",
+  SPECIALS_SPACING: "Overmap Specials Spacing",
+  CITY_SPACING: "City Spacing",
+  WANDER_SPAWNS: "Wander Spawns (Hordes)",
+  VEHICLE_DAMAGE: "Vehicle Damage Multiplier",
+  CRAFTING_SPEED_MULT: "Crafting Speed Multiplier",
+  GROWTH_SCALING: "Crop Growth Scaling",
+  DEFAULT_REGION: "Default Region",
+  RANDOM_NPC: "Random NPC Spawns",
+  INITIAL_TIME: "Initial Time of Day",
+  VEHICLE_LOCKS: "Vehicle Door Locks",
+  RAD_MUTATION: "Radiation Mutations",
+  NPC_DENSITY: "Dynamic NPC Density",
+  CHARACTER_POINT_POOLS: "Character Point Pools",
+  RESTOCK_DELAY_MULT: "Merchant Restock Delay",
+};
+
+const ENUM_VALUE_MAPPING: Record<string, string> = {
+  reset: "Reset World",
+  delete: "Delete World",
+  query: "Query User",
+  keep: "Keep World",
+  never: "Never",
+  always: "Always",
+  scenario: "Based on Scenario",
+  normal: "Normal Cycle",
+  day: "Eternal Day",
+  night: "Eternal Night",
+  any: "Any Pool",
+  multi_pool: "Multiple Pools",
+  no_freeform: "No Freeform",
+  default: "Default Region",
+};
+
 export default function WorldOptions() {
   const [selectedVariant, setSelectedVariant] =
     useState<string>("DarkDaysAhead");
@@ -156,8 +207,25 @@ export default function WorldOptions() {
 
   const isDirty = form.formState.isDirty;
 
+  const getFriendlyName = (name: string) => {
+    if (OPTION_NAME_MAPPING[name]) {
+      return OPTION_NAME_MAPPING[name];
+    }
+    if (name.startsWith("SPAWN_RATE_")) {
+      const category = name
+        .replace("SPAWN_RATE_", "")
+        .replace(/_/g, " ");
+      return `Spawn Rate: ${category.charAt(0).toUpperCase() + category.slice(1)}`;
+    }
+    return name;
+  };
+
+  const getFriendlyEnumValue = (value: string) => {
+    return ENUM_VALUE_MAPPING[value] || value;
+  };
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-24">
       <div className="flex flex-col gap-4 md:flex-row md:items-end">
         <div className="w-full md:w-64">
           <Label className="mb-2 block text-sm font-medium">
@@ -191,31 +259,7 @@ export default function WorldOptions() {
 
       {selectedWorldName ? (
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-            <CardTitle className="text-xl font-bold">
-              Options for {selectedWorldName}
-            </CardTitle>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={cancel}
-                disabled={!isDirty || isUpdating}
-              >
-                <X className="mr-2 h-4 w-4" />
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                onClick={apply}
-                disabled={!isDirty || isUpdating}
-              >
-                <Save className="mr-2 h-4 w-4" />
-                {isUpdating ? "Saving..." : "Save"}
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
+          <CardContent className="pt-6">
             {isLoading ? (
               <div className="py-8 text-center text-muted-foreground">
                 Loading options...
@@ -250,9 +294,16 @@ export default function WorldOptions() {
                       className="space-y-2 rounded-lg border p-4 shadow-sm"
                     >
                       <div className="flex items-start justify-between">
-                        <Label className="text-base font-semibold">
-                          {option.name}
-                        </Label>
+                        <div className="flex flex-col">
+                          <Label className="text-base font-semibold">
+                            {getFriendlyName(option.name)}
+                          </Label>
+                          {isKnown && (
+                            <span className="text-[10px] text-muted-foreground font-mono uppercase">
+                              {option.name}
+                            </span>
+                          )}
+                        </div>
                         {!isKnown && (
                           <div
                             className="flex items-center gap-1 text-xs text-amber-500"
@@ -308,7 +359,7 @@ export default function WorldOptions() {
                                 items={
                                   schema?.values?.map((v) => ({
                                     value: v,
-                                    label: v,
+                                    label: getFriendlyEnumValue(v),
                                   })) ?? []
                                 }
                                 value={field.value}
@@ -368,11 +419,7 @@ export default function WorldOptions() {
                                 },
                               },
                             )}
-                            type={
-                              type === "Integer" || type === "Float"
-                                ? "text"
-                                : "text"
-                            }
+                            type="text"
                             placeholder="Value"
                           />
                         )}
@@ -403,6 +450,15 @@ export default function WorldOptions() {
         <div className="rounded-lg border border-dashed p-12 text-center text-muted-foreground">
           Select a variant and a world to manage its options.
         </div>
+      )}
+
+      {selectedWorldName && (
+        <WorldOptionsFooter
+          isDirty={isDirty}
+          isUpdating={isUpdating}
+          apply={apply}
+          cancel={cancel}
+        />
       )}
     </div>
   );

--- a/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
@@ -1,10 +1,409 @@
+import { useMemo, useState } from "react";
+import { Controller, useFieldArray } from "react-hook-form";
+import { AlertTriangle, Save, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { VirtualizedCombobox } from "@/components/virtualized-combobox";
+import { GameVariant } from "@/generated-types/GameVariant";
+import { toastCL } from "@/lib/utils";
+import { useGameVariants } from "@/hooks/useGameVariants";
+import { useWorlds } from "../hooks/useWorlds";
+import { useWorldOptionsForm } from "../hooks/useWorldOptionsForm";
+
+type OptionType = "Boolean" | "Integer" | "Float" | "String" | "Enum";
+
+interface OptionSchema {
+  name: string;
+  type: OptionType;
+  min?: number;
+  max?: number;
+  values?: string[];
+}
+
+const SCHEMA: OptionSchema[] = [
+  { name: "BLACK_ROAD", type: "Boolean" },
+  { name: "ETERNAL_SEASON", type: "Boolean" },
+  {
+    name: "CONSTRUCTION_SCALING",
+    type: "Integer",
+    min: 0,
+    max: 1000,
+  },
+  { name: "SEASON_LENGTH", type: "Integer", min: 14, max: 127 },
+  {
+    name: "WORLD_END",
+    type: "Enum",
+    values: ["reset", "delete", "query", "keep"],
+  },
+  { name: "ITEM_SPAWNRATE", type: "Float", min: 0.01, max: 10.0 },
+  { name: "SPAWN_DENSITY", type: "Float", min: 0.0, max: 50.0 },
+  {
+    name: "EVOLUTION_INVERSE_MULTIPLIER",
+    type: "Float",
+    min: 0.0,
+    max: 100.0,
+  },
+  {
+    name: "ETERNAL_TIME_OF_DAY",
+    type: "Enum",
+    values: ["normal", "day", "night"],
+  },
+  { name: "NPC_SPAWNTIME", type: "Float", min: 0.0, max: 100.0 },
+  {
+    name: "MONSTER_RESILIENCE",
+    type: "Integer",
+    min: 1,
+    max: 1000,
+  },
+  { name: "META_PROGRESS", type: "Boolean" },
+  { name: "MONSTER_SPEED", type: "Integer", min: 1, max: 1000 },
+  { name: "INITIAL_DAY", type: "Integer", min: -1, max: 999 },
+  { name: "VEHICLE_SPAWNRATE", type: "Float", min: 0.0, max: 5.0 },
+  { name: "CARRION_SPAWNRATE", type: "Float", min: 0.0, max: 10.0 },
+  { name: "SPECIALS_DENSITY", type: "Float", min: 0.01, max: 10.0 },
+  { name: "SPAWN_DELAY", type: "Integer", min: 0, max: 9999 },
+  {
+    name: "SPAWN_ANIMAL_DENSITY",
+    type: "Float",
+    min: 0.0,
+    max: 50.0,
+  },
+  { name: "CITY_SIZE", type: "Integer", min: 0, max: 16 },
+  {
+    name: "MONSTER_UPGRADE_FACTOR",
+    type: "Float",
+    min: 0.0,
+    max: 100.0,
+  },
+  {
+    name: "STARTING_NPC",
+    type: "Enum",
+    values: ["never", "always", "scenario"],
+  },
+  { name: "SPECIALS_SPACING", type: "Integer", min: -1, max: 72 },
+  { name: "CITY_SPACING", type: "Integer", min: 0, max: 8 },
+  { name: "WANDER_SPAWNS", type: "Boolean" },
+  { name: "VEHICLE_DAMAGE", type: "Float", min: 0.0, max: 10.0 },
+  {
+    name: "CRAFTING_SPEED_MULT",
+    type: "Integer",
+    min: 0,
+    max: 1000,
+  },
+  { name: "GROWTH_SCALING", type: "Integer", min: 0, max: 1000 },
+  { name: "DEFAULT_REGION", type: "Enum", values: ["default"] },
+  { name: "RANDOM_NPC", type: "Boolean" },
+  { name: "INITIAL_TIME", type: "Integer", min: 0, max: 23 },
+  { name: "VEHICLE_LOCKS", type: "Boolean" },
+  { name: "RAD_MUTATION", type: "Boolean" },
+  { name: "NPC_DENSITY", type: "Float", min: 0.0, max: 100.0 },
+  {
+    name: "CHARACTER_POINT_POOLS",
+    type: "Enum",
+    values: ["any", "multi_pool", "no_freeform"],
+  },
+  { name: "RESTOCK_DELAY_MULT", type: "Float", min: 0.01, max: 10.0 },
+];
+
 export default function WorldOptions() {
+  const [selectedVariant, setSelectedVariant] =
+    useState<string>("DarkDaysAhead");
+  const [selectedWorldName, setSelectedWorldName] =
+    useState<string>("");
+
+  const { gameVariants } = useGameVariants();
+  const { data: worlds } = useWorlds(selectedVariant as GameVariant);
+
+  const { form, isLoading, isUpdating, apply, cancel } =
+    useWorldOptionsForm({
+      variant: selectedVariant as GameVariant,
+      worldName: selectedWorldName,
+      onWorldOptionsError: (error) =>
+        toastCL("error", "Failed to load world options.", error),
+      onUpdateError: (error) =>
+        toastCL("error", "Failed to update world options.", error),
+      onUpdateSuccess: () =>
+        toastCL("success", "World options updated successfully."),
+    });
+
+  const { fields } = useFieldArray({
+    control: form.control,
+    name: "options",
+  });
+
+  const variantOptions = useMemo(() => {
+    return (gameVariants ?? []).map((v) => ({
+      value: v.id,
+      label: v.name,
+    }));
+  }, [gameVariants]);
+
+  const worldOptions = useMemo(() => {
+    return (worlds ?? []).map((w) => ({
+      value: w.name,
+      label: w.name,
+    }));
+  }, [worlds]);
+
+  const isDirty = form.formState.isDirty;
+
   return (
-    <div className="space-y-4">
-      <h2 className="text-2xl font-bold">World Options</h2>
-      <div className="rounded-lg border border-dashed p-12 text-center text-muted-foreground">
-        Coming soon: World Options Configuration
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="w-full md:w-64">
+          <Label className="mb-2 block text-sm font-medium">
+            Variant
+          </Label>
+          <VirtualizedCombobox
+            items={variantOptions}
+            value={selectedVariant}
+            onChange={(v: string) => {
+              setSelectedVariant(v);
+              setSelectedWorldName("");
+            }}
+            placeholder="Select a variant"
+          />
+        </div>
+        <div className="w-full md:w-64">
+          <Label className="mb-2 block text-sm font-medium">
+            World
+          </Label>
+          <VirtualizedCombobox
+            items={worldOptions}
+            value={selectedWorldName}
+            onChange={setSelectedWorldName}
+            placeholder={
+              worlds?.length ? "Select a world" : "No worlds found"
+            }
+            disabled={!worlds?.length}
+          />
+        </div>
       </div>
+
+      {selectedWorldName ? (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+            <CardTitle className="text-xl font-bold">
+              Options for {selectedWorldName}
+            </CardTitle>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={cancel}
+                disabled={!isDirty || isUpdating}
+              >
+                <X className="mr-2 h-4 w-4" />
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={apply}
+                disabled={!isDirty || isUpdating}
+              >
+                <Save className="mr-2 h-4 w-4" />
+                {isUpdating ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="py-8 text-center text-muted-foreground">
+                Loading options...
+              </div>
+            ) : fields.length === 0 ? (
+              <div className="py-8 text-center text-muted-foreground">
+                No options found in worldoptions.json
+              </div>
+            ) : (
+              <div className="grid gap-6 md:grid-cols-2">
+                {fields.map((field, index) => {
+                  const option = field;
+                  const schema = SCHEMA.find(
+                    (s) => s.name === option.name,
+                  );
+                  const isSpawnRate =
+                    option.name.startsWith("SPAWN_RATE_");
+                  const isKnown = !!schema || isSpawnRate;
+
+                  const type = schema
+                    ? schema.type
+                    : isSpawnRate
+                      ? "Float"
+                      : option.value === "true" ||
+                          option.value === "false"
+                        ? "Boolean"
+                        : "String";
+
+                  return (
+                    <div
+                      key={field.id}
+                      className="space-y-2 rounded-lg border p-4 shadow-sm"
+                    >
+                      <div className="flex items-start justify-between">
+                        <Label className="text-base font-semibold">
+                          {option.name}
+                        </Label>
+                        {!isKnown && (
+                          <div
+                            className="flex items-center gap-1 text-xs text-amber-500"
+                            title="Unknown option"
+                          >
+                            <AlertTriangle className="h-3 w-3" />
+                            <span>Unknown</span>
+                          </div>
+                        )}
+                      </div>
+
+                      {option.info && (
+                        <p className="text-sm text-muted-foreground">
+                          {option.info}
+                        </p>
+                      )}
+
+                      <div className="pt-2">
+                        {type === "Boolean" ? (
+                          <div className="flex items-center space-x-2">
+                            <Controller
+                              control={form.control}
+                              name={`options.${index}.value`}
+                              render={({ field }) => (
+                                <Checkbox
+                                  id={`option-${option.name}`}
+                                  checked={field.value === "true"}
+                                  onCheckedChange={(checked) =>
+                                    field.onChange(
+                                      checked ? "true" : "false",
+                                    )
+                                  }
+                                />
+                              )}
+                            />
+                            <Label
+                              htmlFor={`option-${option.name}`}
+                              className="text-sm font-normal cursor-pointer"
+                            >
+                              {form.getValues(
+                                `options.${index}.value`,
+                              ) === "true"
+                                ? "Enabled"
+                                : "Disabled"}
+                            </Label>
+                          </div>
+                        ) : type === "Enum" ? (
+                          <Controller
+                            control={form.control}
+                            name={`options.${index}.value`}
+                            render={({ field }) => (
+                              <VirtualizedCombobox
+                                items={
+                                  schema?.values?.map((v) => ({
+                                    value: v,
+                                    label: v,
+                                  })) ?? []
+                                }
+                                value={field.value}
+                                onChange={field.onChange}
+                              />
+                            )}
+                          />
+                        ) : (
+                          <Input
+                            {...form.register(
+                              `options.${index}.value`,
+                              {
+                                validate: (value) => {
+                                  if (type === "Integer") {
+                                    const cleanValue = value.endsWith(
+                                      "%",
+                                    )
+                                      ? value.slice(0, -1)
+                                      : value;
+                                    const parsed =
+                                      parseInt(cleanValue);
+                                    if (isNaN(parsed))
+                                      return "Must be an integer";
+                                    if (
+                                      schema?.min !== undefined &&
+                                      parsed < schema.min
+                                    )
+                                      return `Must be at least ${schema.min}`;
+                                    if (
+                                      schema?.max !== undefined &&
+                                      parsed > schema.max
+                                    )
+                                      return `Must be at most ${schema.max}`;
+                                  }
+                                  if (type === "Float") {
+                                    const parsed = parseFloat(value);
+                                    if (isNaN(parsed))
+                                      return "Must be a number";
+                                    const min =
+                                      schema?.min ??
+                                      (isSpawnRate ? 0 : undefined);
+                                    const max =
+                                      schema?.max ??
+                                      (isSpawnRate ? 20 : undefined);
+                                    if (
+                                      min !== undefined &&
+                                      parsed < min
+                                    )
+                                      return `Must be at least ${min}`;
+                                    if (
+                                      max !== undefined &&
+                                      parsed > max
+                                    )
+                                      return `Must be at most ${max}`;
+                                  }
+                                  return true;
+                                },
+                              },
+                            )}
+                            type={
+                              type === "Integer" || type === "Float"
+                                ? "text"
+                                : "text"
+                            }
+                            placeholder="Value"
+                          />
+                        )}
+                        {form.formState.errors.options?.[index]
+                          ?.value && (
+                          <p className="mt-1 text-xs text-destructive">
+                            {
+                              form.formState.errors.options[index]
+                                .value.message
+                            }
+                          </p>
+                        )}
+                      </div>
+
+                      {option.default && (
+                        <p className="mt-1 text-xs text-muted-foreground italic">
+                          {option.default}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="rounded-lg border border-dashed p-12 text-center text-muted-foreground">
+          Select a variant and a world to manage its options.
+        </div>
+      )}
     </div>
   );
 }

--- a/cat-launcher/src/pages/ToolsPage/components/WorldOptionsFooter.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/WorldOptionsFooter.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/button";
+
+interface WorldOptionsFooterProps {
+  isDirty: boolean;
+  isUpdating: boolean;
+  apply: () => void;
+  cancel: () => void;
+}
+
+export function WorldOptionsFooter({
+  isDirty,
+  isUpdating,
+  apply,
+  cancel,
+}: WorldOptionsFooterProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border overflow-x-auto z-10">
+      <div className="container mx-auto max-w-2xl px-4 py-4">
+        <div className="flex justify-end gap-4">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={cancel}
+            disabled={!isDirty || isUpdating}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={apply}
+            disabled={!isDirty || isUpdating}
+          >
+            {isUpdating ? "Applying..." : "Apply"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cat-launcher/src/pages/ToolsPage/hooks/useWorldOptionsForm.ts
+++ b/cat-launcher/src/pages/ToolsPage/hooks/useWorldOptionsForm.ts
@@ -59,6 +59,7 @@ export function useWorldOptionsForm({
   }, [error]);
 
   const form = useForm<WorldOptionsFormData>({
+    mode: "onChange",
     defaultValues: {
       options: options ?? [],
     },

--- a/cat-launcher/src/pages/ToolsPage/hooks/useWorldOptionsForm.ts
+++ b/cat-launcher/src/pages/ToolsPage/hooks/useWorldOptionsForm.ts
@@ -1,0 +1,105 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import type { WorldOption } from "@/generated-types/WorldOption";
+import { getWorldOptions, updateWorldOptions } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export interface UseWorldOptionsFormProps {
+  variant: GameVariant;
+  worldName: string;
+  onWorldOptionsError?: (error: Error) => void;
+  onUpdateError?: (error: Error) => void;
+  onUpdateSuccess?: () => void;
+}
+
+export interface WorldOptionsFormData {
+  options: WorldOption[];
+}
+
+export function useWorldOptionsForm({
+  variant,
+  worldName,
+  onWorldOptionsError,
+  onUpdateError,
+  onUpdateSuccess,
+}: UseWorldOptionsFormProps) {
+  const queryClient = useQueryClient();
+
+  const onWorldOptionsErrorRef = useRef(onWorldOptionsError);
+  const onUpdateErrorRef = useRef(onUpdateError);
+  const onUpdateSuccessRef = useRef(onUpdateSuccess);
+
+  useEffect(() => {
+    onWorldOptionsErrorRef.current = onWorldOptionsError;
+    onUpdateErrorRef.current = onUpdateError;
+    onUpdateSuccessRef.current = onUpdateSuccess;
+  }, [onWorldOptionsError, onUpdateError, onUpdateSuccess]);
+
+  const {
+    data: options,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.worldOptions(variant, worldName),
+    queryFn: () => getWorldOptions(variant, worldName),
+    enabled: !!worldName,
+  });
+
+  useEffect(() => {
+    if (error && onWorldOptionsErrorRef.current) {
+      onWorldOptionsErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  const form = useForm<WorldOptionsFormData>({
+    defaultValues: {
+      options: options ?? [],
+    },
+  });
+
+  useEffect(() => {
+    if (options) {
+      form.reset({ options });
+    }
+  }, [options, form]);
+
+  const updateMutation = useMutation({
+    mutationFn: (data: WorldOptionsFormData) =>
+      updateWorldOptions(variant, worldName, data.options),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.worldOptions(variant, worldName),
+      });
+      form.reset(variables);
+      onUpdateSuccessRef.current?.();
+    },
+    onError: (error) => {
+      onUpdateErrorRef.current?.(error as Error);
+    },
+  });
+
+  const apply = form.handleSubmit((data) => {
+    updateMutation.mutate(data);
+  });
+
+  const cancel = () => {
+    if (options) {
+      form.reset({ options });
+    }
+  };
+
+  return {
+    form,
+    isLoading,
+    isUpdating: updateMutation.isPending,
+    apply,
+    cancel,
+  };
+}

--- a/cat-launcher/src/pages/ToolsPage/hooks/useWorlds.ts
+++ b/cat-launcher/src/pages/ToolsPage/hooks/useWorlds.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import type { GameVariant } from "@/generated-types/GameVariant";
+import { listWorlds } from "@/lib/commands";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useWorlds(
+  variant: GameVariant,
+  onWorldsLoadError?: (error: Error) => void,
+) {
+  const onWorldsLoadErrorRef = useRef(onWorldsLoadError);
+
+  useEffect(() => {
+    onWorldsLoadErrorRef.current = onWorldsLoadError;
+  }, [onWorldsLoadError]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.worlds(variant),
+    queryFn: () => listWorlds(variant),
+  });
+
+  useEffect(() => {
+    if (error && onWorldsLoadErrorRef.current) {
+      onWorldsLoadErrorRef.current(error as Error);
+    }
+  }, [error]);
+
+  return { data, isLoading, error };
+}


### PR DESCRIPTION
This change implements the World Options tool, allowing users to select a game variant and a specific world, then edit its configuration options through a validated form. It includes both backend and frontend changes to handle world discovery, schema-based validation, and data persistence.

---
*PR created automatically by Jules for task [18141975157115973776](https://jules.google.com/task/18141975157115973776) started by @abhi-kr-2100*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the World Options tool so users can pick a game variant and world, edit validated options, and save them safely. Adds inline validation, friendlier labels, and an Apply/Cancel footer for a smoother UX.

- **New Features**
  - Backend: added a `world_options` module for save/ world discovery, reading/writing worldoptions.json, and schema-based validation (Boolean, Integer, Float, Enum, plus bounds for `SPAWN_RATE_*`); exposed Tauri commands `list_worlds`, `get_world_options`, and `update_world_options`; improved validation error messages.
  - Frontend: built the World Options panel with variant/world pickers, a dynamic form with real-time inline validation, unknown option warnings, friendly option/enum labels, and a persistent Apply/Cancel footer; added `listWorlds`, `getWorldOptions`, `updateWorldOptions` in `lib/commands.ts`, query keys for worlds/options, and `useWorlds`/`useWorldOptionsForm` hooks.

<sup>Written for commit 4e05759aa026e3a6cda937dfa7dc3da3b07f32fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

