### PR TITLE
chore(nix): add development shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
 dotenv
+
+if has nix; then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.direnv/
 
 # Generated types
 cat-launcher/src/generated-types/*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,122 @@
+{
+  description = "Development environment for CatLauncher";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = pkgs.lib;
+
+          nodejs =
+            if builtins.hasAttr "nodejs_24" pkgs then
+              pkgs.nodejs_24
+            else
+              pkgs.nodejs;
+
+          pnpm =
+            if builtins.hasAttr "pnpm_10" pkgs then
+              pkgs.pnpm_10
+            else
+              pkgs.pnpm;
+
+          openssl = pkgs.openssl;
+
+          webkitgtk =
+            if builtins.hasAttr "webkitgtk_4_1" pkgs then
+              pkgs.webkitgtk_4_1
+            else
+              pkgs.webkitgtk;
+
+          appIndicatorLibs =
+            lib.optionals (builtins.hasAttr "libayatana-appindicator" pkgs) [
+              pkgs.libayatana-appindicator
+            ]
+            ++ lib.optionals (builtins.hasAttr "libappindicator-gtk3" pkgs) [
+              pkgs."libappindicator-gtk3"
+            ];
+
+          tauriNativeLibs =
+            (with pkgs; [
+              at-spi2-atk
+              atk
+              cairo
+              dbus
+              gdk-pixbuf
+              glib
+              glib-networking
+              gsettings-desktop-schemas
+              gtk3
+              harfbuzz
+              hicolor-icon-theme
+              libdrm
+              libepoxy
+              libglvnd
+              librsvg
+              libsoup_3
+              libxkbcommon
+              openssl
+              pango
+              shared-mime-info
+              wayland
+              webkitgtk
+              xdotool
+              libX11
+              libXcursor
+              libXi
+              libXrandr
+            ])
+            ++ appIndicatorLibs;
+
+          xdgDataDirs = lib.concatStringsSep ":" [
+            "${pkgs.gsettings-desktop-schemas}/share"
+            "${pkgs.gtk3}/share"
+            "${pkgs.hicolor-icon-theme}/share"
+            "${pkgs.shared-mime-info}/share"
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages =
+              (with pkgs; [
+                cargo
+                clippy
+                curl
+                file
+                gcc
+                gnumake
+                nodejs
+                pkg-config
+                pnpm
+                rustc
+                rustfmt
+                uv
+                wget
+              ])
+              ++ tauriNativeLibs;
+
+            env = {
+              GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
+              LD_LIBRARY_PATH = lib.makeLibraryPath tauriNativeLibs;
+              WEBKIT_DISABLE_COMPOSITING_MODE = "1";
+              XDG_DATA_DIRS = xdgDataDirs;
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Nix flake dev shell to standardize Linux development for CatLauncher. It provides the Rust toolchain, Node (prefers 24), `pnpm` (prefers 10), and Tauri GTK/WebKit libs, with `direnv` integration.

- **Migration**
  - Install Nix and `direnv`, then run `direnv allow` (or `nix develop`).
  - `.direnv/` is now ignored by Git.

<sup>Written for commit f7672c3a201482ad29ec63573a23412b5b7a61bf. Summary will update on new commits. <a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

