### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ CatLauncher is 100% open-source and the .dmg is built directly from the source c
 
 Downloading the AppImage is the easiest way to install CatLauncher and keep it automatically up-to-date. However, the AppImage may not work on all Linux distros. It's been tested to work on Ubuntu 24.04.
 
-To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.14.0_amd64.AppImage`, and then run it like you would any other executable.
+To use the AppImage, download it, and make it executable by running `chmod a+x cat-launcher_0.15.0_amd64.AppImage`, and then run it like you would any other executable.
 
 If you encounter issues with the AppImage, you can try installing CatLauncher using the .deb or the .rpm package. It would also help if you can open an issue on GitHub with details of your distro.
 

--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cat-launcher",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "packageManager": "pnpm@10.15.1",
   "type": "module",
   "scripts": {

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "cat-macros",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-launcher"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cat-launcher",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "com.munetmo.cat-launcher",
   "build": {
     "beforeDevCommand": "cargo test --manifest-path ./src-tauri/Cargo.toml && pnpm dev",


### PR DESCRIPTION
Motivation:
- Release new version.

Changes:
- Update version in package.json.
- Update version in Cargo.toml.
- Update version in Cargo.lock.
- Update version in tauri.conf.json.
- Update version in README.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to 0.15.0 across configs and docs to cut the 0.15.0 release. Updated version fields in `cat-launcher/package.json`, `cat-launcher/src-tauri/Cargo.toml`, `cat-launcher/src-tauri/Cargo.lock`, `cat-launcher/src-tauri/tauri.conf.json`, and the AppImage command in `README.md`.

<sup>Written for commit 69e387709beeaf75f667a539bc8bafc305a77f12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

