### PR TITLE
chore(rust): upgrade to Rust 2024 edition and update dependencies

### DIFF
--- a/cat-launcher/cat-macros/Cargo.lock
+++ b/cat-launcher/cat-macros/Cargo.lock
@@ -13,18 +13,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -71,6 +71,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/cat-launcher/cat-macros/Cargo.toml
+++ b/cat-launcher/cat-macros/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "cat-macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.39", features = ["full"] }
-quote = "1.0.33"
-serde = "1.0.193"
+syn = { version = "2.0.117", features = ["full"] }
+quote = "1.0.45"
+serde = "1.0.228"

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "cat-launcher"
 version = "0.15.0"
 description = "A Tauri App"
 authors = ["you"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cat-launcher/src-tauri/src/achievements/achievements.rs
+++ b/cat-launcher/src-tauri/src/achievements/achievements.rs
@@ -5,10 +5,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::active_release::repository::ActiveReleaseRepository;
 use crate::filesystem::paths::{
-  get_game_resources_dir, get_or_create_user_game_data_dir,
   GetGameExecutableDirError, GetUserGameDataDirError,
+  get_game_resources_dir, get_or_create_user_game_data_dir,
 };
-use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::infra::utils::{OSNotSupportedError, get_os_enum};
 use crate::variants::GameVariant;
 
 use super::types::{Achievement, CharacterAchievements};

--- a/cat-launcher/src-tauri/src/achievements/commands.rs
+++ b/cat-launcher/src-tauri/src/achievements/commands.rs
@@ -5,7 +5,7 @@ use tauri::{AppHandle, Manager, State};
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 use crate::variants::GameVariant;
 
-use super::achievements::{get_achievements, GetAchievementsError};
+use super::achievements::{GetAchievementsError, get_achievements};
 use super::types::CharacterAchievements;
 
 #[derive(

--- a/cat-launcher/src-tauri/src/active_release/commands.rs
+++ b/cat-launcher/src-tauri/src/active_release/commands.rs
@@ -1,5 +1,5 @@
 use strum::IntoStaticStr;
-use tauri::{command, State};
+use tauri::{State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/backups/backups.rs
+++ b/cat-launcher/src-tauri/src/backups/backups.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
 use crate::filesystem::paths::{
+  GetAutomaticBackupArchivePathError, GetUserGameDataDirError,
   get_or_create_automatic_backup_archive_filepath,
   get_or_create_user_game_data_dir,
-  GetAutomaticBackupArchivePathError, GetUserGameDataDirError,
 };
-use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::archive::{ExtractionError, extract_archive};
 use crate::infra::utils::OS;
 use crate::launch_game::repository::{
   BackupRepository, BackupRepositoryError,

--- a/cat-launcher/src-tauri/src/backups/commands.rs
+++ b/cat-launcher/src-tauri/src/backups/commands.rs
@@ -4,12 +4,12 @@ use tauri::{Manager, State};
 use cat_macros::CommandErrorSerialize;
 
 use crate::backups::backups::{
-  delete_backup, list_backups, restore_backup, DeleteBackupError,
-  ListBackupsError, RestoreBackupError,
+  DeleteBackupError, ListBackupsError, RestoreBackupError,
+  delete_backup, list_backups, restore_backup,
 };
-use crate::infra::utils::{get_os_enum, OSNotSupportedError};
-use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
+use crate::infra::utils::{OSNotSupportedError, get_os_enum};
 use crate::launch_game::repository::BackupEntry;
+use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
 use crate::variants::GameVariant;
 
 #[derive(

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -2,7 +2,7 @@ use std::env::consts::{ARCH, OS};
 
 use reqwest::Client;
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 
@@ -11,8 +11,8 @@ use crate::fetch_releases::fetch_releases::{
 };
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::infra::utils::{
-  get_arch_enum, get_os_enum, ArchNotSupportedError,
-  OSNotSupportedError,
+  ArchNotSupportedError, OSNotSupportedError, get_arch_enum,
+  get_os_enum,
 };
 use crate::variants::GameVariant;
 

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -13,10 +13,10 @@ use crate::fetch_releases::utils::{
 };
 use crate::game_release::game_release::GameRelease;
 use crate::infra::github::utils::{
-  fetch_github_release_by_tag, fetch_github_releases,
   FetchGitHubReleaseByTagError, GitHubReleaseFetchError,
+  fetch_github_release_by_tag, fetch_github_releases,
 };
-use crate::infra::utils::{get_github_repo_for_variant, Arch, OS};
+use crate::infra::utils::{Arch, OS, get_github_repo_for_variant};
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -129,11 +129,10 @@ impl GameVariant {
       .get_cached_release_by_tag(self, release_id)
       .await?;
 
-    if let Some(release) = cached_release {
-      if let Some(body) = &release.body {
+    if let Some(release) = cached_release
+      && let Some(body) = &release.body {
         return Ok(Some(body.clone()));
       }
-    }
 
     // If not found or body is missing, fetch from GitHub
     let repo = get_github_repo_for_variant(self);

--- a/cat-launcher/src-tauri/src/fetch_releases/repository/sqlite_releases_repository.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/repository/sqlite_releases_repository.rs
@@ -108,11 +108,10 @@ impl ReleasesRepository for SqliteReleasesRepository {
                         });
                 }
 
-                if let Some(asset) = asset {
-                    if let Some(release) = releases_map.get_mut(&release_id) {
+                if let Some(asset) = asset
+                    && let Some(release) = releases_map.get_mut(&release_id) {
                         release.assets.push(asset);
                     }
-                }
             }
 
             Ok(releases_map.into_values().collect())
@@ -206,11 +205,10 @@ impl ReleasesRepository for SqliteReleasesRepository {
                         });
                 }
 
-                if let Some(asset) = asset {
-                    if let Some(release) = releases_map.get_mut(&release_id) {
+                if let Some(asset) = asset
+                    && let Some(release) = releases_map.get_mut(&release_id) {
                         release.assets.push(asset);
                     }
-                }
             }
 
             Ok(releases_map.into_values().next())

--- a/cat-launcher/src-tauri/src/fetch_releases/utils.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/utils.rs
@@ -12,7 +12,7 @@ use crate::game_release::utils::{
 };
 use crate::infra::github::asset::GitHubAsset;
 use crate::infra::github::release::GitHubRelease;
-use crate::infra::utils::{read_from_file, Arch, OS};
+use crate::infra::utils::{Arch, OS, read_from_file};
 use crate::variants::GameVariant;
 
 pub async fn get_default_releases(

--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -229,10 +229,10 @@ pub async fn get_game_executable_filepath(
   {
     Ok(dir) => dir,
     Err(GetGameExecutableDirError::NoInstallation) => {
-      return Err(GetExecutablePathError::DoesNotExist)
+      return Err(GetExecutablePathError::DoesNotExist);
     }
     Err(err) => {
-      return Err(GetExecutablePathError::LauncherDirectory(err))
+      return Err(GetExecutablePathError::LauncherDirectory(err));
     }
   };
 

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -4,8 +4,8 @@ use crate::fetch_releases::repository::ReleasesRepository;
 use crate::fetch_releases::utils::{
   get_default_releases, merge_releases,
 };
-use crate::game_release::game_release::GameReleaseStatus;
 use crate::game_release::GameRelease;
+use crate::game_release::game_release::GameReleaseStatus;
 use crate::infra::github::release::GitHubRelease;
 use crate::infra::utils::{Arch, OS};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
@@ -88,8 +88,8 @@ pub async fn get_release_by_id(
     .get_cached_releases(variant)
     .await
     .unwrap_or_default(); // It's okay if getting cached releases fails.
-                          // If the release is not found, this function
-                          // will return an error.
+  // If the release is not found, this function
+  // will return an error.
 
   let default_releases =
     get_default_releases(variant, resources_dir).await;

--- a/cat-launcher/src-tauri/src/game_tips/commands.rs
+++ b/cat-launcher/src-tauri/src/game_tips/commands.rs
@@ -1,5 +1,5 @@
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/game_tips/lib.rs
+++ b/cat-launcher/src-tauri/src/game_tips/lib.rs
@@ -7,7 +7,7 @@ use crate::fetch_releases::repository::{
   ReleasesRepository, ReleasesRepositoryError,
 };
 use crate::filesystem::paths::{
-  get_tip_file_paths, GetTipFilePathsError,
+  GetTipFilePathsError, get_tip_file_paths,
 };
 use crate::game_release::game_release::{
   GameRelease, GameReleaseStatus,
@@ -72,9 +72,9 @@ pub async fn get_all_tips_for_variant(
   variant: &GameVariant,
   data_dir: &std::path::Path,
   os: &OS,
-  active_release_repository: &(dyn ActiveReleaseRepository
-      + Send
-      + Sync),
+  active_release_repository: &(
+     dyn ActiveReleaseRepository + Send + Sync
+   ),
   releases_repository: &(dyn ReleasesRepository + Send + Sync),
 ) -> Result<Vec<String>, GetAllTipsForVariantError> {
   if let Some(active_release) = active_release_repository

--- a/cat-launcher/src-tauri/src/infra/archive.rs
+++ b/cat-launcher/src-tauri/src/infra/archive.rs
@@ -1,4 +1,4 @@
-use std::fs::{read_dir, File};
+use std::fs::{File, read_dir};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -8,12 +8,12 @@ use tar::Archive;
 use tokio::fs;
 use tokio::task::JoinError;
 use unrar::error::UnrarError;
-use zip::result::ZipError;
-use zip::write::FileOptions;
 use zip::CompressionMethod::Deflated;
 use zip::ZipWriter;
+use zip::result::ZipError;
+use zip::write::FileOptions;
 
-use crate::filesystem::utils::{copy_dir_all, CopyDirError};
+use crate::filesystem::utils::{CopyDirError, copy_dir_all};
 use crate::infra::utils::OS;
 
 #[derive(thiserror::Error, Debug)]
@@ -138,11 +138,10 @@ pub async fn create_zip_archive(
   let source_dir = source_dir.to_owned();
   let archive_path = archive_path.to_owned();
 
-  if let Ok(metadata) = fs::metadata(&archive_path).await {
-    if metadata.is_dir() {
+  if let Ok(metadata) = fs::metadata(&archive_path).await
+    && metadata.is_dir() {
       return Err(ArchiveCreationError::DestinationIsDirectory);
     }
-  }
 
   match fs::metadata(&source_dir).await {
     Ok(metadata) => {
@@ -153,7 +152,7 @@ pub async fn create_zip_archive(
       }
     }
     Err(_) => {
-      return Err(ArchiveCreationError::InvalidOrNonExistentSourceDir)
+      return Err(ArchiveCreationError::InvalidOrNonExistentSourceDir);
     }
   }
 

--- a/cat-launcher/src-tauri/src/infra/github/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/github/utils.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use regex::Regex;
-use reqwest::header::LINK;
 use reqwest::Client;
+use reqwest::header::LINK;
 
 use crate::infra::github::release::GitHubRelease;
 

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,11 +1,11 @@
 use std::env;
 
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Client;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 fn create_github_pat_headers() -> Option<HeaderMap> {
-  if let Ok(github_pat) = env::var("GITHUB_PAT") {
-    if !github_pat.is_empty() {
+  if let Ok(github_pat) = env::var("GITHUB_PAT")
+    && !github_pat.is_empty() {
       let authorization = format!("Bearer {}", github_pat);
       if let Ok(header_value) = HeaderValue::from_str(&authorization)
       {
@@ -14,7 +14,6 @@ fn create_github_pat_headers() -> Option<HeaderMap> {
         return Some(headers);
       }
     }
-  }
   None
 }
 

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use strum::IntoStaticStr;
 use tauri::ipc::Channel;
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -8,14 +8,14 @@ use crate::active_release::active_release::ActiveReleaseError;
 use crate::active_release::repository::ActiveReleaseRepository;
 use crate::fetch_releases::repository::ReleasesRepository;
 use crate::filesystem::paths::{
+  AssetDownloadDirError, AssetExtractionDirError,
   get_or_create_asset_download_dir,
-  get_or_create_asset_installation_dir, AssetDownloadDirError,
-  AssetExtractionDirError,
+  get_or_create_asset_installation_dir,
 };
 use crate::game_release::game_release::{
   GameRelease, GameReleaseStatus,
 };
-use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::infra::archive::{ExtractionError, extract_archive};
 use crate::infra::download::Downloader;
 use crate::infra::github::asset::AssetDownloadError;
 use crate::infra::utils::{Arch, OS};

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -1,16 +1,16 @@
 use std::env::consts::OS;
 
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::game_release::game_release::GameReleaseStatus;
 use crate::game_release::utils::{
-  get_release_by_id, GetReleaseError,
+  GetReleaseError, get_release_by_id,
 };
-use crate::infra::utils::{get_os_enum, OSNotSupportedError};
+use crate::infra::utils::{OSNotSupportedError, get_os_enum};
 use crate::variants::GameVariant;
 
 #[derive(

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use tokio::fs;
 
 use crate::filesystem::paths::{
-  get_game_executable_filepath, AssetDownloadDirError,
-  AssetExtractionDirError, GetExecutablePathError,
+  AssetDownloadDirError, AssetExtractionDirError,
+  GetExecutablePathError, get_game_executable_filepath,
 };
 use crate::game_release::game_release::{
   GameRelease, GameReleaseStatus,
@@ -39,10 +39,10 @@ impl GameRelease {
     {
       Ok(path) => path,
       Err(GetExecutablePathError::DoesNotExist) => {
-        return Ok(GameReleaseStatus::NotDownloaded)
+        return Ok(GameReleaseStatus::NotDownloaded);
       }
       Err(e) => {
-        return Err(GetInstallationStatusError::Executable(e))
+        return Err(GetInstallationStatusError::Executable(e));
       }
     };
 

--- a/cat-launcher/src-tauri/src/last_played_world/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/commands.rs
@@ -1,9 +1,9 @@
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Manager};
+use tauri::{AppHandle, Manager, command};
 
 use crate::last_played_world::last_played_world::{
-  get_last_played_world as get_last_played_world_impl,
   GetLastPlayedWorldError,
+  get_last_played_world as get_last_played_world_impl,
 };
 use crate::variants::GameVariant;
 use cat_macros::CommandErrorSerialize;

--- a/cat-launcher/src-tauri/src/last_played_world/paths.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/paths.rs
@@ -1,5 +1,5 @@
-use crate::filesystem::paths::get_or_create_user_game_data_dir;
 use crate::filesystem::paths::GetUserGameDataDirError;
+use crate::filesystem::paths::get_or_create_user_game_data_dir;
 use crate::variants::GameVariant;
 use std::path::Path;
 use std::path::PathBuf;

--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -2,7 +2,7 @@ use std::env::consts::OS;
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -14,21 +14,21 @@ use crate::active_release::repository::ActiveReleaseRepository;
 use crate::constants::MAX_BACKUPS;
 use crate::fetch_releases::repository::ReleasesRepository;
 use crate::filesystem::paths::{
-  get_game_executable_filepath,
+  AssetDownloadDirError, AssetExtractionDirError,
+  GetAutomaticBackupArchivePathError, GetExecutablePathError,
+  GetUserGameDataDirError, get_game_executable_filepath,
   get_or_create_automatic_backup_archive_filepath,
-  get_or_create_user_game_data_dir, AssetDownloadDirError,
-  AssetExtractionDirError, GetAutomaticBackupArchivePathError,
-  GetExecutablePathError, GetUserGameDataDirError,
+  get_or_create_user_game_data_dir,
 };
 use crate::game_release::game_release::GameRelease;
 use crate::game_release::utils::{
-  get_release_by_id, GetReleaseError,
+  GetReleaseError, get_release_by_id,
 };
 use crate::infra::utils::OS;
 use crate::launch_game::repository::{
   BackupRepository, BackupRepositoryError,
 };
-use crate::launch_game::utils::{backup_save_files, BackupError};
+use crate::launch_game::utils::{BackupError, backup_save_files};
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -246,12 +246,10 @@ async fn cleanup_old_backups(
         .delete_backup_entry(backup.id)
         .await
         .is_ok()
-      {
-        if let Ok(path) = path_res {
+        && let Ok(path) = path_res {
           // file deletion fails is ignored.
           let _ = tokio::fs::remove_file(&path).await;
         }
-      }
     });
   }
 

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use crate::filesystem::paths::{
+  GetAutomaticBackupArchivePathError, GetUserGameDataDirError,
   get_or_create_automatic_backup_archive_filepath,
   get_or_create_user_game_data_dir,
-  GetAutomaticBackupArchivePathError, GetUserGameDataDirError,
 };
 use crate::infra::archive::{
-  create_zip_archive, ArchiveCreationError,
+  ArchiveCreationError, create_zip_archive,
 };
 use crate::variants::GameVariant;
 

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -76,7 +76,7 @@ use crate::utils::{
 };
 use crate::variants::commands::get_game_variants_info;
 use crate::variants::commands::update_game_variant_order;
-use tauri::{command, AppHandle};
+use tauri::{AppHandle, command};
 
 #[command]
 fn confirm_quit(app_handle: AppHandle) {

--- a/cat-launcher/src-tauri/src/manual_backups/commands.rs
+++ b/cat-launcher/src-tauri/src/manual_backups/commands.rs
@@ -1,5 +1,5 @@
-use serde::ser::SerializeStruct;
 use serde::Serialize;
+use serde::ser::SerializeStruct;
 use std::time::SystemTimeError;
 use strum::IntoStaticStr;
 use tauri::{Manager, State};

--- a/cat-launcher/src-tauri/src/manual_backups/manual_backups.rs
+++ b/cat-launcher/src-tauri/src/manual_backups/manual_backups.rs
@@ -1,13 +1,13 @@
 use std::path::{Path, PathBuf};
 
 use crate::filesystem::paths::{
+  GetManualBackupArchivePathError, GetUserGameDataDirError,
   get_or_create_manual_backup_archive_filepath,
-  get_or_create_user_game_data_dir, GetManualBackupArchivePathError,
-  GetUserGameDataDirError,
+  get_or_create_user_game_data_dir,
 };
 use crate::infra::archive::{
-  create_zip_archive, extract_archive, ArchiveCreationError,
-  ExtractionError,
+  ArchiveCreationError, ExtractionError, create_zip_archive,
+  extract_archive,
 };
 use crate::infra::utils::OS;
 use crate::manual_backups::repository::manual_backup_repository::{

--- a/cat-launcher/src-tauri/src/master_reset/commands.rs
+++ b/cat-launcher/src-tauri/src/master_reset/commands.rs
@@ -1,5 +1,5 @@
 use strum::IntoStaticStr;
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/mods/get_last_activity_for_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/get_last_activity_for_third_party_mod.rs
@@ -4,10 +4,10 @@ use ts_rs::TS;
 use url::Url;
 
 use crate::infra::github::get_last_commit::{
-  get_last_commit, GetLastCommitError,
+  GetLastCommitError, get_last_commit,
 };
 use crate::mods::get_third_party_mod_by_id::{
-  get_third_party_mod_by_id, GetThirdPartyModByIdError,
+  GetThirdPartyModByIdError, get_third_party_mod_by_id,
 };
 use crate::mods::repository::mods_repository::ModsRepository;
 use crate::mods::types::ModActivity;

--- a/cat-launcher/src-tauri/src/mods/install_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/install_third_party_mod.rs
@@ -6,11 +6,11 @@ use downloader::progress::Reporter;
 use tokio::fs::create_dir_all;
 
 use crate::filesystem::paths::{
-  get_or_create_directory, get_or_create_user_game_data_dir,
   GetOrCreateDirectoryError, GetUserGameDataDirError,
+  get_or_create_directory, get_or_create_user_game_data_dir,
 };
-use crate::filesystem::utils::{copy_dir_all, CopyDirError};
-use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::filesystem::utils::{CopyDirError, copy_dir_all};
+use crate::infra::archive::{ExtractionError, extract_archive};
 use crate::infra::download::{DownloadFileError, Downloader};
 use crate::infra::utils::OS;
 use crate::mods::repository::installed_mods_repository::{

--- a/cat-launcher/src-tauri/src/mods/lib.rs
+++ b/cat-launcher/src-tauri/src/mods/lib.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::filesystem::paths::{
-  get_game_resources_dir, GetGameExecutableDirError,
+  GetGameExecutableDirError, get_game_resources_dir,
 };
 use crate::infra::utils::OS;
 use crate::mods::types::OnlineModRepository;

--- a/cat-launcher/src-tauri/src/mods/list_all_mods.rs
+++ b/cat-launcher/src-tauri/src/mods/list_all_mods.rs
@@ -6,9 +6,9 @@ use std::path::Path;
 use tokio::fs::{read_dir, read_to_string};
 
 use crate::active_release::repository::ActiveReleaseRepository;
-use crate::infra::utils::{sort_assets, OS};
+use crate::infra::utils::{OS, sort_assets};
 use crate::mods::lib::{
-  get_mods_resource_path, get_stock_mods_dir, GetStockModsDirError,
+  GetStockModsDirError, get_mods_resource_path, get_stock_mods_dir,
 };
 use crate::mods::online::types::OnlineModRepository;
 use crate::mods::repository::mods_repository::{
@@ -346,7 +346,7 @@ pub async fn list_all_third_party_mods(
     match third_party_mod {
       Ok(third_party_mod) => mods.push(third_party_mod),
       Err(e) => {
-        return Err(ListThirdPartyModsError::ParseModsJson(e))
+        return Err(ListThirdPartyModsError::ParseModsJson(e));
       }
     }
   }

--- a/cat-launcher/src-tauri/src/mods/online/bright_nights/manifest.rs
+++ b/cat-launcher/src-tauri/src/mods/online/bright_nights/manifest.rs
@@ -91,7 +91,7 @@ impl BrightNightsOnlineMod {
           IntoThirdPartyModError::FailedToExtractRepoFromGithubUrl(
             self.source.url.clone(),
           ),
-        )
+        );
       }
     };
 
@@ -119,7 +119,7 @@ impl BrightNightsOnlineMod {
           IntoThirdPartyModError::FailedToExtractArchiveFilename(
             self.source.url.clone(),
           ),
-        )
+        );
       }
     };
 

--- a/cat-launcher/src-tauri/src/mods/uninstall_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/uninstall_third_party_mod.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::Path;
 
 use crate::filesystem::paths::{
-  get_or_create_user_game_data_dir, GetUserGameDataDirError,
+  GetUserGameDataDirError, get_or_create_user_game_data_dir,
 };
 use crate::mods::repository::installed_mods_repository::{
   InstalledModsRepository, InstalledModsRepositoryError,

--- a/cat-launcher/src-tauri/src/settings/commands.rs
+++ b/cat-launcher/src-tauri/src/settings/commands.rs
@@ -1,6 +1,6 @@
 use std::env::consts::OS;
 
-use tauri::{command, AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/settings/fonts.rs
+++ b/cat-launcher/src-tauri/src/settings/fonts.rs
@@ -72,11 +72,10 @@ async fn get_fonts_in_dir_recursive(dir: PathBuf) -> Vec<Font> {
               path.extension().and_then(|e| e.to_str())
             {
               let ext = ext.to_lowercase();
-              if ext == "ttf" || ext == "otf" {
-                if let Ok(font) = get_font_from_file(&path).await {
+              if (ext == "ttf" || ext == "otf")
+                && let Ok(font) = get_font_from_file(&path).await {
                   fonts.push(font);
                 }
-              }
             }
           }
         }

--- a/cat-launcher/src-tauri/src/settings/paths.rs
+++ b/cat-launcher/src-tauri/src/settings/paths.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::filesystem::paths::{
-  get_or_create_user_game_data_dir, GetUserGameDataDirError,
+  GetUserGameDataDirError, get_or_create_user_game_data_dir,
 };
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;

--- a/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
@@ -5,12 +5,12 @@ use async_trait::async_trait;
 use r2d2_sqlite::SqliteConnectionManager;
 use tokio::task;
 
+use crate::settings::Settings;
 use crate::settings::fonts::get_font_from_file;
 use crate::settings::repository::settings_repository::{
   GetSettingsError, SaveSettingsError, SettingsRepository,
 };
 use crate::settings::types::ColorTheme;
-use crate::settings::Settings;
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 

--- a/cat-launcher/src-tauri/src/settings/update_color_files.rs
+++ b/cat-launcher/src-tauri/src/settings/update_color_files.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use strum::IntoEnumIterator;
 
 use crate::filesystem::paths::GetUserGameDataDirError;
-use crate::settings::paths::{
-  get_or_create_user_config_dir, GetOrCreateUserConfigDirError,
-};
 use crate::settings::Settings;
+use crate::settings::paths::{
+  GetOrCreateUserConfigDirError, get_or_create_user_config_dir,
+};
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]

--- a/cat-launcher/src-tauri/src/settings/update_font_files.rs
+++ b/cat-launcher/src-tauri/src/settings/update_font_files.rs
@@ -4,12 +4,12 @@ use std::path::Path;
 use strum::IntoEnumIterator;
 
 use crate::filesystem::paths::GetUserGameDataDirError;
+use crate::settings::Settings;
 use crate::settings::consts::FALLBACK_FONTS;
 use crate::settings::paths::{
-  get_or_create_user_config_dir, GetOrCreateUserConfigDirError,
+  GetOrCreateUserConfigDirError, get_or_create_user_config_dir,
 };
 use crate::settings::types::Font;
-use crate::settings::Settings;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
@@ -107,7 +107,7 @@ async fn ensure_font_blending(
       return Ok(());
     }
     Err(e) => {
-      return Err(EnsureFontBlendingError::ReadOptionsJson(e))
+      return Err(EnsureFontBlendingError::ReadOptionsJson(e));
     }
   };
 

--- a/cat-launcher/src-tauri/src/settings/update_settings.rs
+++ b/cat-launcher/src-tauri/src/settings/update_settings.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 
+use crate::settings::Settings;
 use crate::settings::repository::settings_repository::{
   SaveSettingsError, SettingsRepository,
 };
 use crate::settings::update_color_files::{
-  update_color_files, UpdateColorFilesError,
+  UpdateColorFilesError, update_color_files,
 };
 use crate::settings::update_font_files::{
-  update_font_files, UpdateFontFilesError,
+  UpdateFontFilesError, update_font_files,
 };
-use crate::settings::Settings;
 
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateSettingsError {

--- a/cat-launcher/src-tauri/src/soundpacks/install_third_party_soundpack.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/install_third_party_soundpack.rs
@@ -8,11 +8,11 @@ use tokio::fs::{create_dir_all, read_to_string};
 use downloader::progress::Reporter;
 
 use crate::filesystem::paths::{
-  get_or_create_directory, get_or_create_user_game_data_dir,
   GetOrCreateDirectoryError, GetUserGameDataDirError,
+  get_or_create_directory, get_or_create_user_game_data_dir,
 };
-use crate::filesystem::utils::{copy_dir_all, CopyDirError};
-use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::filesystem::utils::{CopyDirError, copy_dir_all};
+use crate::infra::archive::{ExtractionError, extract_archive};
 use crate::infra::download::{DownloadFileError, Downloader};
 
 use crate::infra::utils::OS;

--- a/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
@@ -9,10 +9,10 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::active_release::repository::{
   ActiveReleaseRepository, ActiveReleaseRepositoryError,
 };
-use crate::infra::utils::{sort_assets, OS};
+use crate::infra::utils::{OS, sort_assets};
 use crate::soundpacks::paths::{
-  get_soundpacks_resource_path, get_stock_soundpacks_dir,
-  GetStockSoundpacksDirError,
+  GetStockSoundpacksDirError, get_soundpacks_resource_path,
+  get_stock_soundpacks_dir,
 };
 use crate::soundpacks::types::{
   Soundpack, StockSoundpack, ThirdPartySoundpack,
@@ -184,7 +184,7 @@ async fn list_all_third_party_soundpacks(
     Err(e) => {
       return Err(ListThirdPartySoundpacksError::ReadSoundpacksJson(
         e,
-      ))
+      ));
     }
   };
 
@@ -210,7 +210,7 @@ async fn list_all_third_party_soundpacks(
       Err(e) => {
         return Err(
           ListThirdPartySoundpacksError::ParseSoundpacksJson(e),
-        )
+        );
       }
     }
   }

--- a/cat-launcher/src-tauri/src/soundpacks/paths.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/paths.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::filesystem::paths::{
-  get_game_resources_dir, GetGameExecutableDirError,
+  GetGameExecutableDirError, get_game_resources_dir,
 };
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;

--- a/cat-launcher/src-tauri/src/theme/commands.rs
+++ b/cat-launcher/src-tauri/src/theme/commands.rs
@@ -4,8 +4,8 @@ use tauri::State;
 
 use crate::theme::sqlite_theme_preference_repository::SqliteThemePreferenceRepository;
 use crate::theme::theme::{
-  get_theme_preference, update_theme_preference, GetThemeError,
-  Theme, ThemePreference, UpdateThemeError,
+  GetThemeError, Theme, ThemePreference, UpdateThemeError,
+  get_theme_preference, update_theme_preference,
 };
 
 #[derive(

--- a/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
@@ -7,11 +7,11 @@ use downloader::progress::Reporter;
 use tokio::fs::{create_dir_all, read_to_string};
 
 use crate::filesystem::paths::{
-  get_or_create_directory, get_or_create_user_game_data_dir,
   GetOrCreateDirectoryError, GetUserGameDataDirError,
+  get_or_create_directory, get_or_create_user_game_data_dir,
 };
-use crate::filesystem::utils::{copy_dir_all, CopyDirError};
-use crate::infra::archive::{extract_archive, ExtractionError};
+use crate::filesystem::utils::{CopyDirError, copy_dir_all};
+use crate::infra::archive::{ExtractionError, extract_archive};
 use crate::infra::download::{DownloadFileError, Downloader};
 
 use crate::infra::utils::OS;

--- a/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
+++ b/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
@@ -9,10 +9,10 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::active_release::repository::{
   ActiveReleaseRepository, ActiveReleaseRepositoryError,
 };
-use crate::infra::utils::{sort_assets, OS};
+use crate::infra::utils::{OS, sort_assets};
 use crate::tilesets::paths::{
-  get_stock_tilesets_dir, get_tilesets_resource_path,
-  GetStockTilesetsDirError,
+  GetStockTilesetsDirError, get_stock_tilesets_dir,
+  get_tilesets_resource_path,
 };
 use crate::tilesets::types::{
   StockTileset, ThirdPartyTileset, Tileset,
@@ -178,7 +178,7 @@ async fn list_all_third_party_tilesets(
   let content = match read_to_string(&tilesets_json_path).await {
     Ok(content) => content,
     Err(e) => {
-      return Err(ListThirdPartyTilesetsError::ReadTilesetsJson(e))
+      return Err(ListThirdPartyTilesetsError::ReadTilesetsJson(e));
     }
   };
 
@@ -202,7 +202,7 @@ async fn list_all_third_party_tilesets(
         tilesets.push(Tileset::ThirdParty(third_party_tileset))
       }
       Err(e) => {
-        return Err(ListThirdPartyTilesetsError::ParseTilesetsJson(e))
+        return Err(ListThirdPartyTilesetsError::ParseTilesetsJson(e));
       }
     }
   }

--- a/cat-launcher/src-tauri/src/tilesets/paths.rs
+++ b/cat-launcher/src-tauri/src/tilesets/paths.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::filesystem::paths::{
-  get_game_resources_dir, GetGameExecutableDirError,
+  GetGameExecutableDirError, get_game_resources_dir,
 };
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;

--- a/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::Path;
 
 use crate::filesystem::paths::{
-  get_or_create_user_game_data_dir, GetUserGameDataDirError,
+  GetUserGameDataDirError, get_or_create_user_game_data_dir,
 };
 use crate::tilesets::repository::installed_tilesets_repository::{
   InstalledTilesetsRepository, InstalledTilesetsRepositoryError,

--- a/cat-launcher/src-tauri/src/users/commands.rs
+++ b/cat-launcher/src-tauri/src/users/commands.rs
@@ -5,7 +5,7 @@ use cat_macros::CommandErrorSerialize;
 
 use crate::users::repository::sqlite_users_repository::SqliteUsersRepository;
 use crate::users::service::{
-  get_or_create_user_id, GetOrCreateUserIdError,
+  GetOrCreateUserIdError, get_or_create_user_id,
 };
 
 #[derive(

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -222,9 +222,9 @@ pub fn manage_posthog(app: &App) {
           Ok(id) => id,
           Err(e) => {
             eprintln!(
-                            "Failed to get or create user for PostHog identification: {}",
-                            e
-                        );
+              "Failed to get or create user for PostHog identification: {}",
+              e
+            );
             return;
           }
         };

--- a/cat-launcher/src-tauri/src/variants/commands.rs
+++ b/cat-launcher/src-tauri/src/variants/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{command, State};
+use tauri::{State, command};
 
 use cat_macros::CommandErrorSerialize;
 

--- a/cat-launcher/src-tauri/src/variants/repository/sqlite_game_variant_order_repository.rs
+++ b/cat-launcher/src-tauri/src/variants/repository/sqlite_game_variant_order_repository.rs
@@ -3,11 +3,11 @@ use r2d2_sqlite::SqliteConnectionManager;
 use std::str::FromStr;
 use tokio::task;
 
+use crate::variants::GameVariant;
 use crate::variants::repository::game_variant_order_repository::{
   GameVariantOrderRepository, GameVariantOrderRepositoryError,
   GetGameVariantOrderError, UpdateGameVariantOrderError,
 };
-use crate::variants::GameVariant;
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 

--- a/cat-launcher/src-tauri/src/variants/update_game_variant_order.rs
+++ b/cat-launcher/src-tauri/src/variants/update_game_variant_order.rs
@@ -1,6 +1,6 @@
+use crate::variants::GameVariant;
 use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepository;
 use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepositoryError;
-use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateGameVariantOrderError {


### PR DESCRIPTION
Motivation:
- To keep the project up to date with the latest Rust edition and dependencies.

Changes:
- Changed edition to 2024 in cat-launcher/src-tauri/Cargo.toml and cat-launcher/cat-macros/Cargo.toml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade project to Rust 2024 edition with minor code cleanups and dependency bumps. No behavior changes intended.

- **Dependencies**
  - Updated `syn` to 2.0.117, `quote` to 1.0.45, `serde` to 1.0.228 in `cat-macros`.
  - Refreshed `Cargo.lock` (e.g., `proc-macro2`, `quote`, `syn`, `unicode-ident`).

- **Migration**
  - Requires a Rust toolchain that supports the 2024 edition (run `rustup update`).
  - If builds fail due to cache, run `cargo clean && cargo build`.

<sup>Written for commit 2d08693f3a4cce80771fa8653a99c73300e1f2fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

