### PR TITLE
docs: add comments to functions, constants, classes, and components

### DIFF
--- a/cat-launcher/cat-macros/src/lib.rs
+++ b/cat-launcher/cat-macros/src/lib.rs
@@ -4,6 +4,10 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
+/// A procedural macro to derive `serde::Serialize` for command error types.
+///
+/// This macro generates a `Serialize` implementation that includes the error's
+/// type (from `Into<&'static str>`) and its message (from `ToString`).
 #[proc_macro_derive(CommandErrorSerialize)]
 pub fn derive_command_error_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/cat-launcher/src-tauri/src/achievements/achievements.rs
+++ b/cat-launcher/src-tauri/src/achievements/achievements.rs
@@ -13,10 +13,14 @@ use crate::variants::GameVariant;
 
 use super::types::{Achievement, CharacterAchievements};
 
+/// Represents the structure of an achievement file stored by the game.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AchievementFile {
+  /// The version of the achievement format.
   pub achievement_version: i32,
+  /// A list of achievement IDs earned.
   pub achievements: Vec<String>,
+  /// The name of the character associated with these achievements.
   pub avatar_name: String,
 }
 
@@ -44,20 +48,27 @@ struct AchievementJsonEntry {
   name: Option<AchievementName>,
 }
 
+/// Errors that can occur when retrieving achievements.
 #[derive(thiserror::Error, Debug)]
 pub enum GetAchievementsError {
+  /// An error occurred while determining the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameData(#[from] GetUserGameDataDirError),
+  /// An error occurred while reading from the filesystem.
   #[error("failed to read achievements directory: {0}")]
   Read(#[from] std::io::Error),
+  /// An error occurred while retrieving the active release.
   #[error("failed to get active release: {0}")]
   ActiveRelease(
     #[from] crate::active_release::active_release::ActiveReleaseError,
   ),
+  /// The current operating system is not supported.
   #[error("unsupported OS: {0}")]
   UnsupportedOS(#[from] OSNotSupportedError),
+  /// An error occurred while determining the game resources directory.
   #[error("failed to get game resources directory: {0}")]
   GameResourcesDir(#[from] GetGameExecutableDirError),
+  /// An error occurred while parsing JSON data.
   #[error("failed to parse achievements.json: {0}")]
   Serde(#[from] serde_json::Error),
 }
@@ -148,6 +159,10 @@ async fn load_character_achievement_ids(
   Ok(character_achievements_map)
 }
 
+/// Retrieves all achievements for a character across all game variants.
+///
+/// This function reads the achievement files from the user's game data directory
+/// and maps them to their friendly names by parsing the game's achievement definitions.
 pub async fn get_achievements(
   variant: &GameVariant,
   data_dir: &Path,

--- a/cat-launcher/src-tauri/src/achievements/commands.rs
+++ b/cat-launcher/src-tauri/src/achievements/commands.rs
@@ -8,16 +8,22 @@ use crate::variants::GameVariant;
 use super::achievements::{GetAchievementsError, get_achievements};
 use super::types::CharacterAchievements;
 
+/// Errors that can occur when retrieving achievements for a game variant.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetAchievementsForVariantCommandError {
+  /// An error occurred while retrieving achievements from the game files.
   #[error("failed to get achievements: {0}")]
   GetAchievements(#[from] GetAchievementsError),
+  /// An error occurred while determining the data directory.
   #[error("failed to get data directory: {0}")]
   DataDir(#[from] tauri::Error),
 }
 
+/// Retrieves all achievements for a specific game variant.
+///
+/// This command scans the game's data directory to find character achievements.
 #[tauri::command]
 pub async fn get_achievements_for_variant(
   variant: GameVariant,

--- a/cat-launcher/src-tauri/src/achievements/types.rs
+++ b/cat-launcher/src-tauri/src/achievements/types.rs
@@ -1,18 +1,24 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+/// Represents a single achievement in the game.
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Achievement {
+  /// The unique identifier of the achievement.
   pub id: String,
+  /// The display name of the achievement.
   pub name: String,
 }
 
+/// Represents the achievements earned by a specific character.
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct CharacterAchievements {
+  /// The name of the character.
   pub character_name: String,
+  /// The list of achievements earned by this character.
   pub achievements: Vec<Achievement>,
 }

--- a/cat-launcher/src-tauri/src/active_release/active_release.rs
+++ b/cat-launcher/src-tauri/src/active_release/active_release.rs
@@ -3,13 +3,16 @@ use crate::active_release::repository::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when interacting with the active release.
 #[derive(thiserror::Error, Debug)]
 pub enum ActiveReleaseError {
+  /// An error occurred in the active release repository.
   #[error("failed to access active release: {0}")]
   Repository(#[from] ActiveReleaseRepositoryError),
 }
 
 impl GameVariant {
+  /// Retrieves the version of the currently active release for this variant.
   pub async fn get_active_release(
     &self,
     repository: &dyn ActiveReleaseRepository,
@@ -17,6 +20,7 @@ impl GameVariant {
     Ok(repository.get_active_release(self).await?)
   }
 
+  /// Sets the version of the active release for this variant.
   pub async fn set_active_release(
     &self,
     version: &str,

--- a/cat-launcher/src-tauri/src/active_release/commands.rs
+++ b/cat-launcher/src-tauri/src/active_release/commands.rs
@@ -7,17 +7,21 @@ use crate::active_release::active_release::ActiveReleaseError;
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving the active release.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum ActiveReleaseCommandError {
+  /// An error occurred while retrieving the active release from the repository.
   #[error("failed to get active release: {0}")]
   GetActiveRelease(#[from] ActiveReleaseError),
 
+  /// An error occurred while determining a system directory.
   #[error("failed to get system directory: {0}")]
   SystemDirectory(#[from] tauri::Error),
 }
 
+/// Retrieves the version of the active release for a specific game variant.
 #[command]
 pub async fn get_active_release(
   variant: GameVariant,

--- a/cat-launcher/src-tauri/src/active_release/repository/active_release_repository.rs
+++ b/cat-launcher/src-tauri/src/active_release/repository/active_release_repository.rs
@@ -4,22 +4,28 @@ use async_trait::async_trait;
 
 use crate::variants::game_variant::GameVariant;
 
+/// Errors that can occur when interacting with the active release repository.
 #[derive(thiserror::Error, Debug)]
 pub enum ActiveReleaseRepositoryError {
+  /// An error occurred while retrieving the active release version.
   #[error("failed to get active release: {0}")]
   Get(Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while setting the active release version.
   #[error("failed to set active release: {0}")]
   Set(Box<dyn Error + Send + Sync>),
 }
 
+/// A repository for managing the version of the active release for each game variant.
 #[async_trait]
 pub trait ActiveReleaseRepository: Send + Sync {
+  /// Retrieves the version of the currently active release for the given game variant.
   async fn get_active_release(
     &self,
     game_variant: &GameVariant,
   ) -> Result<Option<String>, ActiveReleaseRepositoryError>;
 
+  /// Sets the version of the active release for the given game variant.
   async fn set_active_release(
     &self,
     game_variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/active_release/repository/sqlite_active_release_repository.rs
+++ b/cat-launcher/src-tauri/src/active_release/repository/sqlite_active_release_repository.rs
@@ -9,11 +9,13 @@ use crate::variants::game_variant::GameVariant;
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A repository for managing active release data using a SQLite database.
 pub struct SqliteActiveReleaseRepository {
   pool: Pool,
 }
 
 impl SqliteActiveReleaseRepository {
+  /// Creates a new instance of `SqliteActiveReleaseRepository` with the given connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/backups/backups.rs
+++ b/cat-launcher/src-tauri/src/backups/backups.rs
@@ -12,12 +12,15 @@ use crate::launch_game::repository::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when listing backups.
 #[derive(thiserror::Error, Debug)]
 pub enum ListBackupsError {
+  /// Failed to retrieve backup entries from the repository.
   #[error("failed to get backup entries: {0}")]
   Get(#[from] BackupRepositoryError),
 }
 
+/// Retrieves a list of all backups for a specific game variant, sorted by timestamp.
 pub async fn list_backups(
   game_variant: &GameVariant,
   backup_repository: &impl BackupRepository,
@@ -31,18 +34,25 @@ pub async fn list_backups(
   Ok(backups)
 }
 
+/// Errors that can occur when deleting a backup.
 #[derive(thiserror::Error, Debug)]
 pub enum DeleteBackupError {
+  /// Failed to retrieve the backup entry.
   #[error("failed to get backup entry: {0}")]
   Get(#[from] BackupRepositoryError),
 
+  /// Failed to construct the file path to the backup archive.
   #[error("failed to get backup archive path: {0}")]
   BackupArchivePath(#[from] GetAutomaticBackupArchivePathError),
 
+  /// Failed to remove the backup file from the filesystem.
   #[error("failed to remove backup file: {0}")]
   RemoveBackupFile(#[from] std::io::Error),
 }
 
+/// Deletes a backup from both the database and the filesystem.
+/// 
+/// If the file removal fails, it attempts to re-insert the backup entry back into the database.
 pub async fn delete_backup(
   id: i64,
   data_dir: &Path,
@@ -76,21 +86,27 @@ pub async fn delete_backup(
   Ok(())
 }
 
+/// Errors that can occur when restoring a backup.
 #[derive(thiserror::Error, Debug)]
 pub enum RestoreBackupError {
+  /// Failed to retrieve the backup entry.
   #[error("failed to get backup entry: {0}")]
   Get(#[from] BackupRepositoryError),
 
+  /// Failed to construct the file path to the backup archive.
   #[error("failed to get backup archive path: {0}")]
   BackupArchivePath(#[from] GetAutomaticBackupArchivePathError),
 
+  /// Failed to determine the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// Failed to extract the backup archive.
   #[error("failed to extract archive: {0}")]
   Extract(#[from] ExtractionError),
 }
 
+/// Restores a backup by extracting its archive into the user's game data directory.
 pub async fn restore_backup(
   id: i64,
   data_dir: &Path,

--- a/cat-launcher/src-tauri/src/backups/commands.rs
+++ b/cat-launcher/src-tauri/src/backups/commands.rs
@@ -12,14 +12,17 @@ use crate::launch_game::repository::BackupEntry;
 use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when executing the list backups command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum ListBackupsCommandError {
+  /// Failed to retrieve the list of backups.
   #[error("failed to get backups: {0}")]
   Get(#[from] ListBackupsError),
 }
 
+/// Tauri command to list all backups for a specific game variant.
 #[tauri::command]
 pub async fn list_backups_for_variant(
   variant: GameVariant,
@@ -30,16 +33,20 @@ pub async fn list_backups_for_variant(
   Ok(backups)
 }
 
+/// Errors that can occur when executing the delete backup command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum DeleteBackupCommandError {
+  /// Failed to delete the backup.
   #[error("failed to delete backup: {0}")]
   Delete(#[from] DeleteBackupError),
+  /// Failed to access the app local data directory.
   #[error("failed to get data directory: {0}")]
   DataDir(#[from] tauri::Error),
 }
 
+/// Tauri command to delete a backup by its ID.
 #[tauri::command]
 pub async fn delete_backup_by_id(
   id: i64,
@@ -51,18 +58,23 @@ pub async fn delete_backup_by_id(
   Ok(())
 }
 
+/// Errors that can occur when executing the restore backup command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum RestoreBackupCommandError {
+  /// Failed to restore the backup.
   #[error("failed to restore backup: {0}")]
   Restore(#[from] RestoreBackupError),
+  /// Failed to access the app local data directory.
   #[error("failed to get data directory: {0}")]
   DataDir(#[from] tauri::Error),
+  /// The current operating system is not supported.
   #[error("unsupported OS: {0}")]
   UnsupportedOS(#[from] OSNotSupportedError),
 }
 
+/// Tauri command to restore a backup by its ID.
 #[tauri::command]
 pub async fn restore_backup_by_id(
   id: i64,

--- a/cat-launcher/src-tauri/src/backups/mod.rs
+++ b/cat-launcher/src-tauri/src/backups/mod.rs
@@ -1,2 +1,4 @@
+/// Module for managing game backups.
 pub mod backups;
+/// Module for backup-related tauri commands.
 pub mod commands;

--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -7,20 +7,25 @@ use crate::filesystem::utils::get_safe_filename;
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
+/// Returns the path to the application database file.
 pub fn get_db_path(data_dir: &Path) -> PathBuf {
   data_dir.join("cat-launcher.db")
 }
 
+/// Returns the path to the application settings file.
 pub fn get_settings_path(resource_dir: &Path) -> PathBuf {
   resource_dir.join("settings.json")
 }
 
+/// Errors that can occur when getting the schema file path.
 #[derive(thiserror::Error, Debug)]
 pub enum GetSchemaFilePathError {
+  /// Error retrieving the resource directory.
   #[error("failed to get resource directory: {0}")]
   ResourceDir(#[from] tauri::Error),
 }
 
+/// Returns the path to the database schema SQL file.
 pub fn get_schema_file_path(
   resources_dir: &Path,
 ) -> Result<PathBuf, GetSchemaFilePathError> {
@@ -28,6 +33,7 @@ pub fn get_schema_file_path(
   Ok(schema_dir.join("schema.sql"))
 }
 
+/// Returns the path to the default releases JSON file for a variant.
 pub fn get_default_releases_file_path(
   variant: &GameVariant,
   resources_dir: &Path,
@@ -37,6 +43,7 @@ pub fn get_default_releases_file_path(
     .join(format!("{}.json", variant.id()))
 }
 
+/// Returns the cached releases path for a variant.
 pub fn get_releases_cache_filepath(
   variant: &GameVariant,
   cache_dir: &Path,

--- a/cat-launcher/src-tauri/src/filesystem/utils.rs
+++ b/cat-launcher/src-tauri/src/filesystem/utils.rs
@@ -6,6 +6,8 @@ use tokio::process::Command;
 
 use crate::infra::utils::OS;
 
+/// Returns a filesystem-safe version of the given name by replacing non-alphanumeric
+/// characters with underscores.
 pub fn get_safe_filename(name: &str) -> String {
   name
     .chars()
@@ -13,12 +15,17 @@ pub fn get_safe_filename(name: &str) -> String {
     .collect()
 }
 
+/// Errors that can occur when copying a directory.
 #[derive(thiserror::Error, Debug)]
 pub enum CopyDirError {
+  /// General IO error encountered during copy.
   #[error("IO error: {0}")]
   Io(#[from] io::Error),
 }
 
+/// Recursively copies a directory from source to destination.
+///
+/// Uses platform-specific utilities (like `ditto` on macOS) to handle edge cases.
 pub async fn copy_dir_all(
   src: &Path,
   dst: &Path,

--- a/cat-launcher/src-tauri/src/game_release/game_release.rs
+++ b/cat-launcher/src-tauri/src/game_release/game_release.rs
@@ -14,9 +14,13 @@ use crate::variants::GameVariant;
   Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, TS,
 )]
 #[ts(export)]
+/// The type of a game release.
 pub enum ReleaseType {
+  /// A stable release, well-tested and recommended for most players.
   Stable,
+  /// A release candidate, potentially containing new features but still being tested.
   ReleaseCandidate,
+  /// An experimental release, containing the latest changes but may be unstable.
   Experimental,
 }
 
@@ -24,12 +28,19 @@ pub enum ReleaseType {
   Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, TS,
 )]
 #[ts(export)]
+/// Represents a specific release of the game.
 pub struct GameRelease {
+  /// The game variant this release belongs to.
   pub variant: GameVariant,
+  /// The version string (usually the Git tag).
   pub version: String,
+  /// The release notes or description.
   pub body: Option<String>,
+  /// The type of release (Stable, Experimental, etc.).
   pub release_type: ReleaseType,
+  /// The current installation status on the local system.
   pub status: GameReleaseStatus,
+  /// The date and time when the release was created.
   #[ts(type = "string")]
   pub created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -38,16 +49,24 @@ pub struct GameRelease {
   Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, TS,
 )]
 #[ts(export)]
+/// The possible installation statuses of a game release.
 pub enum GameReleaseStatus {
+  /// The release is not available for the current platform.
   NotAvailable,
+  /// The release has not been downloaded yet.
   NotDownloaded,
+  /// The downloaded asset is corrupted.
   Corrupted,
+  /// The release has been downloaded but not yet installed/extracted.
   NotInstalled,
+  /// The release is installed and ready to be played.
   ReadyToPlay,
+  /// The status of the release is unknown.
   Unknown,
 }
 
 impl GameRelease {
+  /// Attempts to find a compatible GitHub asset for this release based on the OS and architecture.
   pub async fn get_asset(
     &self,
     os: &OS,

--- a/cat-launcher/src-tauri/src/game_release/utils.rs
+++ b/cat-launcher/src-tauri/src/game_release/utils.rs
@@ -11,6 +11,7 @@ use crate::infra::utils::{Arch, OS};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
+/// Returns a list of substrings that identify the correct game asset for the given platform and architecture.
 pub fn get_platform_asset_substrs(
   variant: &GameVariant,
   os: &OS,
@@ -50,15 +51,19 @@ pub fn get_platform_asset_substrs(
   }
 }
 
+/// Errors that can occur when retrieving a specific game release.
 #[derive(thiserror::Error, Debug)]
 pub enum GetReleaseError {
+  /// An error occurred while retrieving the installation status of the release.
   #[error("failed to get release status: {0}")]
   Status(#[from] GetInstallationStatusError),
 
+  /// The release with the specified ID was not found.
   #[error("release with ID {0} not found")]
   NotFound(String),
 }
 
+/// Converts a `GitHubRelease` into a `GameRelease` for a specific game variant.
 pub fn gh_release_to_game_release(
   gh_release: &GitHubRelease,
   variant: &GameVariant,
@@ -76,6 +81,10 @@ pub fn gh_release_to_game_release(
   }
 }
 
+/// Retrieves a specific game release by its ID (tag name).
+///
+/// This function merges cached and default releases to find the requested release
+/// and populates its current installation status.
 pub async fn get_release_by_id(
   variant: &GameVariant,
   release_id: &str,

--- a/cat-launcher/src-tauri/src/game_tips/commands.rs
+++ b/cat-launcher/src-tauri/src/game_tips/commands.rs
@@ -10,20 +10,25 @@ use crate::variants::GameVariant;
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 
+/// Errors that can occur when executing the get tips command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetTipsCommandError {
+  /// Failed to access the app local data directory.
   #[error("failed to get data directory: {0}")]
   DataDir(#[from] tauri::Error),
 
+  /// The current operating system is not supported.
   #[error("unsupported OS: {0}")]
   UnsupportedOS(#[from] OSNotSupportedError),
 
+  /// Failed to retrieve tips for the given game variant.
   #[error("failed to get tips for variant: {0}")]
   GetForVariant(#[from] GetAllTipsForVariantError),
 }
 
+/// Tauri command to retrieve game tips for a specified game variant.
 #[command]
 pub async fn get_tips(
   app_handle: AppHandle,

--- a/cat-launcher/src-tauri/src/game_tips/lib.rs
+++ b/cat-launcher/src-tauri/src/game_tips/lib.rs
@@ -18,27 +18,35 @@ use crate::infra::utils::OS;
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving game tips for a variant.
 #[derive(Debug, Error)]
 pub enum GetAllTipsForVariantError {
+  /// Failed to determine the paths for the tips files.
   #[error("failed to get tip file paths: {0}")]
   GetTipFilePaths(#[from] GetTipFilePathsError),
 
+  /// Failed to parse the tips JSON file.
   #[error("serde json error: {0}")]
   SerdeJson(#[from] serde_json::Error),
 
+  /// Failed to retrieve the active release information.
   #[error("failed to get active release: {0}")]
   GetActiveRelease(#[from] ActiveReleaseRepositoryError),
 
+  /// A tokio IO error occurred while reading the tips file.
   #[error("tokio io error: {0}")]
   Tokio(#[from] tokio::io::Error),
 
+  /// Failed to check the installation status of a release.
   #[error("failed to get installation status: {0}")]
   GetInstallationStatus(#[from] GetInstallationStatusError),
 
+  /// Failed to retrieve cached releases from the repository.
   #[error("failed to get cached releases: {0}")]
   GetCachedReleases(#[from] ReleasesRepositoryError),
 }
 
+/// Reads all tip files associated with a specific game version and collects the text.
 async fn get_tips_from_version(
   variant: &GameVariant,
   version: &str,
@@ -68,6 +76,7 @@ async fn get_tips_from_version(
   Ok(all_tips)
 }
 
+/// Retrieves all game tips for the currently active or installed game release variant.
 pub async fn get_all_tips_for_variant(
   variant: &GameVariant,
   data_dir: &std::path::Path,

--- a/cat-launcher/src-tauri/src/game_tips/mod.rs
+++ b/cat-launcher/src-tauri/src/game_tips/mod.rs
@@ -1,3 +1,6 @@
+/// Module for retrieving and managing game tips.
 pub mod commands;
+/// Internal library for game tips logic.
 pub mod lib;
+/// Type definitions for game tips.
 pub mod types;

--- a/cat-launcher/src-tauri/src/game_tips/types.rs
+++ b/cat-launcher/src-tauri/src/game_tips/types.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
+/// Represents a collection of game tips.
 #[derive(Debug, Deserialize, Clone)]
 pub struct Tip {
+  /// The list of tip strings.
   pub text: Vec<String>,
 }

--- a/cat-launcher/src-tauri/src/infra/archive.rs
+++ b/cat-launcher/src-tauri/src/infra/archive.rs
@@ -16,6 +16,7 @@ use zip::write::FileOptions;
 use crate::filesystem::utils::{CopyDirError, copy_dir_all};
 use crate::infra::utils::OS;
 
+/// Represents errors that can occur during archive extraction.
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractionError {
   #[error("unsupported archive format")]
@@ -37,6 +38,8 @@ pub enum ExtractionError {
   Join(#[from] JoinError),
 }
 
+/// Extracts an archive at the given `archive_path` to the `target_dir` for the specified `os`.
+/// Supports zip, tar.gz, dmg, and rar formats.
 pub async fn extract_archive(
   archive_path: &Path,
   target_dir: &Path,
@@ -109,6 +112,7 @@ pub async fn extract_archive(
   }
 }
 
+/// Represents errors that can occur during archive creation.
 #[derive(thiserror::Error, Debug)]
 pub enum ArchiveCreationError {
   #[error("destination is a directory")]
@@ -130,6 +134,8 @@ pub enum ArchiveCreationError {
   Join(#[from] JoinError),
 }
 
+/// Creates a zip archive at `archive_path` containing the specified `paths_to_include`
+/// relative to the `source_dir`.
 pub async fn create_zip_archive(
   source_dir: &Path,
   paths_to_include: &[PathBuf],
@@ -178,6 +184,7 @@ pub async fn create_zip_archive(
   .await?
 }
 
+/// Represents errors that can occur while adding files to a zip archive.
 #[derive(thiserror::Error, Debug)]
 pub enum AddToZipError {
   #[error("failed to add to zip file: {0}")]

--- a/cat-launcher/src-tauri/src/infra/autoupdate/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/autoupdate/mod.rs
@@ -1,3 +1,7 @@
+//! Auto-update modules.
+
+/// Core update logic and execution.
 pub mod update;
 
+/// Status definitions for the auto-update process.
 mod update_status;

--- a/cat-launcher/src-tauri/src/infra/autoupdate/update.rs
+++ b/cat-launcher/src-tauri/src/infra/autoupdate/update.rs
@@ -3,6 +3,7 @@ use tauri_plugin_updater::UpdaterExt;
 
 use crate::infra::autoupdate::update_status::UpdateStatus;
 
+/// Checks for updates, downloads, and installs them if available, emitting progress events.
 pub async fn run_updater(handle: AppHandle) {
   // Nothing can be done with emit errors. We ignore them.
   let _ = handle.emit("autoupdate-status", &UpdateStatus::Checking);

--- a/cat-launcher/src-tauri/src/infra/autoupdate/update_status.rs
+++ b/cat-launcher/src-tauri/src/infra/autoupdate/update_status.rs
@@ -4,6 +4,7 @@ use ts_rs::TS;
 #[derive(Serialize, Clone, TS)]
 #[ts(export)]
 #[serde(tag = "type", content = "payload")]
+/// Represents the current status of the auto-update process.
 pub enum UpdateStatus {
   Checking,
   Downloading,

--- a/cat-launcher/src-tauri/src/infra/download.rs
+++ b/cat-launcher/src-tauri/src/infra/download.rs
@@ -6,6 +6,7 @@ use downloader::progress::Reporter;
 use reqwest::Client;
 use thiserror::Error;
 
+/// Represents errors that can occur during file download.
 #[derive(Error, Debug)]
 pub enum DownloadFileError {
   #[error("downloader creation failed: {0}")]
@@ -15,12 +16,14 @@ pub enum DownloadFileError {
   NoDownloadResult,
 }
 
+/// A struct for managing file downloads using a shared `reqwest::Client`.
 pub struct Downloader {
   client: Client,
   parallel_requests: NonZeroU16,
 }
 
 impl Downloader {
+  /// Creates a new `Downloader` with the given client and max parallel requests.
   pub fn new(client: Client, parallel_requests: NonZeroU16) -> Self {
     Self {
       client,
@@ -28,6 +31,7 @@ impl Downloader {
     }
   }
 
+  /// Downloads a file from the given `url` to the `download_dir` and reports progress.
   pub async fn download_file(
     &self,
     url: &str,

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -17,6 +17,8 @@ fn create_github_pat_headers() -> Option<HeaderMap> {
   None
 }
 
+/// Creates and returns a `reqwest::Client` instance configured with a user-agent
+/// and authorization headers if `GITHUB_PAT` is available in the environment.
 pub fn create_http_client() -> Client {
   let mut builder = Client::builder().user_agent("cat-launcher");
 

--- a/cat-launcher/src-tauri/src/infra/installation_progress_monitor/channel_reporter.rs
+++ b/cat-launcher/src-tauri/src/infra/installation_progress_monitor/channel_reporter.rs
@@ -5,6 +5,7 @@ use tauri::ipc::{Channel, InvokeResponseBody};
 
 use crate::infra::installation_progress_monitor::download_progress::DownloadProgress;
 
+/// Reports download progress back to the frontend via a Tauri channel.
 pub struct ChannelReporter {
   channel: Channel,
   // Use AtomicU64 for interior mutability across threads without locking.
@@ -12,6 +13,7 @@ pub struct ChannelReporter {
 }
 
 impl ChannelReporter {
+  /// Creates a new ChannelReporter.
   pub fn new(channel: Channel) -> Self {
     Self {
       channel,
@@ -21,12 +23,14 @@ impl ChannelReporter {
 }
 
 impl Reporter for ChannelReporter {
+  /// Sets up the total bytes to be downloaded.
   fn setup(&self, max_progress: Option<u64>, _message: &str) {
     if let Some(total) = max_progress {
       self.total_bytes.store(total, Ordering::Relaxed);
     }
   }
 
+  /// Sends the current download progress to the channel.
   fn progress(&self, current: u64) {
     let total_bytes = self.total_bytes.load(Ordering::Relaxed);
     let progress = DownloadProgress {

--- a/cat-launcher/src-tauri/src/infra/installation_progress_monitor/download_progress.rs
+++ b/cat-launcher/src-tauri/src/infra/installation_progress_monitor/download_progress.rs
@@ -3,7 +3,10 @@ use ts_rs::TS;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
+/// Represents the progress of a file download.
 pub struct DownloadProgress {
+  /// The number of bytes already downloaded.
   pub bytes_downloaded: u64,
+  /// The total number of bytes to be downloaded.
   pub total_bytes: u64,
 }

--- a/cat-launcher/src-tauri/src/infra/repository/db_helper.rs
+++ b/cat-launcher/src-tauri/src/infra/repository/db_helper.rs
@@ -4,6 +4,7 @@ use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use tokio::task;
 
+/// Executes a database operation within a blocking task on the thread pool.
 pub async fn run_db<F, R, E>(
   pool: Pool<SqliteConnectionManager>,
   f: F,

--- a/cat-launcher/src-tauri/src/infra/repository/db_schema.rs
+++ b/cat-launcher/src-tauri/src/infra/repository/db_schema.rs
@@ -7,6 +7,7 @@ use crate::theme::theme::Theme;
 use crate::variants::game_variant::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
+/// Errors that can occur during database schema initialization.
 pub enum InitializeSchemaError {
   #[error("failed to execute schema: {0}")]
   Execute(#[from] rusqlite::Error),
@@ -15,6 +16,8 @@ pub enum InitializeSchemaError {
   ReadFile(#[from] std::io::Error),
 }
 
+/// Initializes the database schema by executing SQL from the provided paths
+/// and populating the variants and themes tables.
 pub fn initialize_schema(
   conn: &Connection,
   schema_paths: &[PathBuf],

--- a/cat-launcher/src-tauri/src/infra/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/repository/mod.rs
@@ -1,2 +1,7 @@
+//! Repository modules.
+
+/// Database helper utilities.
 pub mod db_helper;
+
+/// Database schema initialization logic.
 pub mod db_schema;

--- a/cat-launcher/src-tauri/src/infra/rfc3339.rs
+++ b/cat-launcher/src-tauri/src/infra/rfc3339.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Deserializer, Serializer};
 
+/// Serializes a `DateTime<Utc>` to an RFC3339 formatted string.
 pub fn serialize<S>(
   date: &DateTime<Utc>,
   serializer: S,
@@ -13,6 +14,7 @@ where
   serializer.serialize_str(&s)
 }
 
+/// Deserializes an RFC3339 formatted string to a `DateTime<Utc>`.
 pub fn deserialize<'de, D>(
   deserializer: D,
 ) -> Result<DateTime<Utc>, D::Error>

--- a/cat-launcher/src-tauri/src/infra/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/utils.rs
@@ -6,12 +6,16 @@ use tokio::fs;
 
 use crate::variants::GameVariant;
 
+/// A trait for assets in the launcher.
 pub trait Asset {
+  /// Returns `true` if the asset is third-party.
   fn is_third_party(&self) -> bool;
 
+  /// Returns the ID of the asset.
   fn id(&self) -> &str;
 }
 
+/// Returns the GitHub repository string for a given game variant.
 pub fn get_github_repo_for_variant(
   variant: &GameVariant,
 ) -> &'static str {
@@ -22,6 +26,7 @@ pub fn get_github_repo_for_variant(
   }
 }
 
+/// Represents errors that can occur while reading and deserializing data from a file.
 #[derive(thiserror::Error, Debug)]
 pub enum ReadFromFileError {
   #[error("failed to read from file: {0}")]
@@ -31,6 +36,7 @@ pub enum ReadFromFileError {
   Deserialize(#[from] serde_json::Error),
 }
 
+/// Reads the content of a file at the given path and deserializes it to type `T`.
 pub async fn read_from_file<T: DeserializeOwned>(
   path: &Path,
 ) -> Result<T, ReadFromFileError> {

--- a/cat-launcher/src-tauri/src/install_release/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/commands.rs
@@ -18,26 +18,36 @@ use crate::install_release::install_release::ReleaseInstallationError;
 
 use crate::variants::GameVariant;
 
+/// Errors that can occur when executing the `install_release` command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum InstallReleaseCommandError {
+  /// The system's local data or resource directory could not be found.
   #[error("system directory not found: {0}")]
   SystemDir(#[from] tauri::Error),
 
+  /// The installation process failed.
   #[error("installation failed: {0}")]
   Install(#[from] ReleaseInstallationError),
 
+  /// Failed to retrieve the release information from the repository.
   #[error("failed to obtain release: {0}")]
   Release(#[from] GetReleaseError),
 
+  /// The current operating system is not supported.
   #[error("failed to get OS enum: {0}")]
   Os(#[from] OSNotSupportedError),
 
+  /// The current architecture is not supported.
   #[error("failed to get arch enum: {0}")]
   Arch(#[from] ArchNotSupportedError),
 }
 
+/// A Tauri command that installs a specific game release.
+///
+/// This command handles downloading the release asset and extracting it to the
+/// appropriate directory, while reporting progress via a channel.
 #[command]
 pub async fn install_release(
   app_handle: AppHandle,

--- a/cat-launcher/src-tauri/src/install_release/install_release.rs
+++ b/cat-launcher/src-tauri/src/install_release/install_release.rs
@@ -21,34 +21,51 @@ use crate::infra::github::asset::AssetDownloadError;
 use crate::infra::utils::{Arch, OS};
 use crate::install_release::installation_status::status::GetInstallationStatusError;
 
+/// Errors that can occur during the release installation process.
 #[derive(thiserror::Error, Debug)]
 pub enum ReleaseInstallationError {
+  /// Failed to determine or create the download directory.
   #[error("failed to get download directory: {0}")]
   DownloadDir(#[from] AssetDownloadDirError),
 
+  /// Failed to determine or create the extraction directory.
   #[error("failed to get extraction directory: {0}")]
   ExtractionDir(#[from] AssetExtractionDirError),
 
+  /// An error occurred with the underlying downloader.
   #[error("failed to create downloader: {0}")]
   Downloader(#[from] downloader::Error),
 
+  /// No compatible asset (OS/Arch) was found for this release.
   #[error("no compatible asset found")]
   NoCompatibleAsset,
 
+  /// Failed to download the release asset.
   #[error("failed to download asset: {0}")]
   Download(#[from] AssetDownloadError),
 
+  /// Failed to extract the downloaded archive.
   #[error("failed to extract asset: {0}")]
   Extract(#[from] ExtractionError),
 
+  /// Failed to determine the release status during or after installation.
   #[error("failed to get release status: {0}")]
   ReleaseStatus(#[from] GetInstallationStatusError),
 
+  /// Failed to update the active release in the repository.
   #[error("failed to set active release: {0}")]
   ActiveRelease(#[from] ActiveReleaseError),
 }
 
 impl GameRelease {
+  /// Installs the game release.
+  ///
+  /// This process involves:
+  /// 1. Checking the current status.
+  /// 2. Downloading the appropriate asset if not already downloaded.
+  /// 3. Extracting the asset to the installation directory.
+  /// 4. Setting this release as the active one.
+  /// 5. Cleaning up the downloaded archive and other old installations.
   #[allow(clippy::too_many_arguments)]
   pub async fn install_release(
     &mut self,

--- a/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/commands.rs
@@ -13,20 +13,25 @@ use crate::game_release::utils::{
 use crate::infra::utils::{OSNotSupportedError, get_os_enum};
 use crate::variants::GameVariant;
 
+/// Errors that can occur when getting the installation status via a Tauri command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetInstallationStatusCommandError {
+  /// The system's local data or resource directory could not be found.
   #[error("system directory not found: {0}")]
   SystemDir(#[from] tauri::Error),
 
+  /// Failed to retrieve the release information from the repository.
   #[error("failed to obtain release: {0}")]
   Release(#[from] GetReleaseError),
 
+  /// The current operating system is not supported.
   #[error("failed to get OS enum: {0}")]
   Os(#[from] OSNotSupportedError),
 }
 
+/// A Tauri command that returns the installation status of a specific release.
 #[command]
 pub async fn get_installation_status(
   app_handle: AppHandle,

--- a/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
+++ b/cat-launcher/src-tauri/src/install_release/installation_status/status.rs
@@ -11,19 +11,27 @@ use crate::game_release::game_release::{
 };
 use crate::infra::utils::OS;
 
+/// Errors that can occur when checking the installation status of a release.
 #[derive(thiserror::Error, Debug)]
 pub enum GetInstallationStatusError {
+  /// Failed to determine the asset download directory.
   #[error("failed to get asset download directory: {0}")]
   AssetDownload(#[from] AssetDownloadDirError),
 
+  /// Failed to determine the asset extraction directory.
   #[error("failed to get asset extraction directory: {0}")]
   AssetExtraction(#[from] AssetExtractionDirError),
 
+  /// Failed to determine the game executable path.
   #[error("failed to get executable directory: {0}")]
   Executable(#[from] GetExecutablePathError),
 }
 
 impl GameRelease {
+  /// Returns the current installation status of the game release.
+  ///
+  /// It checks for the existence of the game executable in the appropriate
+  /// directory for the given operating system.
   pub async fn get_installation_status(
     &self,
     os: &OS,

--- a/cat-launcher/src-tauri/src/last_played/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played/commands.rs
@@ -7,15 +7,21 @@ use crate::last_played::last_played::LastPlayedError;
 use crate::last_played::repository::sqlite_last_played_repository::SqliteLastPlayedVersionRepository;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when executing the last played version command.
 #[derive(thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize)]
 pub enum LastPlayedCommandError {
+    /// Failed to retrieve the last played version from the repository.
     #[error("failed to get last played version: {0}")]
     GetLastPlayedVersion(#[from] LastPlayedError),
 
+    /// A required system directory could not be found.
     #[error("failed to get system directory: {0}")]
     SystemDirectory(#[from] tauri::Error),
 }
 
+/// Tauri command to retrieve the last played version for a game variant.
+///
+/// Returns the version string if it exists in the repository.
 #[command]
 pub async fn get_last_played_version(
     variant: GameVariant,

--- a/cat-launcher/src-tauri/src/last_played_world/commands.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/commands.rs
@@ -8,17 +8,23 @@ use crate::last_played_world::last_played_world::{
 use crate::variants::GameVariant;
 use cat_macros::CommandErrorSerialize;
 
+/// Errors that can occur when retrieving the last played world via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetLastPlayedWorldCommandError {
+  /// An error occurred while retrieving the last played world.
   #[error("failed to get last played world: {0}")]
   GetLastPlayedWorld(#[from] GetLastPlayedWorldError),
 
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app local data directory: {0}")]
   AppLocalDataDir(#[from] tauri::Error),
 }
 
+/// Retrieves the name of the last world played for the specified game variant.
+///
+/// This command reads the `lastworld.json` file from the variant's configuration directory.
 #[command]
 pub async fn get_last_played_world(
   app_handle: AppHandle,

--- a/cat-launcher/src-tauri/src/last_played_world/last_played_world.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/last_played_world.rs
@@ -8,18 +8,23 @@ use crate::last_played_world::paths::get_last_world_path;
 use crate::last_played_world::types::LastWorld;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when reading the last played world.
 #[derive(thiserror::Error, Debug)]
 pub enum GetLastPlayedWorldError {
+  /// An error occurred while determining the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   GetUserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// An error occurred while reading the `lastworld.json` file.
   #[error("failed to read lastworld.json: {0}")]
   Read(#[from] io::Error),
 
+  /// An error occurred while parsing the `lastworld.json` file.
   #[error("failed to parse lastworld.json: {0}")]
   Parse(#[from] serde_json::Error),
 }
 
+/// Retrieves the name of the last played world for a given variant, if it exists.
 pub async fn get_last_played_world(
   data_dir: &Path,
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/last_played_world/paths.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/paths.rs
@@ -4,6 +4,7 @@ use crate::variants::GameVariant;
 use std::path::Path;
 use std::path::PathBuf;
 
+/// Returns the absolute path to the `lastworld.json` file for the specified variant.
 pub async fn get_last_world_path(
   data_dir: &Path,
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/last_played_world/types.rs
+++ b/cat-launcher/src-tauri/src/last_played_world/types.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
+/// Represents the structure of the `lastworld.json` file used by the game.
 #[derive(Deserialize)]
 pub struct LastWorld {
+  /// The name of the world that was last played.
   pub world_name: String,
 }

--- a/cat-launcher/src-tauri/src/launch_game/commands.rs
+++ b/cat-launcher/src-tauri/src/launch_game/commands.rs
@@ -15,23 +15,33 @@ use crate::launch_game::launch_game::{
 use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when executing the launch game command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum LaunchGameCommandError {
+  /// Error that occurred during the game launch or monitoring process.
   #[error("failed to launch game: {0}")]
   LaunchGame(#[from] LaunchGameError),
 
+  /// The system directory required for the operation was not found.
   #[error("system directory not found: {0}")]
   SystemDirectoryNotFound(#[from] tauri::Error),
 
+  /// Failed to retrieve the current system time.
   #[error("failed to get system time: {0}")]
   SystemTime(#[from] SystemTimeError),
 
+  /// The current operating system is not supported.
   #[error("failed to get OS enum: {0}")]
   Os(#[from] OSNotSupportedError),
 }
 
+/// Tauri command to launch and monitor a game instance.
+///
+/// This command resolves necessary paths, gets the current system time,
+/// and starts the game monitoring process. It also sets up an event emitter
+/// to forward game events to the frontend.
 #[command]
 #[allow(clippy::too_many_arguments)]
 pub async fn launch_game(

--- a/cat-launcher/src-tauri/src/launch_game/launch_game.rs
+++ b/cat-launcher/src-tauri/src/launch_game/launch_game.rs
@@ -31,73 +31,100 @@ use crate::launch_game::repository::{
 use crate::launch_game::utils::{BackupError, backup_save_files};
 use crate::variants::GameVariant;
 
+/// Errors that can occur during the game launch process.
 #[derive(thiserror::Error, Debug)]
 pub enum LaunchGameError {
+  /// Error related to the download directory.
   #[error("download directory not found: {0}")]
   DownloadDir(#[from] AssetDownloadDirError),
 
+  /// Error related to the game extraction directory.
   #[error("game directory not found: {0}")]
   GameDir(#[from] AssetExtractionDirError),
 
+  /// Error related to the game executable path.
   #[error("executable not found: {0}")]
   Executable(#[from] GetExecutablePathError),
 
+  /// The directory containing the executable could not be determined.
   #[error("executable directory not found")]
   ExecutableDir,
 
+  /// Failed to spawn the game process.
   #[error("failed to launch game: {0}")]
   Launch(#[from] io::Error),
 
+  /// Failed to backup existing save files.
   #[error("failed to backup and copy saves: {0}")]
   Backup(#[from] BackupError),
 
+  /// Error while interacting with the backup repository.
   #[error("failed to access backup repository: {0}")]
   BackupRepository(#[from] BackupRepositoryError),
 
+  /// Error related to the user's game data directory.
   #[error("failed to get user data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// Failed to capture stdout from the game process.
   #[error("failed to get stdout from child process")]
   Stdout,
 
+  /// Failed to capture stderr from the game process.
   #[error("failed to get stderr from child process")]
   Stderr,
 
+  /// Failed to retrieve information about the game release.
   #[error("failed to obtain release: {0}")]
   Release(#[from] GetReleaseError),
 
+  /// An error occurred while waiting for asynchronous subtasks to complete.
   #[error("failed to wait for subtasks: {0}")]
   Subtasks(#[from] JoinError),
 
+  /// Failed to determine the path for a backup archive.
   #[error("failed to get backup archive path: {0}")]
   BackupArchivePath(#[from] GetAutomaticBackupArchivePathError),
 
+  /// Failed to remove an old backup file.
   #[error("failed to remove backup file: {0}")]
   RemoveBackupFile(io::Error),
 }
 
+/// Events emitted during the game session.
 #[derive(Serialize, Clone, TS)]
 #[ts(export)]
 #[serde(tag = "type", content = "payload")]
 pub enum GameEvent {
+  /// A log line captured from the game's stdout or stderr.
   Log(String),
+  /// The game process has exited.
   Exit(GameExitPayload),
+  /// An error occurred during the game session.
   Error(GameErrorPayload),
 }
 
+/// Payload for the `Error` game event.
 #[derive(Serialize, Clone, serde::Deserialize, TS)]
 #[ts(export)]
 pub struct GameErrorPayload {
+  /// The error message.
   pub message: String,
 }
 
+/// Payload for the `Exit` game event.
 #[derive(Serialize, Clone, serde::Deserialize, TS)]
 #[ts(export)]
 pub struct GameExitPayload {
+  /// The exit code of the game process, if available.
   pub code: Option<i32>,
 }
 
 impl GameRelease {
+  /// Prepares the command and environment for launching this release.
+  ///
+  /// This includes setting up the executable path, creating a backup of save files,
+  /// and configuring the command arguments (e.g., `--userdir`, `--world`).
   pub async fn prepare_launch(
     &self,
     os: &OS,
@@ -156,6 +183,10 @@ impl GameRelease {
   }
 }
 
+/// Runs the game process and monitors its output.
+///
+/// Spawns the command, captures stdout and stderr, and forwards logs
+/// and the exit event via the provided `on_game_event` callback.
 pub async fn run_game_and_monitor<F, Fut>(
   mut command: Command,
   on_game_event: F,
@@ -258,6 +289,10 @@ async fn cleanup_old_backups(
   Ok(())
 }
 
+/// High-level function to launch and monitor a game release.
+///
+/// This function coordinates retrieving the release information, preparing the launch
+/// environment (including backups), and starting the monitoring task.
 #[allow(clippy::too_many_arguments)]
 pub async fn launch_and_monitor_game<F, Fut>(
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/launch_game/mod.rs
+++ b/cat-launcher/src-tauri/src/launch_game/mod.rs
@@ -1,4 +1,10 @@
+//! Game launch orchestration module.
+
+/// Tauri commands for launching the game.
 pub mod commands;
+/// Core game launch logic.
 pub mod launch_game;
+/// Repository for persistence related to game launches.
 pub mod repository;
+/// Utilities for game launch-related operations.
 pub mod utils;

--- a/cat-launcher/src-tauri/src/launch_game/repository/backup_repository.rs
+++ b/cat-launcher/src-tauri/src/launch_game/repository/backup_repository.rs
@@ -4,32 +4,44 @@ use ts_rs::TS;
 
 use crate::variants::GameVariant;
 
+/// Represents a single backup entry in the repository.
 #[derive(Debug, Clone, Serialize, TS)]
 #[ts(export)]
 pub struct BackupEntry {
+  /// Unique identifier for the backup entry.
   pub id: i64,
+  /// The game variant this backup belongs to.
   pub game_variant: GameVariant,
+  /// The version of the release when the backup was created.
   pub release_version: String,
+  /// Unix timestamp when the backup was created.
   pub timestamp: u64,
 }
 
+/// Errors that can occur during backup repository operations.
 #[derive(thiserror::Error, Debug)]
 pub enum BackupRepositoryError {
+  /// Failed to add a new backup entry.
   #[error("failed to add backup entry: {0}")]
   Add(Box<dyn std::error::Error + Send + Sync>),
 
+  /// Failed to retrieve backup entries.
   #[error("failed to get backup entries: {0}")]
   Get(Box<dyn std::error::Error + Send + Sync>),
 
+  /// Failed to delete a backup entry.
   #[error("failed to delete backup entry: {0}")]
   Delete(Box<dyn std::error::Error + Send + Sync>),
 
+  /// The requested backup entry was not found.
   #[error("backup entry with id {0} not found")]
   NotFound(i64),
 }
 
+/// Trait defining the operations for managing game backups.
 #[async_trait]
 pub trait BackupRepository: Send + Sync {
+  /// Adds a new backup entry to the repository.
   async fn add_backup_entry(
     &self,
     game_variant: &GameVariant,
@@ -37,16 +49,19 @@ pub trait BackupRepository: Send + Sync {
     timestamp: u64,
   ) -> Result<i64, BackupRepositoryError>;
 
+  /// Retrieves all backup entries for a specific game variant, sorted by timestamp.
   async fn get_backups_sorted_by_timestamp(
     &self,
     game_variant: &GameVariant,
   ) -> Result<Vec<BackupEntry>, BackupRepositoryError>;
 
+  /// Retrieves a specific backup entry by its ID.
   async fn get_backup_entry(
     &self,
     id: i64,
   ) -> Result<BackupEntry, BackupRepositoryError>;
 
+  /// Deletes a backup entry from the repository by its ID.
   async fn delete_backup_entry(
     &self,
     id: i64,

--- a/cat-launcher/src-tauri/src/launch_game/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/launch_game/repository/mod.rs
@@ -1,4 +1,8 @@
+//! Repository module for game launch-related data persistence.
+
+/// Repository traits and types for managing backups.
 pub mod backup_repository;
+/// SQLite implementation of the backup repository.
 pub mod sqlite_backup_repository;
 
 pub use backup_repository::{

--- a/cat-launcher/src-tauri/src/launch_game/repository/sqlite_backup_repository.rs
+++ b/cat-launcher/src-tauri/src/launch_game/repository/sqlite_backup_repository.rs
@@ -11,12 +11,14 @@ use crate::variants::GameVariant;
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A SQLite-backed implementation of the [`BackupRepository`] trait.
 #[derive(Clone)]
 pub struct SqliteBackupRepository {
   pool: Pool,
 }
 
 impl SqliteBackupRepository {
+  /// Creates a new instance of [`SqliteBackupRepository`] with the given connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/launch_game/utils.rs
+++ b/cat-launcher/src-tauri/src/launch_game/utils.rs
@@ -10,18 +10,26 @@ use crate::infra::archive::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur during the backup of game save files.
 #[derive(thiserror::Error, Debug)]
 pub enum BackupError {
+  /// Failed to determine the path for the backup archive.
   #[error("failed to get backup archive path: {0}")]
   BackupArchivePath(#[from] GetAutomaticBackupArchivePathError),
 
+  /// Failed to create the zip archive for the backup.
   #[error("failed to create archive: {0}")]
   ArchiveCreation(#[from] ArchiveCreationError),
 
+  /// Failed to locate or create the user's game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
 }
 
+/// Backs up game save files for a specific game variant.
+///
+/// This function creates a zip archive containing the 'save' directory
+/// from the user's game data folder.
 pub async fn backup_save_files(
   variant: &GameVariant,
   id: i64,

--- a/cat-launcher/src-tauri/src/mods/get_third_party_mod_by_id.rs
+++ b/cat-launcher/src-tauri/src/mods/get_third_party_mod_by_id.rs
@@ -4,12 +4,15 @@ use crate::mods::repository::mods_repository::{
 use crate::mods::types::ThirdPartyMod;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving a third-party mod by its ID.
 #[derive(thiserror::Error, Debug)]
 pub enum GetThirdPartyModByIdError {
+  /// Failed to retrieve the mod from the repository.
   #[error("failed to get mod from repository: {0}")]
   Repository(#[from] RepoError),
 }
 
+/// Retrieves a third-party mod by its ID for a specific game variant.
 pub async fn get_third_party_mod_by_id(
   mod_id: &str,
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/mods/get_third_party_mod_installation_status.rs
+++ b/cat-launcher/src-tauri/src/mods/get_third_party_mod_installation_status.rs
@@ -4,12 +4,15 @@ use crate::mods::repository::installed_mods_repository::{
 use crate::mods::types::ModInstallationStatus;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when checking the installation status of a third-party mod.
 #[derive(thiserror::Error, Debug)]
 pub enum GetThirdPartyModInstallationStatusError {
+  /// Failed to check mod installation status via the repository.
   #[error("failed to check mod installation status: {0}")]
   Repository(#[from] InstalledModsRepositoryError),
 }
 
+/// Checks the installation status of a third-party mod for a specific game variant.
 pub async fn get_third_party_mod_installation_status(
   mod_id: &str,
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/mods/types.rs
+++ b/cat-launcher/src-tauri/src/mods/types.rs
@@ -1,3 +1,5 @@
+//! Types related to game mods.
+
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -7,43 +9,63 @@ pub use crate::mods::online::types::{
 };
 use crate::variants::GameVariant;
 
+/// Represents mod installation information.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ModInstallation {
+  /// The URL to download the mod from.
   pub download_url: String,
+  /// The mod information JSON or similar structure.
   pub modinfo: String,
 }
 
+/// Represents the type of activity associated with a mod.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(tag = "activity_type")]
 pub enum ModActivity {
+  /// GitHub repository commit information.
   #[serde(rename = "github_commit")]
   GithubCommit { github: String },
 }
 
+/// Represents a third-party mod.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ThirdPartyMod {
+  /// Unique identifier for the mod.
   pub id: String,
+  /// Name of the mod.
   pub name: String,
+  /// Description of the mod.
   pub description: String,
+  /// Category the mod belongs to.
   pub category: String,
+  /// Installation details.
   pub installation: ModInstallation,
+  /// Optional activity metadata.
   pub activity: Option<ModActivity>,
 }
 
+/// Represents a stock mod included in the game release.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct StockMod {
+  /// Unique identifier for the mod.
   pub id: String,
+  /// Name of the mod.
   pub name: String,
+  /// Description of the mod.
   pub description: String,
+  /// Category the mod belongs to.
   pub category: String,
 }
 
+/// Enumerates the different types of mods.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(tag = "type", content = "content")]
 pub enum Mod {
+  /// A built-in stock mod.
   Stock(StockMod),
+  /// A third-party community mod.
   ThirdParty(ThirdPartyMod),
 }
 
@@ -60,25 +82,35 @@ impl Asset for Mod {
   }
 }
 
+/// Represents the installation status of a mod.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub enum ModInstallationStatus {
+  /// The mod is currently installed.
   Installed,
+  /// The mod is not installed.
   NotInstalled,
 }
 
+/// Payload sent when updating mod information.
 #[derive(Debug, Clone, Serialize, TS)]
 #[ts(export)]
 pub struct ModsUpdatePayload {
+  /// The game variant the updates pertain to.
   pub variant: GameVariant,
+  /// The list of mods.
   pub mods: Vec<Mod>,
+  /// The status of the update process.
   pub status: ModsUpdateStatus,
 }
 
+/// Represents the status of a mod update operation.
 #[derive(Debug, Clone, Serialize, TS, PartialEq, Eq)]
 #[ts(export)]
 pub enum ModsUpdateStatus {
+  /// The mods are currently being fetched.
   Fetching,
+  /// The fetch operation succeeded.
   Success,
   /// Reserved for future use when errors are streamed via the update channel
   /// instead of being returned as a command Result.

--- a/cat-launcher/src-tauri/src/mods/uninstall_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/uninstall_third_party_mod.rs
@@ -9,16 +9,24 @@ use crate::mods::repository::installed_mods_repository::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when uninstalling a third-party mod.
 #[derive(thiserror::Error, Debug)]
 pub enum UninstallThirdPartyModError {
+  /// Error while interacting with the installed mods repository.
   #[error("failed to remove installed mod from repository: {0}")]
   Repository(#[from] InstalledModsRepositoryError),
+  /// Error related to the user's game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
+  /// Failed to delete the mod's directory from the filesystem.
   #[error("failed to delete mod directory: {0}")]
   DeleteModDirectory(#[from] io::Error),
 }
 
+/// Uninstalls a third-party mod for a specific game variant.
+///
+/// This involves removing the mod's record from the repository and
+/// deleting its corresponding directory in the game's data folder.
 pub async fn uninstall_third_party_mod(
   mod_id: &str,
   game_variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/play_time/commands.rs
+++ b/cat-launcher/src-tauri/src/play_time/commands.rs
@@ -12,22 +12,27 @@ use crate::play_time::repository::PlayTimeRepositoryError;
 use crate::play_time::sqlite_play_time_repository::SqlitePlayTimeRepository;
 use crate::variants::game_variant::GameVariant;
 
+/// Errors that can occur when retrieving play time.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetPlayTimeCommandError {
+  /// An error occurred in the play time repository.
   #[error("Failed to get play time: {0}")]
   Repository(#[from] PlayTimeRepositoryError),
 }
 
+/// Errors that can occur when logging play time.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum LogPlayTimeCommandError {
+  /// An error occurred in the play time repository.
   #[error("Failed to log play time: {0}")]
   Repository(#[from] PlayTimeRepositoryError),
 }
 
+/// Retrieves the total play time for a specific game variant.
 #[tauri::command]
 pub async fn get_play_time_for_variant(
   variant: GameVariant,
@@ -38,6 +43,7 @@ pub async fn get_play_time_for_variant(
   Ok(result)
 }
 
+/// Retrieves the play time for a specific version of a game variant.
 #[tauri::command]
 pub async fn get_play_time_for_version(
   variant: GameVariant,
@@ -53,6 +59,7 @@ pub async fn get_play_time_for_version(
   Ok(result)
 }
 
+/// Logs play time for a specific version of a game variant.
 #[tauri::command]
 pub async fn log_play_time(
   variant: GameVariant,

--- a/cat-launcher/src-tauri/src/play_time/play_time.rs
+++ b/cat-launcher/src-tauri/src/play_time/play_time.rs
@@ -3,6 +3,7 @@ use crate::play_time::repository::{
 };
 use crate::variants::game_variant::GameVariant;
 
+/// Retrieves the total play time for a specific game variant from the repository.
 pub async fn get_play_time_for_variant(
   game_variant: &GameVariant,
   play_time_repository: &impl PlayTimeRepository,
@@ -12,6 +13,7 @@ pub async fn get_play_time_for_variant(
     .await
 }
 
+/// Retrieves the play time for a specific version of a game variant from the repository.
 pub async fn get_play_time_for_version(
   game_variant: &GameVariant,
   version: &str,
@@ -22,6 +24,7 @@ pub async fn get_play_time_for_version(
     .await
 }
 
+/// Logs play time for a specific version of a game variant in the repository.
 pub async fn log_play_time(
   game_variant: &GameVariant,
   version: &str,

--- a/cat-launcher/src-tauri/src/play_time/repository.rs
+++ b/cat-launcher/src-tauri/src/play_time/repository.rs
@@ -2,29 +2,38 @@ use async_trait::async_trait;
 
 use crate::variants::GameVariant;
 
+/// Errors that can occur when interacting with the play time repository.
 #[derive(thiserror::Error, Debug)]
 pub enum PlayTimeRepositoryError {
+  /// An error occurred while logging play time.
   #[error("Failed to log play time: {0}")]
   LogPlayTime(Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while retrieving play time for a specific version.
   #[error("Failed to get play time for version: {0}")]
   GetPlayTimeForVersion(Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while retrieving play time for a specific variant.
   #[error("Failed to get play time for variant: {0}")]
   GetPlayTimeForVariant(Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while retrieving the total play time across all variants.
   #[error("Failed to get total play time: {0}")]
   GetTotalPlayTime(Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while waiting for a background task to complete.
   #[error("Task join error: {0}")]
   JoinError(Box<dyn std::error::Error + Send + Sync>),
 
+  /// The provided duration is invalid (e.g., negative).
   #[error("Invalid duration: {0}")]
   InvalidDuration(i64),
 }
 
+/// A repository for managing play time data.
 #[async_trait]
 pub trait PlayTimeRepository: Send + Sync {
+  /// Logs play time for a specific version of a game variant.
   async fn log_play_time(
     &self,
     game_variant: &GameVariant,
@@ -32,12 +41,14 @@ pub trait PlayTimeRepository: Send + Sync {
     duration_in_seconds: i64,
   ) -> Result<(), PlayTimeRepositoryError>;
 
+  /// Retrieves the play time for a specific version of a game variant.
   async fn get_play_time_for_version(
     &self,
     game_variant: &GameVariant,
     version: &str,
   ) -> Result<i64, PlayTimeRepositoryError>;
 
+  /// Retrieves the total play time for a specific game variant.
   async fn get_play_time_for_variant(
     &self,
     game_variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/play_time/sqlite_play_time_repository.rs
+++ b/cat-launcher/src-tauri/src/play_time/sqlite_play_time_repository.rs
@@ -9,12 +9,14 @@ use crate::play_time::repository::{
 };
 use crate::variants::GameVariant;
 
+/// A repository for managing play time data using a SQLite database.
 #[derive(Clone)]
 pub struct SqlitePlayTimeRepository {
   pool: Pool<SqliteConnectionManager>,
 }
 
 impl SqlitePlayTimeRepository {
+  /// Creates a new instance of `SqlitePlayTimeRepository` with the given connection pool.
   pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/settings/colors.rs
+++ b/cat-launcher/src-tauri/src/settings/colors.rs
@@ -13,20 +13,25 @@ use crate::infra::utils::OS;
 use crate::settings::types::ColorTheme;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving available color themes.
 #[derive(thiserror::Error, Debug)]
 pub enum GetColorThemesError {
+  /// An error occurred while determining the game resources directory.
   #[error("failed to get game resources directory: {0}")]
   ResourcesDir(
     #[from] crate::filesystem::paths::GetGameExecutableDirError,
   ),
 
+  /// An error occurred while reading a directory.
   #[error("failed to read directory: {0}")]
   ReadDir(#[from] std::io::Error),
 
+  /// An error occurred while retrieving the active release.
   #[error("failed to get active release: {0}")]
   ActiveRelease(#[from] ActiveReleaseRepositoryError),
 }
 
+/// Retrieves all available color themes, including bundled and game-specific ones.
 pub async fn get_available_color_themes(
   data_dir: &Path,
   resource_dir: &Path,

--- a/cat-launcher/src-tauri/src/settings/commands.rs
+++ b/cat-launcher/src-tauri/src/settings/commands.rs
@@ -18,14 +18,17 @@ use crate::settings::types::{ColorTheme, Font};
 use crate::settings::update_settings::{self, UpdateSettingsError};
 use crate::settings::Settings;
 
+/// Errors that can occur when retrieving available fonts.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetFontsError {
+  /// The current operating system is not supported.
   #[error("failed to get fonts: {0}")]
   OS(#[from] OSNotSupportedError),
 }
 
+/// Retrieves a list of all monospaced fonts available on the system.
 #[command]
 pub async fn get_fonts() -> Result<Vec<Font>, GetFontsError> {
   let os_str = std::env::consts::OS;
@@ -33,20 +36,25 @@ pub async fn get_fonts() -> Result<Vec<Font>, GetFontsError> {
   Ok(get_all_fonts(os).await)
 }
 
+/// Errors that can occur when retrieving color themes.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetColorThemesCommandError {
+  /// An error occurred while retrieving color themes from the filesystem.
   #[error("failed to get color themes: {0}")]
   Get(#[from] GetColorThemesError),
 
+  /// An error occurred while determining the app local data directory.
   #[error("failed to get app local data directory: {0}")]
   AppLocalDataDir(#[from] tauri::Error),
 
+  /// The current operating system is not supported.
   #[error("failed to get os: {0}")]
   OS(#[from] OSNotSupportedError),
 }
 
+/// Retrieves all available color themes, including bundled and game-specific ones.
 #[command]
 pub async fn get_color_themes(
   app_handle: AppHandle,
@@ -66,14 +74,17 @@ pub async fn get_color_themes(
   Ok(themes)
 }
 
+/// Errors that can occur when retrieving application settings.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetSettingsCommandError {
+  /// An error occurred while retrieving settings from the repository.
   #[error("failed to get settings: {0}")]
   Get(#[from] GetSettingsError),
 }
 
+/// Retrieves the current application settings.
 #[command]
 pub async fn get_settings(
   repository: State<'_, SqliteSettingsRepository>,
@@ -82,17 +93,21 @@ pub async fn get_settings(
   Ok(settings)
 }
 
+/// Errors that can occur when updating application settings.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum UpdateSettingsCommandError {
+  /// An error occurred while updating settings.
   #[error("failed to update settings: {0}")]
   Update(#[from] UpdateSettingsError),
 
+  /// An error occurred while determining the app local data directory.
   #[error("failed to get app local data directory: {0}")]
   AppLocalDataDir(#[from] tauri::Error),
 }
 
+/// Updates the application settings and synchronizes them with the game configurations.
 #[command]
 pub async fn update_settings(
   app_handle: AppHandle,
@@ -110,6 +125,7 @@ pub async fn update_settings(
   Ok(())
 }
 
+/// Returns the default application settings.
 #[command]
 pub fn get_default_settings() -> Settings {
   Settings::default()

--- a/cat-launcher/src-tauri/src/settings/consts.rs
+++ b/cat-launcher/src-tauri/src/settings/consts.rs
@@ -1,2 +1,3 @@
+/// A list of relative paths to fonts bundled with the launcher to be used as fallbacks.
 pub const FALLBACK_FONTS: &[&str] =
   &["data/font/Terminus.ttf", "data/font/unifont.ttf"];

--- a/cat-launcher/src-tauri/src/settings/paths.rs
+++ b/cat-launcher/src-tauri/src/settings/paths.rs
@@ -7,15 +7,19 @@ use crate::filesystem::paths::{
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving or creating the user configuration directory.
 #[derive(Debug, thiserror::Error)]
 pub enum GetOrCreateUserConfigDirError {
+  /// An error occurred while retrieving the user game data directory.
   #[error("Failed to get or create user game data directory")]
   GameDataDir(#[from] GetUserGameDataDirError),
 
+  /// An error occurred while creating the configuration directory.
   #[error("Failed to create config directory: {0}")]
   CreateDirFailed(#[from] io::Error),
 }
 
+/// Retrieves the path to the user's configuration directory for a specific game variant, creating it if it doesn't exist.
 pub async fn get_or_create_user_config_dir(
   variant: &GameVariant,
   data_dir: &Path,
@@ -27,6 +31,7 @@ pub async fn get_or_create_user_config_dir(
   Ok(config_dir)
 }
 
+/// Returns a list of standard directories where fonts are typically stored on the given operating system.
 pub fn get_font_directories(os: &OS) -> Vec<PathBuf> {
   let mut paths = Vec::new();
   let home = std::env::var("HOME")

--- a/cat-launcher/src-tauri/src/settings/repository/settings_repository.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/settings_repository.rs
@@ -4,22 +4,29 @@ use async_trait::async_trait;
 
 use crate::settings::Settings;
 
+/// Errors that can occur when retrieving settings from the repository.
 #[derive(thiserror::Error, Debug)]
 pub enum GetSettingsError {
+  /// An error occurred while retrieving settings.
   #[error("failed to get settings: {0}")]
   Get(#[source] Box<dyn Error + Send + Sync>),
 }
 
+/// Errors that can occur when saving settings to the repository.
 #[derive(thiserror::Error, Debug)]
 pub enum SaveSettingsError {
+  /// An error occurred while saving settings.
   #[error("failed to save settings: {0}")]
   Save(#[source] Box<dyn Error + Send + Sync>),
 }
 
+/// A repository for managing application settings.
 #[async_trait]
 pub trait SettingsRepository: Send + Sync {
+  /// Retrieves the current application settings.
   async fn get_settings(&self) -> Result<Settings, GetSettingsError>;
 
+  /// Saves the provided application settings.
   async fn save_settings(
     &self,
     settings: &Settings,

--- a/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
+++ b/cat-launcher/src-tauri/src/settings/repository/sqlite_settings_repository.rs
@@ -14,12 +14,14 @@ use crate::settings::types::ColorTheme;
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A repository for managing application settings using a SQLite database.
 #[derive(Clone)]
 pub struct SqliteSettingsRepository {
   pool: Pool,
 }
 
 impl SqliteSettingsRepository {
+  /// Creates a new instance of `SqliteSettingsRepository` with the given connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/settings/settings.rs
+++ b/cat-launcher/src-tauri/src/settings/settings.rs
@@ -4,19 +4,25 @@ use ts_rs::TS;
 
 use crate::settings::types::{ColorTheme, Font};
 
+/// Represents the application-wide settings.
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
 #[ts(export)]
 #[derive(Default)]
 pub struct Settings {
+  /// The selected font for the game.
   pub font: Option<Font>,
+  /// The selected color theme for the game.
   pub color_theme: Option<ColorTheme>,
 }
 
+/// Errors that can occur when loading settings from a file.
 #[derive(Debug, Error)]
 pub enum LoadSettingsError {
+  /// An error occurred while opening the settings file.
   #[error("Could not open settings.json")]
   OpenFile(#[source] std::io::Error),
 
+  /// An error occurred while parsing the settings file.
   #[error("Could not parse settings.json")]
   Parse(#[from] serde_json::Error),
 }

--- a/cat-launcher/src-tauri/src/settings/types.rs
+++ b/cat-launcher/src-tauri/src/settings/types.rs
@@ -3,26 +3,36 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+/// Represents a font available on the system.
 #[derive(
   Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq, Hash,
 )]
 #[ts(export)]
 pub struct Font {
+  /// The display name of the font.
   pub name: String,
+  /// The absolute path to the font file.
   pub path: String,
 }
 
+/// Represents a color theme for the game.
 #[derive(
   Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq, Hash,
 )]
 #[ts(export)]
 pub struct ColorTheme {
+  /// A unique identifier for the theme.
   pub id: String,
+  /// The display name of the theme.
   pub name: String,
+  /// The absolute path to the theme's configuration file.
   pub path: String,
 }
 
 impl ColorTheme {
+  /// Attempts to create a `ColorTheme` from a file path.
+  ///
+  /// The filename must start with `base_colors-` or `base_colors_` and end with `.json`.
   pub fn from_path(path: &Path) -> Option<Self> {
     let filename = path.file_name()?.to_str()?;
 

--- a/cat-launcher/src-tauri/src/settings/update_color_files.rs
+++ b/cat-launcher/src-tauri/src/settings/update_color_files.rs
@@ -9,18 +9,23 @@ use crate::settings::paths::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when updating color theme files.
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateColorFilesError {
+  /// An error occurred while retrieving the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// An error occurred while retrieving or creating the user config directory.
   #[error("failed to get or create user config directory: {0}")]
   GetOrCreateUserConfigDir(#[from] GetOrCreateUserConfigDirError),
 
+  /// An error occurred while copying the color theme file.
   #[error("failed to copy color theme file: {0}")]
   Copy(#[from] std::io::Error),
 }
 
+/// Synchronizes the selected color theme with the game's `base_colors.json` configuration file.
 pub async fn update_color_files(
   data_dir: &Path,
   settings: &Settings,

--- a/cat-launcher/src-tauri/src/settings/update_font_files.rs
+++ b/cat-launcher/src-tauri/src/settings/update_font_files.rs
@@ -12,42 +12,55 @@ use crate::settings::paths::{
 use crate::settings::types::Font;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when ensuring font blending is enabled in the game options.
 #[derive(thiserror::Error, Debug)]
 pub enum EnsureFontBlendingError {
+  /// An error occurred while reading `options.json`.
   #[error("failed to read existing options.json: {0}")]
   ReadOptionsJson(#[source] std::io::Error),
 
+  /// An error occurred while parsing or serializing JSON data.
   #[error("failed to serialize JSON: {0}")]
   Json(#[from] serde_json::Error),
 
+  /// An error occurred while writing `options.json`.
   #[error("failed to write options.json: {0}")]
   WriteOptionsJson(#[source] std::io::Error),
 
+  /// The `options.json` file has an invalid format.
   #[error("bad options.json file")]
   BadOptionsJson,
 }
 
+/// Errors that can occur when updating font configuration files.
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateFontFilesError {
+  /// An error occurred while retrieving the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// An error occurred while retrieving or creating the user config directory.
   #[error("failed to get or create user config directory: {0}")]
   GetOrCreateUserConfigDir(#[from] GetOrCreateUserConfigDirError),
 
+  /// An error occurred while reading `fonts.json`.
   #[error("failed to read existing fonts.json: {0}")]
   ReadFontsJson(#[source] std::io::Error),
 
+  /// An error occurred while parsing or serializing JSON data.
   #[error("failed to serialize JSON: {0}")]
   Json(#[from] serde_json::Error),
 
+  /// An error occurred while writing `fonts.json`.
   #[error("failed to write fonts.json: {0}")]
   WriteFontsJson(#[source] std::io::Error),
 
+  /// An error occurred while ensuring font blending is enabled.
   #[error("failed to ensure font blending: {0}")]
   EnsureFontBlending(#[from] EnsureFontBlendingError),
 }
 
+/// Synchronizes the selected font with the game's `fonts.json` configuration file.
 pub async fn update_font_files(
   data_dir: &Path,
   settings: &Settings,

--- a/cat-launcher/src-tauri/src/settings/update_settings.rs
+++ b/cat-launcher/src-tauri/src/settings/update_settings.rs
@@ -11,18 +11,23 @@ use crate::settings::update_font_files::{
   UpdateFontFilesError, update_font_files,
 };
 
+/// Errors that can occur when updating settings.
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateSettingsError {
+  /// An error occurred while updating font files.
   #[error("failed to update font files: {0}")]
   UpdateFontFiles(#[from] UpdateFontFilesError),
 
+  /// An error occurred while updating color files.
   #[error("failed to update color files: {0}")]
   UpdateColorFiles(#[from] UpdateColorFilesError),
 
+  /// An error occurred while saving settings to the repository.
   #[error("failed to update settings in repository: {0}")]
   Repository(#[from] SaveSettingsError),
 }
 
+/// Updates the application settings and synchronizes them with the game's configuration files.
 pub async fn update_settings(
   data_dir: &Path,
   settings: &Settings,

--- a/cat-launcher/src-tauri/src/soundpacks/commands.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/commands.rs
@@ -25,20 +25,25 @@ use crate::soundpacks::uninstall_third_party_soundpack::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when listing all soundpacks via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum ListAllSoundpacksCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while retrieving OS information.
   #[error("failed to get OS information")]
   OSInfo(#[from] OSNotSupportedError),
 
+  /// An error occurred while listing the soundpacks.
   #[error("failed to list soundpacks: {0}")]
   ListSoundpacks(#[from] ListAllSoundpacksError),
 }
 
+/// Lists all available soundpacks (both stock and third-party) for a game variant.
 #[tauri::command]
 pub async fn list_all_soundpacks_command(
   variant: GameVariant,
@@ -62,20 +67,25 @@ pub async fn list_all_soundpacks_command(
   Ok(soundpacks)
 }
 
+/// Errors that can occur when installing a third-party soundpack via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum InstallThirdPartySoundpackCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while retrieving OS information.
   #[error("failed to get OS information")]
   OSInfo(#[from] OSNotSupportedError),
 
+  /// An error occurred while installing the soundpack.
   #[error("failed to install soundpack: {0}")]
   Install(#[from] InstallThirdPartySoundpackError),
 }
 
+/// Installs a third-party soundpack for a game variant.
 #[tauri::command]
 pub async fn install_third_party_soundpack_command(
   id: String,
@@ -109,17 +119,21 @@ pub async fn install_third_party_soundpack_command(
   Ok(())
 }
 
+/// Errors that can occur when uninstalling a third-party soundpack via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum UninstallThirdPartySoundpackCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory: {0}")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while uninstalling the soundpack.
   #[error("failed to uninstall soundpack: {0}")]
   Uninstall(#[from] UninstallThirdPartySoundpackError),
 }
 
+/// Uninstalls a previously installed third-party soundpack.
 #[tauri::command]
 pub async fn uninstall_third_party_soundpack_command(
   id: String,
@@ -139,14 +153,17 @@ pub async fn uninstall_third_party_soundpack_command(
   Ok(())
 }
 
+/// Errors that can occur when retrieving the installation status of a third-party soundpack via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetThirdPartySoundpackInstallationStatusCommandError {
+  /// An error occurred while getting the installation status.
   #[error("failed to get soundpack installation status: {0}")]
   GetStatus(#[from] GetThirdPartySoundpackInstallationStatusError),
 }
 
+/// Retrieves the current installation status of a third-party soundpack.
 #[tauri::command]
 pub async fn get_third_party_soundpack_installation_status_command(
   id: String,

--- a/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/list_all_soundpacks.rs
@@ -19,21 +19,27 @@ use crate::soundpacks::types::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when listing all soundpacks.
 #[derive(thiserror::Error, Debug)]
 pub enum ListAllSoundpacksError {
+  /// An error occurred while determining the stock soundpacks directory.
   #[error("failed to get stock soundpacks dir: {0}")]
   GetStockSoundpacksDir(#[from] GetStockSoundpacksDirError),
 
+  /// An error occurred while listing stock soundpacks.
   #[error("failed to read stock soundpack dir: {0}")]
   ExtractStockSoundpack(#[from] ListAllStockSoundpacksError),
 
+  /// An error occurred while retrieving the active release version.
   #[error("failed to get active release: {0}")]
   GetActiveRelease(#[from] ActiveReleaseRepositoryError),
 
+  /// An error occurred while listing third-party soundpacks.
   #[error("failed to list third-party soundpacks: {0}")]
   ListThirdPartySoundpacks(#[from] ListThirdPartySoundpacksError),
 }
 
+/// Lists all available soundpacks (both stock and third-party) for a game variant.
 pub async fn list_all_soundpacks(
   game_variant: &GameVariant,
   data_dir: &Path,
@@ -72,10 +78,13 @@ pub async fn list_all_soundpacks(
   Ok(soundpacks)
 }
 
+/// Errors that can occur when extracting stock soundpack information.
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractStockSoundpackError {
+  /// An error occurred while reading the `soundpack.txt` file.
   #[error("failed to read soundpack.txt: {0}")]
   ReadSoundpackTxt(#[from] io::Error),
+  /// A required field is missing from `soundpack.txt`.
   #[error("missing field in soundpack.txt: {0}")]
   MissingField(String),
 }
@@ -117,8 +126,10 @@ async fn extract_stock_soundpack_from_soundpack_txt(
   Ok(StockSoundpack { id, name })
 }
 
+/// Errors that can occur when listing all stock soundpacks.
 #[derive(Debug, thiserror::Error)]
 pub enum ListAllStockSoundpacksError {
+  /// An error occurred while reading the stock soundpacks directory.
   #[error("failed to read stock soundpacks directory: {0}")]
   ReadDir(#[from] io::Error),
 }
@@ -161,11 +172,14 @@ async fn list_all_stock_soundpacks(
   Ok(soundpacks)
 }
 
+/// Errors that can occur when listing third-party soundpacks.
 #[derive(thiserror::Error, Debug)]
 pub enum ListThirdPartySoundpacksError {
+  /// An error occurred while reading the `soundpacks.json` file.
   #[error("failed to read soundpacks.json: {0}")]
   ReadSoundpacksJson(#[from] io::Error),
 
+  /// An error occurred while parsing the `soundpacks.json` file.
   #[error("failed to parse soundpacks.json: {0}")]
   ParseSoundpacksJson(#[from] serde_json::Error),
 }

--- a/cat-launcher/src-tauri/src/soundpacks/paths.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/paths.rs
@@ -6,12 +6,15 @@ use crate::filesystem::paths::{
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when determining the stock soundpacks directory.
 #[derive(thiserror::Error, Debug)]
 pub enum GetStockSoundpacksDirError {
+  /// An error occurred while determining the game resources directory.
   #[error("failed to get game resources directory: {0}")]
   GameResourcesDir(#[from] GetGameExecutableDirError),
 }
 
+/// Returns the absolute path to the stock soundpacks directory for a given game variant and version.
 pub async fn get_stock_soundpacks_dir(
   variant: &GameVariant,
   release_version: &str,
@@ -25,6 +28,7 @@ pub async fn get_stock_soundpacks_dir(
   Ok(game_resources_dir.join("data").join("sound"))
 }
 
+/// Returns the path to the soundpacks metadata resource file.
 pub fn get_soundpacks_resource_path(resource_dir: &Path) -> PathBuf {
   resource_dir.join("content").join("soundpacks.json")
 }

--- a/cat-launcher/src-tauri/src/soundpacks/repository/installed_soundpacks_repository.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/repository/installed_soundpacks_repository.rs
@@ -4,45 +4,56 @@ use async_trait::async_trait;
 
 use crate::variants::GameVariant;
 
+/// Errors that can occur when interacting with the installed soundpacks repository.
 #[derive(thiserror::Error, Debug)]
 pub enum InstalledSoundpacksRepositoryError {
+  /// An error occurred while adding an installed soundpack.
   #[error("failed to add installed soundpack: {0}")]
   Add(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while deleting an installed soundpack.
   #[error("failed to delete installed soundpack: {0}")]
   Delete(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while deleting all installed soundpacks.
   #[error("failed to delete all installed soundpacks: {0}")]
   DeleteAll(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while checking if a soundpack is installed.
   #[error("failed to check if soundpack is installed: {0}")]
   IsInstalled(#[source] Box<dyn Error + Send + Sync>),
 
+  /// The specified installed soundpack was not found.
   #[error(
     "installed soundpack with id {0} not found for variant {1}"
   )]
   NotFound(String, String),
 }
 
+/// A repository for managing records of installed third-party soundpacks.
 #[async_trait]
 pub trait InstalledSoundpacksRepository: Send + Sync {
+  /// Adds a record indicating that a soundpack has been installed for a specific game variant.
   async fn add_installed_soundpack(
     &self,
     soundpack_id: &str,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledSoundpacksRepositoryError>;
 
+  /// Deletes the record of an installed soundpack for a specific game variant.
   async fn delete_installed_soundpack(
     &self,
     soundpack_id: &str,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledSoundpacksRepositoryError>;
 
+  /// Deletes all records of installed soundpacks for a specific game variant.
   async fn delete_all_installed_soundpacks(
     &self,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledSoundpacksRepositoryError>;
 
+  /// Checks if a record exists for an installed soundpack for a specific game variant.
   async fn is_soundpack_installed(
     &self,
     soundpack_id: &str,

--- a/cat-launcher/src-tauri/src/soundpacks/repository/sqlite_installed_soundpacks_repository.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/repository/sqlite_installed_soundpacks_repository.rs
@@ -7,11 +7,13 @@ use crate::soundpacks::repository::installed_soundpacks_repository::{
 };
 use crate::variants::GameVariant;
 
+/// A SQLite implementation of the `InstalledSoundpacksRepository`.
 pub struct SqliteInstalledSoundpacksRepository {
   pool: r2d2::Pool<SqliteConnectionManager>,
 }
 
 impl SqliteInstalledSoundpacksRepository {
+  /// Creates a new `SqliteInstalledSoundpacksRepository` with the provided connection pool.
   pub fn new(pool: r2d2::Pool<SqliteConnectionManager>) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/soundpacks/types.rs
+++ b/cat-launcher/src-tauri/src/soundpacks/types.rs
@@ -3,37 +3,54 @@ use ts_rs::TS;
 
 use crate::infra::utils::Asset;
 
+/// Details about the installation of a third-party soundpack.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct SoundpackInstallation {
+  /// The URL where the soundpack archive can be downloaded.
   pub download_url: String,
+  /// The relative path to the soundpack directory within the archive.
   pub soundpack: String,
 }
 
+/// Information about the activity and origin of a third-party soundpack.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct SoundpackActivity {
+  /// The type of activity or project status.
   pub activity_type: String,
+  /// An optional link to the GitHub repository.
   pub github: Option<String>,
 }
 
+/// Represents a third-party soundpack.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ThirdPartySoundpack {
+  /// The unique identifier for the soundpack.
   pub id: String,
+  /// The display name of the soundpack.
   pub name: String,
+  /// Installation details for the soundpack.
   pub installation: SoundpackInstallation,
+  /// Activity information for the soundpack.
   pub activity: SoundpackActivity,
 }
 
+/// Represents a stock soundpack included with the game.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct StockSoundpack {
+  /// The unique identifier for the soundpack.
   pub id: String,
+  /// The display name of the soundpack.
   pub name: String,
 }
 
+/// Represents a soundpack, which can be either a stock soundpack or a third-party one.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(tag = "type", content = "content")]
 pub enum Soundpack {
+  /// A stock soundpack.
   Stock(StockSoundpack),
+  /// A third-party soundpack.
   ThirdParty(ThirdPartySoundpack),
 }
 
@@ -50,9 +67,12 @@ impl Asset for Soundpack {
   }
 }
 
+/// The installation status of a third-party soundpack.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub enum SoundpackInstallationStatus {
+  /// The soundpack is currently installed.
   Installed,
+  /// The soundpack is not installed.
   NotInstalled,
 }

--- a/cat-launcher/src-tauri/src/theme/commands.rs
+++ b/cat-launcher/src-tauri/src/theme/commands.rs
@@ -8,14 +8,17 @@ use crate::theme::theme::{
   get_theme_preference, update_theme_preference,
 };
 
+/// Errors that can occur when retrieving the preferred theme via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetPreferredThemeCommandError {
+  /// An error occurred while loading the theme preference from the repository.
   #[error("failed to load theme preference: {0}")]
   Get(#[from] GetThemeError),
 }
 
+/// Retrieves the user's preferred theme preference.
 #[tauri::command]
 pub async fn get_preferred_theme(
   repository: State<'_, SqliteThemePreferenceRepository>,
@@ -23,14 +26,17 @@ pub async fn get_preferred_theme(
   Ok(get_theme_preference(repository.inner()).await?)
 }
 
+/// Errors that can occur when setting the preferred theme via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum SetPreferredThemeCommandError {
+  /// An error occurred while updating the theme preference in the repository.
   #[error("failed to update theme preference: {0}")]
   Update(#[from] UpdateThemeError),
 }
 
+/// Sets the user's preferred theme preference.
 #[tauri::command]
 pub async fn set_preferred_theme(
   theme: Theme,

--- a/cat-launcher/src-tauri/src/theme/sqlite_theme_preference_repository.rs
+++ b/cat-launcher/src-tauri/src/theme/sqlite_theme_preference_repository.rs
@@ -12,12 +12,14 @@ use crate::theme::theme_preference_repository::{
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A SQLite-backed implementation of the `ThemePreferenceRepository`.
 #[derive(Clone)]
 pub struct SqliteThemePreferenceRepository {
   pool: Pool,
 }
 
 impl SqliteThemePreferenceRepository {
+  /// Creates a new `SqliteThemePreferenceRepository` with the given connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/theme/theme.rs
+++ b/cat-launcher/src-tauri/src/theme/theme.rs
@@ -6,6 +6,7 @@ use crate::theme::theme_preference_repository::{
   ThemePreferenceRepository, ThemePreferenceRepositoryError,
 };
 
+/// Represents the available UI themes.
 #[derive(
   Debug,
   Clone,
@@ -23,34 +24,44 @@ use crate::theme::theme_preference_repository::{
 #[strum(ascii_case_insensitive)]
 #[ts(export)]
 pub enum Theme {
+  /// Light theme.
   Light,
+  /// Dark theme.
   Dark,
 }
 
+/// Represents the user's theme preference.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct ThemePreference {
+  /// The selected theme.
   pub theme: Theme,
 }
 
+/// Errors that can occur when retrieving the theme preference.
 #[derive(Debug, thiserror::Error)]
 pub enum GetThemeError {
+  /// An error occurred in the underlying repository.
   #[error("failed to load theme preference: {0}")]
   Repository(#[from] ThemePreferenceRepositoryError),
 }
 
+/// Retrieves the current theme preference from the repository.
 pub async fn get_theme_preference(
   repository: &impl ThemePreferenceRepository,
 ) -> Result<ThemePreference, GetThemeError> {
   Ok(repository.get_preferred_theme().await?)
 }
 
+/// Errors that can occur when updating the theme preference.
 #[derive(Debug, thiserror::Error)]
 pub enum UpdateThemeError {
+  /// An error occurred in the underlying repository.
   #[error("failed to update theme preference: {0}")]
   Repository(#[from] ThemePreferenceRepositoryError),
 }
 
+/// Updates the theme preference in the repository.
 pub async fn update_theme_preference(
   theme: Theme,
   repository: &impl ThemePreferenceRepository,

--- a/cat-launcher/src-tauri/src/theme/theme_preference_repository.rs
+++ b/cat-launcher/src-tauri/src/theme/theme_preference_repository.rs
@@ -2,24 +2,31 @@ use async_trait::async_trait;
 
 use crate::theme::theme::{Theme, ThemePreference};
 
+/// Errors that can occur when interacting with a theme preference repository.
 #[derive(Debug, thiserror::Error)]
 pub enum ThemePreferenceRepositoryError {
+  /// An error occurred while reading the theme preference.
   #[error("failed to read theme preference: {0}")]
   Get(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while persisting the theme preference.
   #[error("failed to persist theme preference: {0}")]
   Update(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+  /// The theme value retrieved from the repository is invalid.
   #[error("invalid theme value: {0}")]
   InvalidTheme(String),
 }
 
+/// A repository for managing user theme preferences.
 #[async_trait]
 pub trait ThemePreferenceRepository: Send + Sync {
+  /// Retrieves the currently preferred theme.
   async fn get_preferred_theme(
     &self,
   ) -> Result<ThemePreference, ThemePreferenceRepositoryError>;
 
+  /// Sets and persists the preferred theme.
   async fn set_preferred_theme(
     &self,
     theme: &Theme,

--- a/cat-launcher/src-tauri/src/tilesets/commands.rs
+++ b/cat-launcher/src-tauri/src/tilesets/commands.rs
@@ -25,20 +25,25 @@ use crate::tilesets::uninstall_third_party_tileset::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when listing all tilesets via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum ListAllTilesetsCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while retrieving OS information.
   #[error("failed to get OS information")]
   OSInfo(#[from] OSNotSupportedError),
 
+  /// An error occurred while listing the tilesets.
   #[error("failed to list tilesets: {0}")]
   ListTilesets(#[from] ListAllTilesetsError),
 }
 
+/// Lists all available tilesets (both stock and third-party) for a game variant.
 #[tauri::command]
 pub async fn list_all_tilesets_command(
   variant: GameVariant,
@@ -62,20 +67,25 @@ pub async fn list_all_tilesets_command(
   Ok(tilesets)
 }
 
+/// Errors that can occur when installing a third-party tileset via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum InstallThirdPartyTilesetCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while retrieving OS information.
   #[error("failed to get OS information")]
   OSInfo(#[from] OSNotSupportedError),
 
+  /// An error occurred while installing the tileset.
   #[error("failed to install tileset: {0}")]
   Install(#[from] InstallThirdPartyTilesetError),
 }
 
+/// Installs a third-party tileset for a game variant.
 #[tauri::command]
 pub async fn install_third_party_tileset_command(
   id: String,
@@ -109,17 +119,21 @@ pub async fn install_third_party_tileset_command(
   Ok(())
 }
 
+/// Errors that can occur when uninstalling a third-party tileset via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum UninstallThirdPartyTilesetCommandError {
+  /// An error occurred while accessing the application's local data directory.
   #[error("failed to get app data directory: {0}")]
   AppDataDir(#[from] tauri::Error),
 
+  /// An error occurred while uninstalling the tileset.
   #[error("failed to uninstall tileset: {0}")]
   Uninstall(#[from] UninstallThirdPartyTilesetError),
 }
 
+/// Uninstalls a previously installed third-party tileset.
 #[tauri::command]
 pub async fn uninstall_third_party_tileset_command(
   id: String,
@@ -139,14 +153,17 @@ pub async fn uninstall_third_party_tileset_command(
   Ok(())
 }
 
+/// Errors that can occur when retrieving the installation status of a third-party tileset via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetThirdPartyTilesetInstallationStatusCommandError {
+  /// An error occurred while getting the installation status.
   #[error("failed to get tileset installation status: {0}")]
   GetStatus(#[from] GetThirdPartyTilesetInstallationStatusError),
 }
 
+/// Retrieves the current installation status of a third-party tileset.
 #[tauri::command]
 pub async fn get_third_party_tileset_installation_status_command(
   id: String,

--- a/cat-launcher/src-tauri/src/tilesets/get_third_party_tileset_installation_status.rs
+++ b/cat-launcher/src-tauri/src/tilesets/get_third_party_tileset_installation_status.rs
@@ -4,12 +4,15 @@ use crate::tilesets::repository::installed_tilesets_repository::{
 use crate::tilesets::types::TilesetInstallationStatus;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving the installation status of a third-party tileset.
 #[derive(thiserror::Error, Debug)]
 pub enum GetThirdPartyTilesetInstallationStatusError {
+  /// An error occurred in the underlying repository.
   #[error("failed to check tileset installation status: {0}")]
   Repository(#[from] InstalledTilesetsRepositoryError),
 }
 
+/// Checks if a third-party tileset is currently installed for a given game variant.
 pub async fn get_third_party_tileset_installation_status(
   tileset_id: &str,
   variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/install_third_party_tileset.rs
@@ -22,36 +22,47 @@ use crate::tilesets::repository::installed_tilesets_repository::{
 use crate::tilesets::types::ThirdPartyTileset;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when installing a third-party tileset.
 #[derive(thiserror::Error, Debug)]
 pub enum InstallThirdPartyTilesetError {
+  /// An error occurred while retrieving tileset details from the metadata file.
   #[error("failed to get tileset from tilesets.json: {0}")]
   GetTilesetFromJson(#[from] GetTilesetFromJsonError),
 
+  /// An error occurred while creating a directory.
   #[error("failed to create directory: {0}")]
   CreateDirectory(#[from] io::Error),
 
+  /// An error occurred while downloading the tileset.
   #[error("failed to download tileset: {0}")]
   Download(#[from] DownloadFileError),
 
+  /// An error occurred while extracting the tileset archive.
   #[error("failed to extract tileset: {0}")]
   Extract(#[from] ExtractionError),
 
+  /// An error occurred while determining the parent directory of the tileset within the archive.
   #[error("failed to get tileset parent dir: {0}")]
   GetTilesetParentDir(#[from] GetTilesetParentDirError),
 
+  /// An error occurred while determining the user game data directory.
   #[error("failed to get user game data dir: {0}")]
   GetUserGameDataDir(#[from] GetUserGameDataDirError),
 
+  /// An error occurred while creating the user tileset data directory.
   #[error("failed to get user tileset data dir: {0}")]
   GetUserTilesetDataDir(#[from] GetOrCreateDirectoryError),
 
+  /// An error occurred while copying tileset files.
   #[error("failed to copy tileset: {0}")]
   Copy(#[from] CopyDirError),
 
+  /// An error occurred while updating the installed tilesets repository.
   #[error("failed to update repository: {0}")]
   UpdateRepository(#[from] InstalledTilesetsRepositoryError),
 }
 
+/// Downloads, extracts, and installs a third-party tileset for a given game variant.
 #[allow(clippy::too_many_arguments)]
 pub async fn install_third_party_tileset(
   tileset_id: &str,
@@ -150,8 +161,10 @@ async fn get_tileset_from_json(
   Ok(third_party_tileset)
 }
 
+/// Errors that can occur when determining the parent directory of a tileset.
 #[derive(Debug, thiserror::Error)]
 pub enum GetTilesetParentDirError {
+  /// The parent directory for the specified tileset path could not be found.
   #[error("failed to get parent directory for tileset path")]
   ParentDirNotFound,
 }

--- a/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
+++ b/cat-launcher/src-tauri/src/tilesets/list_all_tilesets.rs
@@ -19,21 +19,27 @@ use crate::tilesets::types::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when listing all tilesets.
 #[derive(thiserror::Error, Debug)]
 pub enum ListAllTilesetsError {
+  /// An error occurred while determining the stock tilesets directory.
   #[error("failed to get stock tilesets dir: {0}")]
   GetStockTilesetsDir(#[from] GetStockTilesetsDirError),
 
+  /// An error occurred while listing stock tilesets.
   #[error("failed to read stock tileset dir: {0}")]
   ExtractStockTileset(#[from] ListAllStockTilesetsError),
 
+  /// An error occurred while retrieving the active release version.
   #[error("failed to get active release: {0}")]
   GetActiveRelease(#[from] ActiveReleaseRepositoryError),
 
+  /// An error occurred while listing third-party tilesets.
   #[error("failed to list third-party tilesets: {0}")]
   ListThirdPartyTilesets(#[from] ListThirdPartyTilesetsError),
 }
 
+/// Lists all available tilesets (both stock and third-party) for a game variant.
 pub async fn list_all_tilesets(
   game_variant: &GameVariant,
   data_dir: &Path,
@@ -71,10 +77,13 @@ pub async fn list_all_tilesets(
   Ok(tilesets)
 }
 
+/// Errors that can occur when extracting stock tileset information.
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractStockTilesetError {
+  /// An error occurred while reading the `tileset.txt` file.
   #[error("failed to read tileset.txt: {0}")]
   ReadTilesetTxt(#[from] io::Error),
+  /// A required field is missing from `tileset.txt`.
   #[error("missing field in tileset.txt: {0}")]
   MissingField(String),
 }
@@ -158,11 +167,14 @@ async fn list_all_stock_tilesets(
   Ok(tilesets)
 }
 
+/// Errors that can occur when listing third-party tilesets.
 #[derive(thiserror::Error, Debug)]
 pub enum ListThirdPartyTilesetsError {
+  /// An error occurred while reading the `tilesets.json` resource file.
   #[error("failed to read tilesets.json: {0}")]
   ReadTilesetsJson(#[from] io::Error),
 
+  /// An error occurred while parsing the `tilesets.json` file.
   #[error("failed to parse tilesets.json: {0}")]
   ParseTilesetsJson(#[from] serde_json::Error),
 }

--- a/cat-launcher/src-tauri/src/tilesets/paths.rs
+++ b/cat-launcher/src-tauri/src/tilesets/paths.rs
@@ -6,12 +6,15 @@ use crate::filesystem::paths::{
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
+/// Errors that can occur when determining the stock tilesets directory.
 #[derive(thiserror::Error, Debug)]
 pub enum GetStockTilesetsDirError {
+  /// An error occurred while determining the game resources directory.
   #[error("failed to get game resources directory: {0}")]
   GameResourcesDir(#[from] GetGameExecutableDirError),
 }
 
+/// Returns the absolute path to the stock tilesets directory for a given game variant and version.
 pub async fn get_stock_tilesets_dir(
   variant: &GameVariant,
   release_version: &str,
@@ -25,6 +28,7 @@ pub async fn get_stock_tilesets_dir(
   Ok(game_resources_dir.join("gfx"))
 }
 
+/// Returns the path to the tilesets metadata resource file.
 pub fn get_tilesets_resource_path(resource_dir: &Path) -> PathBuf {
   resource_dir.join("content").join("tilesets.json")
 }

--- a/cat-launcher/src-tauri/src/tilesets/repository/installed_tilesets_repository.rs
+++ b/cat-launcher/src-tauri/src/tilesets/repository/installed_tilesets_repository.rs
@@ -4,43 +4,54 @@ use async_trait::async_trait;
 
 use crate::variants::GameVariant;
 
+/// Errors that can occur when interacting with the installed tilesets repository.
 #[derive(thiserror::Error, Debug)]
 pub enum InstalledTilesetsRepositoryError {
+  /// An error occurred while adding an installed tileset.
   #[error("failed to add installed tileset: {0}")]
   Add(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while deleting an installed tileset.
   #[error("failed to delete installed tileset: {0}")]
   Delete(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while deleting all installed tilesets.
   #[error("failed to delete all installed tilesets: {0}")]
   DeleteAll(#[source] Box<dyn Error + Send + Sync>),
 
+  /// An error occurred while checking if a tileset is installed.
   #[error("failed to check if tileset is installed: {0}")]
   IsInstalled(#[source] Box<dyn Error + Send + Sync>),
 
+  /// The specified installed tileset was not found.
   #[error("installed tileset with id {0} not found for variant {1}")]
   NotFound(String, String),
 }
 
+/// A repository for managing records of installed third-party tilesets.
 #[async_trait]
 pub trait InstalledTilesetsRepository: Send + Sync {
+  /// Adds a record indicating that a tileset has been installed for a specific game variant.
   async fn add_installed_tileset(
     &self,
     tileset_id: &str,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledTilesetsRepositoryError>;
 
+  /// Deletes the record of an installed tileset for a specific game variant.
   async fn delete_installed_tileset(
     &self,
     tileset_id: &str,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledTilesetsRepositoryError>;
 
+  /// Deletes all records of installed tilesets for a specific game variant.
   async fn delete_all_installed_tilesets(
     &self,
     game_variant: &GameVariant,
   ) -> Result<(), InstalledTilesetsRepositoryError>;
 
+  /// Checks if a record exists for an installed tileset for a specific game variant.
   async fn is_tileset_installed(
     &self,
     tileset_id: &str,

--- a/cat-launcher/src-tauri/src/tilesets/repository/sqlite_installed_tilesets_repository.rs
+++ b/cat-launcher/src-tauri/src/tilesets/repository/sqlite_installed_tilesets_repository.rs
@@ -7,11 +7,13 @@ use crate::tilesets::repository::installed_tilesets_repository::{
 };
 use crate::variants::GameVariant;
 
+/// A SQLite implementation of the `InstalledTilesetsRepository`.
 pub struct SqliteInstalledTilesetsRepository {
   pool: r2d2::Pool<SqliteConnectionManager>,
 }
 
 impl SqliteInstalledTilesetsRepository {
+  /// Creates a new `SqliteInstalledTilesetsRepository` with the provided connection pool.
   pub fn new(pool: r2d2::Pool<SqliteConnectionManager>) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/tilesets/types.rs
+++ b/cat-launcher/src-tauri/src/tilesets/types.rs
@@ -3,37 +3,54 @@ use ts_rs::TS;
 
 use crate::infra::utils::Asset;
 
+/// Details about the installation of a third-party tileset.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct TilesetInstallation {
+  /// The URL where the tileset archive can be downloaded.
   pub download_url: String,
+  /// The relative path to the tileset directory within the archive.
   pub tileset: String,
 }
 
+/// Information about the activity and origin of a third-party tileset.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct TilesetActivity {
+  /// The type of activity or project status.
   pub activity_type: String,
+  /// An optional link to the GitHub repository.
   pub github: Option<String>,
 }
 
+/// Represents a third-party tileset.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ThirdPartyTileset {
+  /// The unique identifier for the tileset.
   pub id: String,
+  /// The display name of the tileset.
   pub name: String,
+  /// Installation details for the tileset.
   pub installation: TilesetInstallation,
+  /// Activity information for the tileset.
   pub activity: TilesetActivity,
 }
 
+/// Represents a stock tileset included with the game.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct StockTileset {
+  /// The unique identifier for the tileset.
   pub id: String,
+  /// The display name of the tileset.
   pub name: String,
 }
 
+/// Represents a tileset, which can be either a stock tileset or a third-party one.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(tag = "type", content = "content")]
 pub enum Tileset {
+  /// A stock tileset.
   Stock(StockTileset),
+  /// A third-party tileset.
   ThirdParty(ThirdPartyTileset),
 }
 
@@ -50,9 +67,12 @@ impl Asset for Tileset {
   }
 }
 
+/// The installation status of a third-party tileset.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub enum TilesetInstallationStatus {
+  /// The tileset is currently installed.
   Installed,
+  /// The tileset is not installed.
   NotInstalled,
 }

--- a/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
+++ b/cat-launcher/src-tauri/src/tilesets/uninstall_third_party_tileset.rs
@@ -9,16 +9,21 @@ use crate::tilesets::repository::installed_tilesets_repository::{
 };
 use crate::variants::GameVariant;
 
+/// Errors that can occur when uninstalling a third-party tileset.
 #[derive(thiserror::Error, Debug)]
 pub enum UninstallThirdPartyTilesetError {
+  /// An error occurred while removing the tileset record from the repository.
   #[error("failed to remove installed tileset from repository: {0}")]
   Repository(#[from] InstalledTilesetsRepositoryError),
+  /// An error occurred while determining the user game data directory.
   #[error("failed to get user game data directory: {0}")]
   UserGameDataDir(#[from] GetUserGameDataDirError),
+  /// An error occurred while deleting the tileset directory from the filesystem.
   #[error("failed to delete tileset directory: {0}")]
   DeleteTilesetDirectory(#[from] io::Error),
 }
 
+/// Uninstalls a third-party tileset by removing its files and repository record.
 pub async fn uninstall_third_party_tileset(
   tileset_id: &str,
   game_variant: &GameVariant,

--- a/cat-launcher/src-tauri/src/users/commands.rs
+++ b/cat-launcher/src-tauri/src/users/commands.rs
@@ -8,14 +8,17 @@ use crate::users::service::{
   GetOrCreateUserIdError, get_or_create_user_id,
 };
 
+/// Errors that can occur when retrieving the user ID via a command.
 #[derive(
   thiserror::Error, Debug, IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetUserIdCommandError {
+  /// An error occurred while getting or creating the user ID.
   #[error("failed to get or create user id: {0}")]
   GetOrCreateUserId(#[from] GetOrCreateUserIdError),
 }
 
+/// Retrieves the unique identifier for the current user, creating one if it doesn't exist.
 #[tauri::command]
 pub async fn get_user_id(
   repo: State<'_, SqliteUsersRepository>,

--- a/cat-launcher/src-tauri/src/users/repository/sqlite_users_repository.rs
+++ b/cat-launcher/src-tauri/src/users/repository/sqlite_users_repository.rs
@@ -8,12 +8,14 @@ use super::users_repository::{
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A SQLite implementation of the `UsersRepository`.
 #[derive(Clone)]
 pub struct SqliteUsersRepository {
   pool: Pool,
 }
 
 impl SqliteUsersRepository {
+  /// Creates a new `SqliteUsersRepository` with the provided connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/users/repository/users_repository.rs
+++ b/cat-launcher/src-tauri/src/users/repository/users_repository.rs
@@ -1,16 +1,21 @@
 use async_trait::async_trait;
 
+/// Errors that can occur when interacting with the users repository.
 #[derive(Debug, thiserror::Error)]
 pub enum UsersRepositoryError {
+  /// An error occurred while retrieving the user.
   #[error("failed to get user: {0}")]
   Get(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+  /// An error occurred while creating a new user.
   #[error("failed to create user: {0}")]
   Create(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// A repository for managing user data.
 #[async_trait]
 pub trait UsersRepository: Send + Sync {
+  /// Retrieves the existing user ID or creates a new one with the provided `id` if none exists.
   async fn get_or_create_user(
     &self,
     id: &str,

--- a/cat-launcher/src-tauri/src/users/service.rs
+++ b/cat-launcher/src-tauri/src/users/service.rs
@@ -4,12 +4,15 @@ use crate::users::repository::users_repository::{
   UsersRepository, UsersRepositoryError,
 };
 
+/// Errors that can occur in the user service.
 #[derive(thiserror::Error, Debug)]
 pub enum GetOrCreateUserIdError {
+  /// An error occurred in the underlying repository.
   #[error("failed to get user id: {0}")]
   GetUserId(#[from] UsersRepositoryError),
 }
 
+/// Retrieves the current user ID or generates and persists a new one if it doesn't exist.
 pub async fn get_or_create_user_id(
   repo: &impl UsersRepository,
 ) -> Result<String, GetOrCreateUserIdError> {

--- a/cat-launcher/src-tauri/src/variants/commands.rs
+++ b/cat-launcher/src-tauri/src/variants/commands.rs
@@ -7,14 +7,17 @@ use crate::variants::repository::sqlite_game_variant_order_repository::SqliteGam
 use crate::variants::update_game_variant_order::{self, UpdateGameVariantOrderError};
 use crate::variants::GameVariant;
 
+/// Errors that can occur when updating the game variant display order.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum UpdateGameVariantOrderCommandError {
+  /// The update operation failed in the repository.
   #[error("failed to update game variant order: {0}")]
   Update(#[from] UpdateGameVariantOrderError),
 }
 
+/// A Tauri command that updates the display order of game variants.
 #[command]
 pub async fn update_game_variant_order(
   variants: Vec<GameVariant>,
@@ -32,14 +35,17 @@ pub async fn update_game_variant_order(
   Ok(())
 }
 
+/// Errors that can occur when retrieving game variant information.
 #[derive(
   thiserror::Error, Debug, strum::IntoStaticStr, CommandErrorSerialize,
 )]
 pub enum GetGameVariantsInfoCommandError {
+  /// The retrieval operation failed in the repository.
   #[error("failed to get game variant order: {0}")]
   Get(#[from] GetGameVariantsInfoError),
 }
 
+/// A Tauri command that retrieves information for all available game variants.
 #[command]
 pub async fn get_game_variants_info(
   game_variant_order_repository: State<

--- a/cat-launcher/src-tauri/src/variants/game_variant.rs
+++ b/cat-launcher/src-tauri/src/variants/game_variant.rs
@@ -4,6 +4,7 @@ use ts_rs::TS;
 
 use crate::game_release::game_release::ReleaseType;
 
+/// Represents the different variants of the game supported by the launcher.
 #[derive(
   Debug,
   Display,
@@ -21,8 +22,11 @@ use crate::game_release::game_release::ReleaseType;
 )]
 #[non_exhaustive]
 pub enum GameVariant {
+  /// Cataclysm: Dark Days Ahead
   DarkDaysAhead,
+  /// Cataclysm: Bright Nights
   BrightNights,
+  /// The Last Generation
   TheLastGeneration,
 }
 
@@ -36,10 +40,12 @@ const DDA_CATEGORIES: &[&str] = &[
 ];
 
 impl GameVariant {
+  /// Returns a stable string identifier for the variant.
   pub fn id(&self) -> &'static str {
     self.into()
   }
 
+  /// Returns the human-readable name of the variant.
   pub fn name(&self) -> &'static str {
     match self {
       GameVariant::DarkDaysAhead => "Dark Days Ahead",
@@ -48,6 +54,8 @@ impl GameVariant {
     }
   }
 
+  /// Determines the `ReleaseType` based on the tag name and prerelease flag,
+  /// which varies depending on the variant's naming conventions.
   pub fn determine_release_type(
     &self,
     tag_name: &str,
@@ -73,6 +81,7 @@ impl GameVariant {
     }
   }
 
+  /// Returns the list of typeface categories supported by this variant.
   pub fn supported_typeface_categories(
     &self,
   ) -> &'static [&'static str] {

--- a/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
+++ b/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
@@ -5,14 +5,18 @@ use crate::variants::repository::game_variant_order_repository::GameVariantOrder
 use crate::variants::GameVariant;
 use ts_rs::TS;
 
+/// Information about a game variant, suitable for display in the UI.
 #[derive(serde::Serialize, TS)]
 #[ts(export)]
 pub struct GameVariantInfo {
+  /// The unique identifier for the game variant.
   pub id: GameVariant,
+  /// The human-readable name of the game variant.
   pub name: String,
 }
 
 impl GameVariantInfo {
+  /// Creates a new `GameVariantInfo` from a `GameVariant`.
   pub fn from_variant(variant: GameVariant) -> Self {
     GameVariantInfo {
       id: variant,
@@ -21,12 +25,15 @@ impl GameVariantInfo {
   }
 }
 
+/// Errors that can occur when retrieving game variant information.
 #[derive(thiserror::Error, Debug)]
 pub enum GetGameVariantsInfoError {
+  /// Failed to retrieve the variant order from the repository.
   #[error("failed to get game variant order")]
     Get(#[from] crate::variants::repository::game_variant_order_repository::GameVariantOrderRepositoryError),
 }
 
+/// Retrieves information for all game variants in their preferred display order.
 pub async fn get_game_variants_info(
   game_variant_order_repository: &impl GameVariantOrderRepository,
 ) -> Result<Vec<GameVariantInfo>, GetGameVariantsInfoError> {

--- a/cat-launcher/src-tauri/src/variants/repository/game_variant_order_repository.rs
+++ b/cat-launcher/src-tauri/src/variants/repository/game_variant_order_repository.rs
@@ -2,33 +2,43 @@ use async_trait::async_trait;
 
 use crate::variants::GameVariant;
 
+/// Errors that can occur when retrieving the game variant order.
 #[derive(thiserror::Error, Debug)]
 pub enum GetGameVariantOrderError {
+  /// An underlying error occurred during retrieval.
   #[error("failed to get game variant order: {0}")]
   Get(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// Errors that can occur when updating the game variant order.
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateGameVariantOrderError {
+  /// An underlying error occurred during the update.
   #[error("failed to update game variant order: {0}")]
   Update(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// A unified error type for game variant order repository operations.
 #[derive(thiserror::Error, Debug)]
 pub enum GameVariantOrderRepositoryError {
+  /// Failed to get the order.
   #[error("failed to get game variant order: {0}")]
   Get(#[from] GetGameVariantOrderError),
 
+  /// Failed to update the order.
   #[error("failed to update game variant order: {0}")]
   Update(#[from] UpdateGameVariantOrderError),
 }
 
+/// A repository for managing the display order of game variants.
 #[async_trait]
 pub trait GameVariantOrderRepository: Send + Sync {
+  /// Retrieves the current ordered list of game variants.
   async fn get_ordered_variants(
     &self,
   ) -> Result<Vec<GameVariant>, GameVariantOrderRepositoryError>;
 
+  /// Updates the display order of game variants.
   async fn update_order(
     &self,
     variants: &[GameVariant],

--- a/cat-launcher/src-tauri/src/variants/repository/sqlite_game_variant_order_repository.rs
+++ b/cat-launcher/src-tauri/src/variants/repository/sqlite_game_variant_order_repository.rs
@@ -11,12 +11,14 @@ use crate::variants::repository::game_variant_order_repository::{
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 
+/// A SQLite-backed implementation of the `GameVariantOrderRepository`.
 #[derive(Clone)]
 pub struct SqliteGameVariantOrderRepository {
   pool: Pool,
 }
 
 impl SqliteGameVariantOrderRepository {
+  /// Creates a new `SqliteGameVariantOrderRepository` with the given connection pool.
   pub fn new(pool: Pool) -> Self {
     Self { pool }
   }

--- a/cat-launcher/src-tauri/src/variants/update_game_variant_order.rs
+++ b/cat-launcher/src-tauri/src/variants/update_game_variant_order.rs
@@ -2,12 +2,15 @@ use crate::variants::GameVariant;
 use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepository;
 use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepositoryError;
 
+/// Errors that can occur when updating the game variant order.
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateGameVariantOrderError {
+  /// The update operation failed in the underlying repository.
   #[error("failed to update game variant order")]
   Update(#[from] GameVariantOrderRepositoryError),
 }
 
+/// Updates the display order of game variants using the provided repository.
 pub async fn update_game_variant_order(
   variants: &[GameVariant],
   game_variant_order_repository: &impl GameVariantOrderRepository,

--- a/cat-launcher/src/App.tsx
+++ b/cat-launcher/src/App.tsx
@@ -3,6 +3,12 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import NavBar from "@/components/NavBar";
 import { routes } from "@/routes";
 
+/**
+ * The root component of the CatLauncher application.
+ * Defines the overall layout and handles client-side routing.
+ *
+ * @returns The rendered application.
+ */
 function App() {
   return (
     <BrowserRouter>

--- a/cat-launcher/src/components/AutoUpdateNotifier.tsx
+++ b/cat-launcher/src/components/AutoUpdateNotifier.tsx
@@ -15,6 +15,14 @@ import {
 } from "@/providers/hooks";
 import { ExternalLink } from "./ui/ExternalLink";
 
+/**
+ * A dialog component that notifies the user when an automatic update has failed.
+ * It provides a link to manually update the application.
+ *
+ * @returns A React element representing the auto-update notifier dialog, or null if no failure state is present.
+ *
+ * @public
+ */
 const AutoUpdateNotifier = () => {
   const { autoUpdateStatus, resetAutoUpdateStatus } =
     useAutoUpdateEvents();

--- a/cat-launcher/src/components/DataTable.tsx
+++ b/cat-launcher/src/components/DataTable.tsx
@@ -17,12 +17,32 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+/**
+ * Properties for the {@link DataTable} component.
+ *
+ * @typeParam TData - The type of data being displayed in the table.
+ * @typeParam TValue - The type of values within the data.
+ *
+ * @public
+ */
 interface DataTableProps<TData, TValue> {
+  /** The column definitions for the table. */
   columns: ColumnDef<TData, TValue>[];
+  /** The data to be displayed in the table. */
   data: TData[];
+  /** The initial sorting state for the table. */
   initialSort?: SortingState;
 }
 
+/**
+ * A reusable data table component built on top of `@tanstack/react-table`.
+ * Supports sorting and flexible column rendering.
+ *
+ * @param props - The properties for the data table.
+ * @returns A React element representing the data table.
+ *
+ * @public
+ */
 export function DataTable<TData, TValue>({
   columns,
   data,

--- a/cat-launcher/src/components/DownloadProgress.tsx
+++ b/cat-launcher/src/components/DownloadProgress.tsx
@@ -1,11 +1,27 @@
 import { Progress } from "@/components/ui/progress";
 import { formatBytes } from "@/lib/utils";
 
+/**
+ * Properties for the {@link DownloadProgress} component.
+ *
+ * @public
+ */
 interface DownloadProgressProps {
+  /** The number of bytes already downloaded. */
   downloaded: number;
+  /** The total number of bytes to download. If 0, the progress is considered indeterminate. */
   total: number;
 }
 
+/**
+ * A component that displays the progress of a file download.
+ * Handles both determinate and indeterminate (unknown total size) progress states.
+ *
+ * @param props - The properties for the download progress component.
+ * @returns A React element representing the download progress bar.
+ *
+ * @public
+ */
 export function DownloadProgress({
   downloaded,
   total,

--- a/cat-launcher/src/components/DropdownButton.tsx
+++ b/cat-launcher/src/components/DropdownButton.tsx
@@ -15,24 +15,46 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
+/**
+ * Props for the {@link DropdownButton} component.
+ * @public
+ */
 interface DropdownButtonProps extends React.ComponentProps<
   typeof Button
 > {
+  /**
+   * List of options to be displayed in the dropdown menu.
+   */
   options: {
+    /** Unique identifier for the option. */
     id: string;
 
+    /** Display label for the option. */
     label: string;
 
+    /** Callback function to execute when the option is clicked. */
     onClick: () => void;
 
+    /** Whether the individual option is disabled. */
     disabled?: boolean;
 
+    /** Optional tooltip text to display on hover for this option. */
     tooltip?: string;
   }[];
 
+  /**
+   * Whether the main button (left part) is disabled, independent of the dropdown trigger.
+   */
   mainButtonDisabled?: boolean;
 }
 
+/**
+ * A split button component that features a main action and a dropdown for additional options.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the dropdown button.
+ * @public
+ */
 export function DropdownButton({
   children,
 

--- a/cat-launcher/src/components/GameSessionMonitor.tsx
+++ b/cat-launcher/src/components/GameSessionMonitor.tsx
@@ -13,6 +13,13 @@ import {
 import { copyToClipboard, toastCL } from "@/lib/utils";
 import { GameStatus, useGameSessionEvents } from "@/providers/hooks";
 
+/**
+ * A component that monitors the game session and displays a dialog when the game crashes,
+ * terminates unexpectedly, or fails to start. It provides the exit code and logs
+ * to help the user diagnose the issue.
+ *
+ * @returns A React component that renders the game session monitor dialog.
+ */
 const GameSessionMonitor = () => {
   const { gameStatus, logsText, exitCode, resetGameSessionMonitor } =
     useGameSessionEvents();

--- a/cat-launcher/src/components/NavBar.tsx
+++ b/cat-launcher/src/components/NavBar.tsx
@@ -4,10 +4,22 @@ import ThemeToggle from "@/theme/ThemeToggle";
 import { cn } from "@/lib/utils";
 import { BaseRoute, routes } from "@/routes";
 
+/**
+ * Props for the {@link NavItem} component.
+ */
 interface NavItemProps {
+  /**
+   * The route object to render.
+   */
   route: BaseRoute;
 }
 
+/**
+ * A single navigation item in the navigation bar.
+ *
+ * @param props - The component props.
+ * @returns A React component that renders a navigation link.
+ */
 function NavItem({ route }: NavItemProps) {
   const Icon = route.icon;
   const targetPath = route.path.replace("/*", "");
@@ -31,6 +43,11 @@ function NavItem({ route }: NavItemProps) {
   );
 }
 
+/**
+ * The main navigation bar component, displaying links to visible routes and a theme toggle.
+ *
+ * @returns A React component that renders the navigation bar.
+ */
 export default function NavBar() {
   const visibleRoutes = routes.filter((route) => !route.hidden);
 

--- a/cat-launcher/src/components/PlayTimeMonitor.tsx
+++ b/cat-launcher/src/components/PlayTimeMonitor.tsx
@@ -1,6 +1,14 @@
 import { usePlayTimeMonitor } from "@/hooks/usePlayTimeMonitor";
 import { useAppSelector } from "@/store/hooks";
 
+/**
+ * A headless component that monitors the play time of the currently running game.
+ * It uses the `usePlayTimeMonitor` hook to track and save the duration of game sessions.
+ *
+ * @returns null - This component does not render any visual elements.
+ *
+ * @public
+ */
 const PlayTimeMonitor = () => {
   const { currentlyPlaying, currentlyPlayingVersion } =
     useAppSelector((state) => state.gameSession);

--- a/cat-launcher/src/components/PreInstalledButton.tsx
+++ b/cat-launcher/src/components/PreInstalledButton.tsx
@@ -1,5 +1,13 @@
 import { Button } from "./ui/button";
 
+/**
+ * A button component that represents a pre-installed state.
+ * It is disabled by default to indicate that no further action is required for installation.
+ *
+ * @returns A React element representing the pre-installed button.
+ *
+ * @public
+ */
 export function PreInstalledButton() {
   return (
     <Button className="w-full" disabled>

--- a/cat-launcher/src/components/SearchInput.tsx
+++ b/cat-launcher/src/components/SearchInput.tsx
@@ -3,14 +3,41 @@ import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
+/**
+ * Props for the {@link SearchInput} component.
+ */
 export interface SearchInputProps {
+  /**
+   * The current search query.
+   */
   value: string;
+  /**
+   * Callback fired when the search query changes.
+   * @param _value - The new search query.
+   */
   onChange: (_value: string) => void;
+  /**
+   * Placeholder text for the input field.
+   * @defaultValue "Search..."
+   */
   placeholder?: string;
+  /**
+   * Additional CSS class names for the container.
+   */
   className?: string;
+  /**
+   * Whether the input is disabled.
+   * @defaultValue false
+   */
   disabled?: boolean;
 }
 
+/**
+ * A reusable search input component with a search icon.
+ *
+ * @param props - The component props.
+ * @returns A React component that renders the search input.
+ */
 export function SearchInput({
   value,
   onChange,

--- a/cat-launcher/src/components/Sidebar.tsx
+++ b/cat-launcher/src/components/Sidebar.tsx
@@ -5,26 +5,60 @@ import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
+/**
+ * Represents an individual item within the sidebar navigation.
+ *
+ * @public
+ */
 export interface SidebarItem {
+  /** The destination path for the navigation link. */
   path: string;
+  /** The display label for the item. */
   label: string;
+  /** The icon to display alongside the label. */
   icon: LucideIcon;
+  /** Whether the item should be hidden from the sidebar. */
   hidden?: boolean;
 }
 
+/**
+ * Properties for the {@link Sidebar} component.
+ *
+ * @public
+ */
 export interface SidebarProps {
+  /** The list of navigation items to display. */
   items: SidebarItem[];
+  /** Whether the sidebar is currently in a collapsed state. */
   isCollapsed: boolean;
+  /** Callback function triggered when the collapse state is toggled. */
   onToggleCollapse: () => void;
+  /** An optional base path to prepend to all item paths. */
   basePath?: string;
 }
 
+/**
+ * Properties for the internal {@link SidebarNavItem} component.
+ *
+ * @internal
+ */
 interface SidebarNavItemProps {
+  /** The sidebar item to render. */
   item: SidebarItem;
+  /** Whether the sidebar is collapsed. */
   isCollapsed: boolean;
+  /** The base path for navigation. */
   basePath: string;
 }
 
+/**
+ * An individual navigation link component used within the sidebar.
+ *
+ * @param props - The properties for the sidebar navigation item.
+ * @returns A React element representing a single navigation link.
+ *
+ * @internal
+ */
 function SidebarNavItem({
   item,
   isCollapsed,
@@ -61,6 +95,15 @@ function SidebarNavItem({
   );
 }
 
+/**
+ * The main sidebar navigation component.
+ * Provides a collapsible menu with icons and labels.
+ *
+ * @param props - The properties for the sidebar.
+ * @returns A React element representing the sidebar.
+ *
+ * @public
+ */
 export function Sidebar({
   items,
   isCollapsed,

--- a/cat-launcher/src/components/VariantSelector.tsx
+++ b/cat-launcher/src/components/VariantSelector.tsx
@@ -5,15 +5,45 @@ import {
 import { GameVariantInfo } from "@/generated-types/GameVariantInfo";
 import { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * Props for the {@link VariantSelector} component.
+ */
 interface VariantSelectorProps {
+  /**
+   * The list of available game variants.
+   */
   gameVariants: GameVariantInfo[];
+  /**
+   * The currently selected game variant, or null if none is selected.
+   */
   selectedVariant: GameVariant | null;
+  /**
+   * Callback fired when a game variant is selected.
+   * @param _variant - The selected game variant.
+   */
   onVariantChange: (_variant: GameVariant) => void;
+  /**
+   * Whether the game variants are currently being loaded.
+   */
   isLoading: boolean;
+  /**
+   * Optional placeholder text to display in the selector.
+   */
   placeholder?: string;
+  /**
+   * Whether the selector is disabled.
+   * @defaultValue false
+   */
   disabled?: boolean;
 }
 
+/**
+ * A component that allows the user to select a game variant from a list.
+ * Uses a {@link VirtualizedCombobox} for efficient rendering of large lists.
+ *
+ * @param props - The component props.
+ * @returns A React component that renders the variant selector.
+ */
 export default function VariantSelector({
   gameVariants,
   selectedVariant,

--- a/cat-launcher/src/components/ui/ConfirmationDialog.tsx
+++ b/cat-launcher/src/components/ui/ConfirmationDialog.tsx
@@ -11,17 +11,36 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+/**
+ * Props for the {@link ConfirmationDialog} component.
+ * @public
+ */
 interface ConfirmationDialogProps {
+  /** Whether the dialog is currently open. */
   open: boolean;
+  /** Callback function called when the dialog's open state changes. */
   onOpenChange: (_open: boolean) => void;
+  /** Callback function executed when the user confirms the action. */
   onConfirm: () => void;
+  /** The title of the confirmation dialog. */
   title: string;
+  /** A description providing more context about the action being confirmed. */
   description: string;
+  /** The text to display on the confirmation button. Defaults to "Confirm". */
   confirmText?: string;
+  /** The text to display on the cancel button. Defaults to "Cancel". */
   cancelText?: string;
+  /** Optional additional content to display within the dialog. */
   children?: ReactNode;
 }
 
+/**
+ * A reusable dialog component for confirming user actions.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the confirmation dialog.
+ * @public
+ */
 export function ConfirmationDialog({
   open,
   onOpenChange,

--- a/cat-launcher/src/components/ui/ExternalLink.tsx
+++ b/cat-launcher/src/components/ui/ExternalLink.tsx
@@ -4,11 +4,24 @@ import { Button } from "@/components/ui/button";
 import { openLink } from "@/lib/utils";
 import { ExternalLinkIcon } from "lucide-react";
 
+/**
+ * Props for the {@link ExternalLink} component.
+ * @public
+ */
 interface ExternalLinkProps {
+  /** The URL to open when the link is clicked. */
   href: string;
+  /** The content to be displayed within the link. */
   children: ReactNode;
 }
 
+/**
+ * A link component that opens an external URL using the system's default browser.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the external link button.
+ * @public
+ */
 export function ExternalLink({ href, children }: ExternalLinkProps) {
   return (
     <Button

--- a/cat-launcher/src/components/ui/alert.tsx
+++ b/cat-launcher/src/components/ui/alert.tsx
@@ -3,6 +3,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Defines the style variants for the {@link Alert} component.
+ * @internal
+ */
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
   {
@@ -19,6 +23,13 @@ const alertVariants = cva(
   },
 );
 
+/**
+ * A callout component for displaying important information or feedback.
+ *
+ * @param props - Component props including {@link VariantProps} for alertVariants.
+ * @returns A React element representing the alert box.
+ * @public
+ */
 function Alert({
   className,
   variant,
@@ -34,6 +45,13 @@ function Alert({
   );
 }
 
+/**
+ * Component for the title of an {@link Alert}.
+ *
+ * @param props - Div component props.
+ * @returns A React element representing the alert title.
+ * @public
+ */
 function AlertTitle({
   className,
   ...props
@@ -50,6 +68,13 @@ function AlertTitle({
   );
 }
 
+/**
+ * Component for the descriptive text within an {@link Alert}.
+ *
+ * @param props - Div component props.
+ * @returns A React element representing the alert description.
+ * @public
+ */
 function AlertDescription({
   className,
   ...props

--- a/cat-launcher/src/components/ui/badge.tsx
+++ b/cat-launcher/src/components/ui/badge.tsx
@@ -4,6 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Defines the visual variants for the Badge component using `class-variance-authority`.
+ *
+ * @public
+ */
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
@@ -25,6 +30,14 @@ const badgeVariants = cva(
   },
 );
 
+/**
+ * A small badge component for displaying status, categories, or other short labels.
+ *
+ * @param props - The properties for the badge component, including variant and an optional `asChild` prop to render as a different element.
+ * @returns A React element representing the badge.
+ *
+ * @public
+ */
 function Badge({
   className,
   variant,

--- a/cat-launcher/src/components/ui/button.tsx
+++ b/cat-launcher/src/components/ui/button.tsx
@@ -4,6 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Defines the visual variants and sizes for the Button component using `class-variance-authority`.
+ *
+ * @public
+ */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -35,6 +40,14 @@ const buttonVariants = cva(
   },
 );
 
+/**
+ * A flexible button component that supports various visual styles and sizes.
+ *
+ * @param props - The properties for the button component, including variant, size, and an optional `asChild` prop to render as a different element.
+ * @returns A React element representing the button.
+ *
+ * @public
+ */
 function Button({
   className,
   variant,

--- a/cat-launcher/src/components/ui/card.tsx
+++ b/cat-launcher/src/components/ui/card.tsx
@@ -2,6 +2,13 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A container component for grouping related content and actions.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card.
+ * @public
+ */
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -15,6 +22,13 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
+/**
+ * Header section of a {@link Card}, typically containing {@link CardTitle} and {@link CardDescription}.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card header.
+ * @public
+ */
 function CardHeader({
   className,
   ...props
@@ -31,6 +45,13 @@ function CardHeader({
   );
 }
 
+/**
+ * The title component for a {@link Card}.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card title.
+ * @public
+ */
 function CardTitle({
   className,
   ...props
@@ -44,6 +65,13 @@ function CardTitle({
   );
 }
 
+/**
+ * The description component for a {@link Card}, providing additional details.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card description.
+ * @public
+ */
 function CardDescription({
   className,
   ...props
@@ -57,6 +85,13 @@ function CardDescription({
   );
 }
 
+/**
+ * An optional action area within the {@link CardHeader}, positioned to the right of the title.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card action.
+ * @public
+ */
 function CardAction({
   className,
   ...props
@@ -73,6 +108,13 @@ function CardAction({
   );
 }
 
+/**
+ * The main content area of a {@link Card}.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card content.
+ * @public
+ */
 function CardContent({
   className,
   ...props
@@ -86,6 +128,13 @@ function CardContent({
   );
 }
 
+/**
+ * The footer section of a {@link Card}, typically used for secondary actions.
+ *
+ * @param props - Div element props.
+ * @returns A React element representing the card footer.
+ * @public
+ */
 function CardFooter({
   className,
   ...props

--- a/cat-launcher/src/components/ui/checkbox.tsx
+++ b/cat-launcher/src/components/ui/checkbox.tsx
@@ -4,6 +4,15 @@ import { CheckIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A checkbox component that allows users to toggle between checked and unchecked states.
+ * Built on top of Radix UI's Checkbox primitive.
+ *
+ * @param props - The properties for the checkbox component, extending Radix UI's Checkbox root properties.
+ * @returns A React element representing the checkbox.
+ *
+ * @public
+ */
 function Checkbox({
   className,
   ...props

--- a/cat-launcher/src/components/ui/combobox.tsx
+++ b/cat-launcher/src/components/ui/combobox.tsx
@@ -15,24 +15,52 @@ import {
 import { ChevronsUpDownIcon } from "lucide-react";
 import { ReactNode, useEffect, useState } from "react";
 
+/**
+ * Represents an individual item in the {@link Combobox}.
+ * @public
+ */
 export interface ComboboxItem {
+  /** The value of the item, used for selection. */
   value: string;
+  /** The display label of the item. */
   label: ReactNode;
 }
 
+/**
+ * Props for the {@link Combobox} component.
+ * @public
+ */
 interface ComboboxProps {
+  /** The list of items to display in the combobox. */
   items: ComboboxItem[];
+  /** The currently selected value. */
   value?: string;
+  /** Optional label to display above the combobox. */
   label?: string;
+  /** Callback function called when the selection changes. */
   onChange: (_value: string) => void;
+  /** Text to display when no item is selected. */
   placeholder?: string;
+  /** Whether the combobox is disabled. */
   disabled?: boolean;
+  /**
+   * Strategy for auto-selecting an item when the component mounts or items change.
+   * Can be a boolean or a function that returns an item to select.
+   */
   autoselect?:
     | boolean
     | ((_items: ComboboxItem[]) => ComboboxItem | undefined);
+  /** Optional CSS class name for the root element. */
   className?: string;
 }
 
+/**
+ * A searchable dropdown selection component.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the combobox.
+ * @public
+ */
 export function Combobox({
   items,
   value,

--- a/cat-launcher/src/components/ui/command.tsx
+++ b/cat-launcher/src/components/ui/command.tsx
@@ -11,6 +11,15 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+/**
+ * The root component for the command palette.
+ * Built on top of the `cmdk` library.
+ *
+ * @param props - The properties for the command component.
+ * @returns A React element representing the command palette root.
+ *
+ * @public
+ */
 function Command({
   className,
   ...props
@@ -27,6 +36,14 @@ function Command({
   );
 }
 
+/**
+ * A dialog component that contains a command palette.
+ *
+ * @param props - The properties for the command dialog, including title, description, and an option to show a close button.
+ * @returns A React element representing the command dialog.
+ *
+ * @public
+ */
 function CommandDialog({
   title = "Command Palette",
   description = "Search for a command to run...",
@@ -58,6 +75,14 @@ function CommandDialog({
   );
 }
 
+/**
+ * The input field for searching within the command palette.
+ *
+ * @param props - The properties for the command input component.
+ * @returns A React element representing the command input.
+ *
+ * @public
+ */
 function CommandInput({
   className,
   ...props
@@ -80,6 +105,14 @@ function CommandInput({
   );
 }
 
+/**
+ * A container for the list of items in the command palette.
+ *
+ * @param props - The properties for the command list component.
+ * @returns A React element representing the command list.
+ *
+ * @public
+ */
 function CommandList({
   className,
   ...props
@@ -96,6 +129,14 @@ function CommandList({
   );
 }
 
+/**
+ * The component to display when no search results are found.
+ *
+ * @param props - The properties for the command empty component.
+ * @returns A React element representing the empty state of the command palette.
+ *
+ * @public
+ */
 function CommandEmpty({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
@@ -108,6 +149,14 @@ function CommandEmpty({
   );
 }
 
+/**
+ * A component for grouping items in the command palette.
+ *
+ * @param props - The properties for the command group component.
+ * @returns A React element representing a group of command items.
+ *
+ * @public
+ */
 function CommandGroup({
   className,
   ...props
@@ -124,6 +173,14 @@ function CommandGroup({
   );
 }
 
+/**
+ * A separator for dividing groups or items in the command palette.
+ *
+ * @param props - The properties for the command separator component.
+ * @returns A React element representing a separator.
+ *
+ * @public
+ */
 function CommandSeparator({
   className,
   ...props
@@ -137,6 +194,14 @@ function CommandSeparator({
   );
 }
 
+/**
+ * An individual item within the command palette.
+ *
+ * @param props - The properties for the command item component.
+ * @returns A React element representing a command item.
+ *
+ * @public
+ */
 function CommandItem({
   className,
   ...props
@@ -153,6 +218,14 @@ function CommandItem({
   );
 }
 
+/**
+ * A shortcut key display for a command item.
+ *
+ * @param props - The properties for the command shortcut component.
+ * @returns A React element representing a command shortcut.
+ *
+ * @public
+ */
 function CommandShortcut({
   className,
   ...props

--- a/cat-launcher/src/components/ui/dialog.tsx
+++ b/cat-launcher/src/components/ui/dialog.tsx
@@ -6,12 +6,20 @@ import { XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Root component for a dialog (modal) window.
+ * @public
+ */
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
+/**
+ * Element that triggers the opening of a {@link Dialog}.
+ * @public
+ */
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
@@ -20,6 +28,10 @@ function DialogTrigger({
   );
 }
 
+/**
+ * Portals the dialog content to a separate DOM node (usually the body).
+ * @public
+ */
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
@@ -28,6 +40,10 @@ function DialogPortal({
   );
 }
 
+/**
+ * Element that closes an open {@link Dialog}.
+ * @public
+ */
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
@@ -36,6 +52,13 @@ function DialogClose({
   );
 }
 
+/**
+ * The dim backdrop that appears behind the {@link DialogContent}.
+ *
+ * @param props - Overlay component props.
+ * @returns A React element representing the dialog overlay.
+ * @public
+ */
 function DialogOverlay({
   className,
   ...props
@@ -52,12 +75,20 @@ function DialogOverlay({
   );
 }
 
+/**
+ * The main container for the content within a {@link Dialog}.
+ *
+ * @param props - Content component props, including an optional `showCloseButton`.
+ * @returns A React element representing the dialog content.
+ * @public
+ */
 function DialogContent({
   className,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  /** Whether to show the default close (X) button in the corner. */
   showCloseButton?: boolean;
 }) {
   return (
@@ -86,6 +117,13 @@ function DialogContent({
   );
 }
 
+/**
+ * Header section of a {@link Dialog}, typically containing {@link DialogTitle}.
+ *
+ * @param props - Div component props.
+ * @returns A React element representing the dialog header.
+ * @public
+ */
 function DialogHeader({
   className,
   ...props
@@ -102,6 +140,13 @@ function DialogHeader({
   );
 }
 
+/**
+ * Footer section of a {@link Dialog}, typically containing action buttons.
+ *
+ * @param props - Div component props.
+ * @returns A React element representing the dialog footer.
+ * @public
+ */
 function DialogFooter({
   className,
   ...props
@@ -118,6 +163,13 @@ function DialogFooter({
   );
 }
 
+/**
+ * The title component for a {@link Dialog}.
+ *
+ * @param props - Title component props.
+ * @returns A React element representing the dialog title.
+ * @public
+ */
 function DialogTitle({
   className,
   ...props
@@ -131,6 +183,13 @@ function DialogTitle({
   );
 }
 
+/**
+ * The description component for a {@link Dialog}, providing additional context.
+ *
+ * @param props - Description component props.
+ * @returns A React element representing the dialog description.
+ * @public
+ */
 function DialogDescription({
   className,
   ...props

--- a/cat-launcher/src/components/ui/dropdown-menu.tsx
+++ b/cat-launcher/src/components/ui/dropdown-menu.tsx
@@ -8,6 +8,15 @@ import {
 
 import { cn } from "@/lib/utils";
 
+/**
+ * The root component of a dropdown menu, which manages its open/closed state.
+ * Built on top of Radix UI's DropdownMenu primitive.
+ *
+ * @param props - The properties for the dropdown menu root.
+ * @returns A React element representing the dropdown menu root.
+ *
+ * @public
+ */
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -19,6 +28,14 @@ function DropdownMenu({
   );
 }
 
+/**
+ * A portal component that renders the dropdown menu content into a separate DOM node.
+ *
+ * @param props - The properties for the dropdown menu portal.
+ * @returns A React element representing the dropdown menu portal.
+ *
+ * @public
+ */
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
@@ -30,6 +47,14 @@ function DropdownMenuPortal({
   );
 }
 
+/**
+ * The trigger element that opens the dropdown menu when interacted with.
+ *
+ * @param props - The properties for the dropdown menu trigger.
+ * @returns A React element representing the dropdown menu trigger.
+ *
+ * @public
+ */
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
@@ -41,6 +66,14 @@ function DropdownMenuTrigger({
   );
 }
 
+/**
+ * The content that is displayed inside the dropdown menu when it is open.
+ *
+ * @param props - The properties for the dropdown menu content.
+ * @returns A React element representing the dropdown menu content.
+ *
+ * @public
+ */
 function DropdownMenuContent({
   className,
   sideOffset = 4,
@@ -61,6 +94,14 @@ function DropdownMenuContent({
   );
 }
 
+/**
+ * A component for grouping dropdown menu items together.
+ *
+ * @param props - The properties for the dropdown menu group.
+ * @returns A React element representing the dropdown menu group.
+ *
+ * @public
+ */
 function DropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
@@ -72,6 +113,14 @@ function DropdownMenuGroup({
   );
 }
 
+/**
+ * An individual item within the dropdown menu.
+ *
+ * @param props - The properties for the dropdown menu item, including an optional `inset` for indentation and a visual `variant`.
+ * @returns A React element representing the dropdown menu item.
+ *
+ * @public
+ */
 function DropdownMenuItem({
   className,
   inset,
@@ -95,6 +144,14 @@ function DropdownMenuItem({
   );
 }
 
+/**
+ * A dropdown menu item that can be toggled on and off.
+ *
+ * @param props - The properties for the dropdown menu checkbox item.
+ * @returns A React element representing the dropdown menu checkbox item.
+ *
+ * @public
+ */
 function DropdownMenuCheckboxItem({
   className,
   children,
@@ -121,6 +178,14 @@ function DropdownMenuCheckboxItem({
   );
 }
 
+/**
+ * A container for a set of radio items within a dropdown menu.
+ *
+ * @param props - The properties for the dropdown menu radio group.
+ * @returns A React element representing the dropdown menu radio group.
+ *
+ * @public
+ */
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
@@ -132,6 +197,14 @@ function DropdownMenuRadioGroup({
   );
 }
 
+/**
+ * An individual radio item within a dropdown menu radio group.
+ *
+ * @param props - The properties for the dropdown menu radio item.
+ * @returns A React element representing the dropdown menu radio item.
+ *
+ * @public
+ */
 function DropdownMenuRadioItem({
   className,
   children,
@@ -156,6 +229,14 @@ function DropdownMenuRadioItem({
   );
 }
 
+/**
+ * A label for a section of the dropdown menu.
+ *
+ * @param props - The properties for the dropdown menu label, including an optional `inset` for indentation.
+ * @returns A React element representing the dropdown menu label.
+ *
+ * @public
+ */
 function DropdownMenuLabel({
   className,
   inset,
@@ -176,6 +257,14 @@ function DropdownMenuLabel({
   );
 }
 
+/**
+ * A horizontal line that separates items in the dropdown menu.
+ *
+ * @param props - The properties for the dropdown menu separator.
+ * @returns A React element representing the dropdown menu separator.
+ *
+ * @public
+ */
 function DropdownMenuSeparator({
   className,
   ...props
@@ -189,6 +278,14 @@ function DropdownMenuSeparator({
   );
 }
 
+/**
+ * A shortcut key display for a dropdown menu item.
+ *
+ * @param props - The properties for the dropdown menu shortcut.
+ * @returns A React element representing the dropdown menu shortcut.
+ *
+ * @public
+ */
 function DropdownMenuShortcut({
   className,
   ...props
@@ -205,6 +302,14 @@ function DropdownMenuShortcut({
   );
 }
 
+/**
+ * The root component of a submenu within a dropdown menu.
+ *
+ * @param props - The properties for the dropdown menu submenu.
+ * @returns A React element representing the dropdown menu submenu.
+ *
+ * @public
+ */
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
@@ -216,6 +321,14 @@ function DropdownMenuSub({
   );
 }
 
+/**
+ * The trigger element that opens a submenu when interacted with.
+ *
+ * @param props - The properties for the dropdown menu submenu trigger, including an optional `inset` for indentation.
+ * @returns A React element representing the dropdown menu submenu trigger.
+ *
+ * @public
+ */
 function DropdownMenuSubTrigger({
   className,
   inset,
@@ -240,6 +353,14 @@ function DropdownMenuSubTrigger({
   );
 }
 
+/**
+ * The content that is displayed inside a submenu when it is open.
+ *
+ * @param props - The properties for the dropdown menu submenu content.
+ * @returns A React element representing the dropdown menu submenu content.
+ *
+ * @public
+ */
 function DropdownMenuSubContent({
   className,
   ...props

--- a/cat-launcher/src/components/ui/field.tsx
+++ b/cat-launcher/src/components/ui/field.tsx
@@ -5,6 +5,14 @@ import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 
+/**
+ * A fieldset component for grouping related elements in a form.
+ *
+ * @param props - The properties for the fieldset component.
+ * @returns A React element representing the fieldset.
+ *
+ * @public
+ */
 function FieldSet({
   className,
   ...props
@@ -22,6 +30,14 @@ function FieldSet({
   );
 }
 
+/**
+ * A legend component for a fieldset, providing a caption.
+ *
+ * @param props - The properties for the field legend component, including an optional visual `variant`.
+ * @returns A React element representing the field legend.
+ *
+ * @public
+ */
 function FieldLegend({
   className,
   variant = "legend",
@@ -44,6 +60,14 @@ function FieldLegend({
   );
 }
 
+/**
+ * A container for grouping fields together.
+ *
+ * @param props - The properties for the field group component.
+ * @returns A React element representing the field group.
+ *
+ * @public
+ */
 function FieldGroup({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
@@ -57,6 +81,11 @@ function FieldGroup({ className, ...props }: ComponentProps<"div">) {
   );
 }
 
+/**
+ * Defines the visual variants for the Field component, supporting different orientations.
+ *
+ * @public
+ */
 const fieldVariants = cva(
   "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
   {
@@ -81,6 +110,14 @@ const fieldVariants = cva(
   },
 );
 
+/**
+ * A wrapper for a single field, including label, input, description, and error message.
+ *
+ * @param props - The properties for the field component, including orientation.
+ * @returns A React element representing the field.
+ *
+ * @public
+ */
 function Field({
   className,
   orientation = "vertical",
@@ -97,6 +134,14 @@ function Field({
   );
 }
 
+/**
+ * A container for the main content of a field (e.g., the input).
+ *
+ * @param props - The properties for the field content component.
+ * @returns A React element representing the field content.
+ *
+ * @public
+ */
 function FieldContent({
   className,
   ...props
@@ -113,6 +158,14 @@ function FieldContent({
   );
 }
 
+/**
+ * A label component specifically styled for use within a Field.
+ *
+ * @param props - The properties for the field label component.
+ * @returns A React element representing the field label.
+ *
+ * @public
+ */
 function FieldLabel({
   className,
   ...props
@@ -131,6 +184,14 @@ function FieldLabel({
   );
 }
 
+/**
+ * A simpler title component for use within a Field when a full Label is not needed.
+ *
+ * @param props - The properties for the field title component.
+ * @returns A React element representing the field title.
+ *
+ * @public
+ */
 function FieldTitle({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
@@ -144,6 +205,14 @@ function FieldTitle({ className, ...props }: ComponentProps<"div">) {
   );
 }
 
+/**
+ * A description component for providing additional context for a field.
+ *
+ * @param props - The properties for the field description component.
+ * @returns A React element representing the field description.
+ *
+ * @public
+ */
 function FieldDescription({
   className,
   ...props
@@ -162,6 +231,14 @@ function FieldDescription({
   );
 }
 
+/**
+ * A separator component for visually dividing sections within a field group.
+ *
+ * @param props - The properties for the field separator component, which can optionally include children.
+ * @returns A React element representing the field separator.
+ *
+ * @public
+ */
 function FieldSeparator({
   children,
   className,
@@ -192,6 +269,14 @@ function FieldSeparator({
   );
 }
 
+/**
+ * A component for displaying error messages related to a field.
+ *
+ * @param props - The properties for the field error component, including an optional `errors` array.
+ * @returns A React element representing the field error, or null if no errors are present.
+ *
+ * @public
+ */
 function FieldError({
   className,
   children,

--- a/cat-launcher/src/components/ui/input.tsx
+++ b/cat-launcher/src/components/ui/input.tsx
@@ -2,6 +2,14 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A standard input component for user text entry.
+ *
+ * @param props - The properties for the input component, extending standard HTML input attributes.
+ * @returns A React element representing the input.
+ *
+ * @public
+ */
 function Input({
   className,
   type,

--- a/cat-launcher/src/components/ui/label.tsx
+++ b/cat-launcher/src/components/ui/label.tsx
@@ -3,6 +3,15 @@ import * as LabelPrimitive from "@radix-ui/react-label";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A label component that provides a caption for an item in a user interface.
+ * Built on top of Radix UI's Label primitive.
+ *
+ * @param props - The properties for the label component, extending Radix UI's Label root properties.
+ * @returns A React element representing the label.
+ *
+ * @public
+ */
 function Label({
   className,
   ...props

--- a/cat-launcher/src/components/ui/popover.tsx
+++ b/cat-launcher/src/components/ui/popover.tsx
@@ -3,12 +3,29 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * The root component of a popover, which manages its open/closed state.
+ * Built on top of Radix UI's Popover primitive.
+ *
+ * @param props - The properties for the popover root component.
+ * @returns A React element representing the popover root.
+ *
+ * @public
+ */
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
+/**
+ * The trigger element that opens the popover when interacted with.
+ *
+ * @param props - The properties for the popover trigger component.
+ * @returns A React element representing the popover trigger.
+ *
+ * @public
+ */
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
@@ -20,6 +37,14 @@ function PopoverTrigger({
   );
 }
 
+/**
+ * The content that is displayed inside the popover when it is open.
+ *
+ * @param props - The properties for the popover content component, including alignment and side offset.
+ * @returns A React element representing the popover content.
+ *
+ * @public
+ */
 function PopoverContent({
   className,
   align = "center",
@@ -42,6 +67,14 @@ function PopoverContent({
   );
 }
 
+/**
+ * An optional anchor element that the popover will position itself relative to.
+ *
+ * @param props - The properties for the popover anchor component.
+ * @returns A React element representing the popover anchor.
+ *
+ * @public
+ */
 function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {

--- a/cat-launcher/src/components/ui/progress.tsx
+++ b/cat-launcher/src/components/ui/progress.tsx
@@ -3,6 +3,14 @@ import * as ProgressPrimitive from "@radix-ui/react-progress";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A progress bar component that visualizes the completion status of a task.
+ * Supports displaying text children that change color based on the filled progress.
+ *
+ * @param props - Component props, extending Radix UI's Progress Root props.
+ * @returns A React element representing the progress bar.
+ * @public
+ */
 function Progress({
   className,
   value,

--- a/cat-launcher/src/components/ui/separator.tsx
+++ b/cat-launcher/src/components/ui/separator.tsx
@@ -3,6 +3,13 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A visual divider component used to separate content.
+ *
+ * @param props - Component props extending Radix UI's Separator Root props.
+ * @returns A React element representing the separator.
+ * @public
+ */
 function Separator({
   className,
   orientation = "horizontal",

--- a/cat-launcher/src/components/ui/sonner.tsx
+++ b/cat-launcher/src/components/ui/sonner.tsx
@@ -2,6 +2,13 @@ import { CSSProperties } from "react";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, ToasterProps } from "sonner";
 
+/**
+ * A toast notification component that integrates with the application's theme.
+ *
+ * @param props - Component props extending {@link ToasterProps} from the sonner library.
+ * @returns A React element representing the toast notification provider.
+ * @public
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
 

--- a/cat-launcher/src/components/ui/table.tsx
+++ b/cat-launcher/src/components/ui/table.tsx
@@ -2,6 +2,13 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Main container for a data table.
+ *
+ * @param props - Table element props.
+ * @returns A React element representing the table.
+ * @public
+ */
 function Table({
   className,
   ...props
@@ -20,6 +27,13 @@ function Table({
   );
 }
 
+/**
+ * The header section of a {@link Table}.
+ *
+ * @param props - Thead element props.
+ * @returns A React element representing the table header.
+ * @public
+ */
 function TableHeader({
   className,
   ...props
@@ -33,6 +47,13 @@ function TableHeader({
   );
 }
 
+/**
+ * The body section of a {@link Table}.
+ *
+ * @param props - Tbody element props.
+ * @returns A React element representing the table body.
+ * @public
+ */
 function TableBody({
   className,
   ...props
@@ -46,6 +67,13 @@ function TableBody({
   );
 }
 
+/**
+ * The footer section of a {@link Table}.
+ *
+ * @param props - Tfoot element props.
+ * @returns A React element representing the table footer.
+ * @public
+ */
 function TableFooter({
   className,
   ...props
@@ -62,6 +90,13 @@ function TableFooter({
   );
 }
 
+/**
+ * A row within a {@link Table}.
+ *
+ * @param props - Tr element props.
+ * @returns A React element representing a table row.
+ * @public
+ */
 function TableRow({
   className,
   ...props
@@ -78,6 +113,13 @@ function TableRow({
   );
 }
 
+/**
+ * A header cell within a {@link TableHeader}.
+ *
+ * @param props - Th element props.
+ * @returns A React element representing a table head cell.
+ * @public
+ */
 function TableHead({
   className,
   ...props
@@ -94,6 +136,13 @@ function TableHead({
   );
 }
 
+/**
+ * A data cell within a {@link TableRow}.
+ *
+ * @param props - Td element props.
+ * @returns A React element representing a table cell.
+ * @public
+ */
 function TableCell({
   className,
   ...props
@@ -110,6 +159,13 @@ function TableCell({
   );
 }
 
+/**
+ * A caption for a {@link Table}.
+ *
+ * @param props - Caption element props.
+ * @returns A React element representing the table caption.
+ * @public
+ */
 function TableCaption({
   className,
   ...props

--- a/cat-launcher/src/components/ui/textarea.tsx
+++ b/cat-launcher/src/components/ui/textarea.tsx
@@ -2,6 +2,13 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * A multi-line text input component.
+ *
+ * @param props - Textarea element props.
+ * @returns A React element representing the textarea.
+ * @public
+ */
 function Textarea({
   className,
   ...props

--- a/cat-launcher/src/components/ui/tooltip.tsx
+++ b/cat-launcher/src/components/ui/tooltip.tsx
@@ -5,12 +5,31 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Provider component for the tooltip system. Wrap your app or section with this.
+ * @public
+ */
 const TooltipProvider = TooltipPrimitive.Provider;
 
+/**
+ * Root component for an individual tooltip.
+ * @public
+ */
 const Tooltip = TooltipPrimitive.Root;
 
+/**
+ * Element that triggers the tooltip on hover, focus, or tap.
+ * @public
+ */
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+/**
+ * The content displayed within the tooltip when it is active.
+ *
+ * @param props - Tooltip content props.
+ * @returns A React element representing the tooltip content.
+ * @public
+ */
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>

--- a/cat-launcher/src/components/virtualized-combobox.tsx
+++ b/cat-launcher/src/components/virtualized-combobox.tsx
@@ -20,19 +20,44 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
+/**
+ * Represents an individual item in the combobox.
+ *
+ * @public
+ */
 export interface ComboboxItem {
+  /** The internal value of the item. */
   value: string;
+  /** The display label of the item, which can be a React node. */
   label: ReactNode;
 }
 
+/**
+ * Properties for the internal {@link VirtualizedCommand} component.
+ *
+ * @internal
+ */
 interface VirtualizedCommandProps {
+  /** The height of the virtualized list. */
   height: string;
+  /** The list of items to display. */
   items: ComboboxItem[];
+  /** Placeholder text for the search input. */
   placeholder: string;
+  /** The currently selected value. */
   value?: string;
+  /** Callback function triggered when an item is selected. */
   onSelect?: (_value: string) => void;
 }
 
+/**
+ * A virtualized command component for efficient rendering of large lists within a command palette.
+ *
+ * @param props - The properties for the virtualized command component.
+ * @returns A React element representing the virtualized command.
+ *
+ * @internal
+ */
 const VirtualizedCommand = ({
   height,
   items,
@@ -134,19 +159,44 @@ const VirtualizedCommand = ({
   );
 };
 
+/**
+ * Properties for the {@link VirtualizedCombobox} component.
+ *
+ * @public
+ */
 interface ComboboxProps {
+  /** The list of items to display in the combobox. */
   items: ComboboxItem[];
+  /** The currently selected value. */
   value?: string;
+  /** An optional label to display above the combobox. */
   label?: string;
+  /** Callback function triggered when the selection changes. */
   onChange: (value: string) => void;
+  /** Placeholder text when no item is selected. */
   placeholder?: string;
+  /** Whether the combobox is disabled. */
   disabled?: boolean;
+  /**
+   * Whether to automatically select an item.
+   * Can be a boolean or a function that returns the item to select.
+   */
   autoselect?:
     | boolean
     | ((items: ComboboxItem[]) => ComboboxItem | undefined);
+  /** Additional CSS class names for the container. */
   className?: string;
 }
 
+/**
+ * A virtualized combobox component for selecting an item from a potentially large list.
+ * Combines a button trigger with a popover containing a virtualized list.
+ *
+ * @param props - The properties for the virtualized combobox.
+ * @returns A React element representing the virtualized combobox.
+ *
+ * @public
+ */
 export function VirtualizedCombobox({
   items,
   value,

--- a/cat-launcher/src/hooks/useBackups.ts
+++ b/cat-launcher/src/hooks/useBackups.ts
@@ -4,6 +4,12 @@ import { GameVariant } from "@/generated-types/GameVariant";
 import { listBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that fetches the list of automatic backups for a specific game variant.
+ *
+ * @param variant - The game variant to fetch backups for.
+ * @returns An object containing the list of backups, loading state, and error information.
+ */
 export function useBackups(variant: GameVariant) {
   const {
     data: backups = [],

--- a/cat-launcher/src/hooks/useCombinedBackups.ts
+++ b/cat-launcher/src/hooks/useCombinedBackups.ts
@@ -10,15 +10,44 @@ import { useRestoreBackup } from "./useRestoreBackup";
 import { useRestoreManualBackup } from "./useRestoreManualBackup";
 import { useCreateManualBackup } from "./useCreateManualBackup";
 
+/**
+ * Options for the {@link useCombinedBackups} hook.
+ */
 interface UseCombinedBackupsOptions {
+  /**
+   * Callback function executed when a backup is successfully deleted.
+   */
   onDeleteSuccess?: () => void;
+  /**
+   * Callback function executed when backup deletion fails.
+   */
   onDeleteError?: (error: unknown) => void;
+  /**
+   * Callback function executed when a backup is successfully restored.
+   */
   onRestoreSuccess?: () => void;
+  /**
+   * Callback function executed when backup restoration fails.
+   */
   onRestoreError?: (error: unknown) => void;
+  /**
+   * Callback function executed when a manual backup is successfully created.
+   */
   onCreateSuccess?: () => void;
+  /**
+   * Callback function executed when manual backup creation fails.
+   */
   onCreateError?: (error: unknown) => void;
 }
 
+/**
+ * A custom hook that combines automatic and manual backups for a specific game variant.
+ * It provides unified functions for listing, creating, deleting, and restoring backups.
+ *
+ * @param variant - The game variant to manage backups for.
+ * @param options - Optional callbacks for various backup operations.
+ * @returns An object containing the combined backups, loading state, and management functions.
+ */
 export function useCombinedBackups(
   variant: GameVariant,
   {

--- a/cat-launcher/src/hooks/useCreateManualBackup.ts
+++ b/cat-launcher/src/hooks/useCreateManualBackup.ts
@@ -5,10 +5,24 @@ import { createManualBackupForVariant } from "@/lib/commands";
 import { ManualBackupEntry } from "@/generated-types/ManualBackupEntry";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that provides a mutation for creating a manual backup for a game variant.
+ * It implements optimistic updates to the manual backups list.
+ *
+ * @param variant - The game variant to create a backup for.
+ * @param options - Optional callbacks for success and error states.
+ * @returns An object containing the `createManualBackup` mutation function and its pending state.
+ */
 export function useCreateManualBackup(
   variant: GameVariant,
   options: {
+    /**
+     * Callback function executed when the creation is successful.
+     */
     onSuccess?: () => void;
+    /**
+     * Callback function executed when the creation fails.
+     */
     onError?: (error: unknown) => void;
   } = {},
 ) {

--- a/cat-launcher/src/hooks/useDebounce.ts
+++ b/cat-launcher/src/hooks/useDebounce.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect } from "react";
 
+/**
+ * A custom hook that returns a debounced version of the provided value.
+ * The debounced value will only update after the specified delay has passed without any new updates to the original value.
+ *
+ * @param value - The value to debounce.
+ * @param delay - The debounce delay in milliseconds.
+ * @returns The debounced value.
+ */
 export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 

--- a/cat-launcher/src/hooks/useDeleteBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteBackup.ts
@@ -5,11 +5,28 @@ import { queryKeys } from "@/lib/queryKeys";
 import { GameVariant } from "@/generated-types/GameVariant";
 import { BackupEntry } from "@/generated-types/BackupEntry";
 
+/**
+ * Options for the {@link useDeleteBackup} hook.
+ */
 interface UseDeleteBackupOptions {
+  /**
+   * Callback function executed when the deletion is successful.
+   */
   onSuccess?: () => void;
+  /**
+   * Callback function executed when the deletion fails.
+   */
   onError?: (error: unknown) => void;
 }
 
+/**
+ * A custom hook that provides a mutation for deleting an automatic backup.
+ * It implements optimistic updates to the backups list.
+ *
+ * @param variant - The game variant the backup belongs to.
+ * @param options - Optional callbacks for success and error states.
+ * @returns An object containing the `deleteBackup` mutation function.
+ */
 export function useDeleteBackup(
   variant: GameVariant,
   { onSuccess, onError }: UseDeleteBackupOptions = {},

--- a/cat-launcher/src/hooks/useDeleteManualBackup.ts
+++ b/cat-launcher/src/hooks/useDeleteManualBackup.ts
@@ -5,10 +5,24 @@ import { deleteManualBackupById } from "@/lib/commands";
 import { ManualBackupEntry } from "@/generated-types/ManualBackupEntry";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that provides a mutation for deleting a manual backup.
+ * It implements optimistic updates to the manual backups list.
+ *
+ * @param variant - The game variant the backup belongs to.
+ * @param options - Optional callbacks for success and error states.
+ * @returns An object containing the `deleteManualBackup` mutation function.
+ */
 export function useDeleteManualBackup(
   variant: GameVariant,
   options: {
+    /**
+     * Callback function executed when the deletion is successful.
+     */
     onSuccess?: () => void;
+    /**
+     * Callback function executed when the deletion fails.
+     */
     onError?: (error: unknown) => void;
   } = {},
 ) {

--- a/cat-launcher/src/hooks/useGameVariants.ts
+++ b/cat-launcher/src/hooks/useGameVariants.ts
@@ -13,11 +13,26 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { useEffect } from "react";
 
+/**
+ * Options for the {@link useGameVariants} hook.
+ */
 interface UseGameVariantsOptions {
+  /**
+   * Callback function executed when updating the variant order fails.
+   */
   onOrderUpdateError?: (error: unknown) => void;
+  /**
+   * Callback function executed when fetching variants fails.
+   */
   onFetchError?: (error: unknown) => void;
 }
 
+/**
+ * A custom hook that manages the list of game variants and their display order.
+ *
+ * @param options - Optional callbacks for order update and fetch errors.
+ * @returns An object containing the list of game variants, an update function, and state information.
+ */
 export function useGameVariants({
   onOrderUpdateError,
   onFetchError,

--- a/cat-launcher/src/hooks/useInstallAndMonitor.ts
+++ b/cat-launcher/src/hooks/useInstallAndMonitor.ts
@@ -11,14 +11,32 @@ import {
   setDownloadProgress,
 } from "@/store/installationProgressSlice";
 
+/**
+ * Represents the type of installation being performed.
+ */
 type InstallationType = "release" | "mod" | "soundpack" | "tileset";
 
+/**
+ * Function type for performing an installation.
+ */
 type InstallationFunction<T> = (
   id: string,
   variant: GameVariant,
   onProgress: (progress: DownloadProgress) => void,
 ) => Promise<T>;
 
+/**
+ * A custom hook that handles the installation of various game components (releases, mods, etc.)
+ * and monitors the download progress, syncing it with the Redux store.
+ *
+ * @param type - The type of component being installed.
+ * @param variant - The game variant.
+ * @param id - The unique identifier of the component being installed.
+ * @param installationFunction - The function that performs the installation and reports progress.
+ * @param onSuccess - Optional callback executed upon successful installation.
+ * @param onError - Optional callback executed upon installation error.
+ * @returns An object containing the install function, installation status, and download progress.
+ */
 export function useInstallAndMonitor<T>(
   type: InstallationType,
   variant: GameVariant,

--- a/cat-launcher/src/hooks/useManualBackups.ts
+++ b/cat-launcher/src/hooks/useManualBackups.ts
@@ -4,6 +4,12 @@ import { GameVariant } from "@/generated-types/GameVariant";
 import { listManualBackupsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that fetches the list of manual backups for a specific game variant.
+ *
+ * @param variant - The game variant to fetch manual backups for.
+ * @returns An object containing the list of manual backups and the loading state.
+ */
 export function useManualBackups(variant: GameVariant) {
   const { data: manualBackups, isLoading } = useQuery({
     queryKey: queryKeys.manualBackups(variant),

--- a/cat-launcher/src/hooks/usePlayTimeMonitor.ts
+++ b/cat-launcher/src/hooks/usePlayTimeMonitor.ts
@@ -6,9 +6,22 @@ import { logPlayTime } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 import { toastCL } from "@/lib/utils";
 
+/**
+ * The duration in seconds after which play time is logged to the backend.
+ */
 const DURATION_TO_LOG_SECONDS = 60;
+/**
+ * The interval in milliseconds at which the play time monitor checks for logging.
+ */
 const INTERVAL_MS = DURATION_TO_LOG_SECONDS * 1000;
 
+/**
+ * A custom hook that monitors and logs play time for the currently playing game variant.
+ * It periodically sends play time updates to the backend and invalidates related queries.
+ *
+ * @param currentlyPlaying - The game variant currently being played, or null if none.
+ * @param currentlyPlayingVersion - The version of the game variant currently being played, or null if none.
+ */
 export function usePlayTimeMonitor(
   currentlyPlaying: GameVariant | null,
   currentlyPlayingVersion: string | null,

--- a/cat-launcher/src/hooks/useRestoreBackup.ts
+++ b/cat-launcher/src/hooks/useRestoreBackup.ts
@@ -2,11 +2,26 @@ import { useMutation } from "@tanstack/react-query";
 
 import { restoreBackupById } from "@/lib/commands";
 
+/**
+ * Options for the {@link useRestoreBackup} hook.
+ */
 interface UseRestoreBackupOptions {
+  /**
+   * Callback function executed when the restoration is successful.
+   */
   onSuccess?: () => void;
+  /**
+   * Callback function executed when the restoration fails.
+   */
   onError?: (error: unknown) => void;
 }
 
+/**
+ * A custom hook that provides a mutation for restoring an automatic backup by its ID.
+ *
+ * @param options - Optional callbacks for success and error states.
+ * @returns An object containing the `restoreBackup` mutation function.
+ */
 export function useRestoreBackup({
   onSuccess,
   onError,

--- a/cat-launcher/src/hooks/useRestoreManualBackup.ts
+++ b/cat-launcher/src/hooks/useRestoreManualBackup.ts
@@ -2,9 +2,21 @@ import { useMutation } from "@tanstack/react-query";
 
 import { restoreManualBackupById } from "@/lib/commands";
 
+/**
+ * A custom hook that provides a mutation for restoring a manual backup by its ID.
+ *
+ * @param options - Optional callbacks for success and error states.
+ * @returns An object containing the `restoreManualBackup` mutation function.
+ */
 export function useRestoreManualBackup(
   options: {
+    /**
+     * Callback function executed when the restoration is successful.
+     */
     onSuccess?: () => void;
+    /**
+     * Callback function executed when the restoration fails.
+     */
     onError?: (error: unknown) => void;
   } = {},
 ) {

--- a/cat-launcher/src/hooks/useSearch.ts
+++ b/cat-launcher/src/hooks/useSearch.ts
@@ -2,11 +2,32 @@ import { useMemo, useState } from "react";
 
 import { useDebounce } from "./useDebounce";
 
+/**
+ * Options for the {@link useSearch} hook.
+ */
 export interface UseSearchOptions<T> {
+  /**
+   * The delay in milliseconds for debouncing the search query. Defaults to 300.
+   */
   debounceDelay?: number;
+  /**
+   * A function that determines if an item matches the search query.
+   *
+   * @param item - The item to test.
+   * @param query - The normalized (trimmed and lowercased) search query.
+   * @returns True if the item matches the query, false otherwise.
+   */
   searchFn?: (item: T, query: string) => boolean;
 }
 
+/**
+ * A custom hook that provides searching and filtering functionality for a list of items.
+ * It includes debouncing and normalization of the search query.
+ *
+ * @param items - The list of items to search through.
+ * @param options - Optional search configuration.
+ * @returns An object containing the search query, a setter for the query, filtered items, and search status.
+ */
 export function useSearch<T>(
   items: T[],
   options: UseSearchOptions<T> = {},

--- a/cat-launcher/src/hooks/useSortableItem.ts
+++ b/cat-launcher/src/hooks/useSortableItem.ts
@@ -2,6 +2,12 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { CSSProperties } from "react";
 
+/**
+ * A custom hook that provides sortable functionality for an item using `@dnd-kit/sortable`.
+ *
+ * @param id - The unique identifier of the sortable item.
+ * @returns An object containing dnd-kit attributes, listeners, refs, styles, and dragging state.
+ */
 export function useSortableItem(id: string) {
   const {
     attributes,

--- a/cat-launcher/src/hooks/useThrottle.ts
+++ b/cat-launcher/src/hooks/useThrottle.ts
@@ -1,5 +1,14 @@
 import { useRef, useCallback, useEffect } from "react";
 
+/**
+ * A custom hook that returns a throttled version of the provided function.
+ * The throttled function will only execute at most once every `delay` milliseconds.
+ * If called multiple times within the delay period, it will execute once at the end of the period.
+ *
+ * @param func - The function to throttle.
+ * @param delay - The throttle delay in milliseconds.
+ * @returns A throttled version of the function.
+ */
 export function useThrottle<Args extends unknown[]>(
   func: (...args: Args) => void,
   delay: number,

--- a/cat-launcher/src/hooks/useThrottleWithCancel.ts
+++ b/cat-launcher/src/hooks/useThrottleWithCancel.ts
@@ -1,5 +1,13 @@
 import { useRef, useCallback, useEffect } from "react";
 
+/**
+ * A custom hook that returns a throttled version of the provided function, along with a cancel function.
+ * The throttled function will only execute at most once every `delay` milliseconds.
+ *
+ * @param func - The function to throttle.
+ * @param delay - The throttle delay in milliseconds.
+ * @returns An object containing the throttled function and a cancel function to stop any pending executions.
+ */
 export function useThrottleWithCancel<Args extends unknown[]>(
   func: (...args: Args) => void,
   delay: number,

--- a/cat-launcher/src/lib/commands.ts
+++ b/cat-launcher/src/lib/commands.ts
@@ -25,6 +25,12 @@ import type { Tileset } from "@/generated-types/Tileset";
 import type { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
 import type { UpdateStatus } from "@/generated-types/UpdateStatus";
 
+/**
+ * Listens for a request to quit the application.
+ *
+ * @param onQuitRequested - Callback function to be executed when a quit is requested.
+ * @returns A promise that resolves to an unlisten function.
+ */
 export async function listenToQuitRequested(
   onQuitRequested: () => void,
 ) {
@@ -33,6 +39,12 @@ export async function listenToQuitRequested(
   });
 }
 
+/**
+ * Listens for updates to the available game releases.
+ *
+ * @param onUpdate - Callback function that receives the {@link ReleasesUpdatePayload}.
+ * @returns A promise that resolves to an unlisten function.
+ */
 export async function listenToReleasesUpdate(
   onUpdate: (payload: ReleasesUpdatePayload) => void,
 ) {
@@ -44,6 +56,12 @@ export async function listenToReleasesUpdate(
   );
 }
 
+/**
+ * Listens for updates to the available mods.
+ *
+ * @param onUpdate - Callback function that receives the {@link ModsUpdatePayload}.
+ * @returns A promise that resolves to an unlisten function.
+ */
 export async function listenToModsUpdate(
   onUpdate: (payload: ModsUpdatePayload) => void,
 ) {
@@ -52,6 +70,12 @@ export async function listenToModsUpdate(
   });
 }
 
+/**
+ * Listens for status updates of the autoupdate process.
+ *
+ * @param onUpdate - Callback function that receives the {@link UpdateStatus}.
+ * @returns A promise that resolves to an unlisten function.
+ */
 export async function listenToAutoupdateStatus(
   onUpdate: (payload: UpdateStatus) => void,
 ) {
@@ -60,6 +84,12 @@ export async function listenToAutoupdateStatus(
   });
 }
 
+/**
+ * Listens for generic game events.
+ *
+ * @param onEvent - Callback function that receives the {@link GameEvent}.
+ * @returns A promise that resolves to an unlisten function.
+ */
 export async function listenToGameEvent(
   onEvent: (payload: GameEvent) => void,
 ) {
@@ -68,10 +98,18 @@ export async function listenToGameEvent(
   });
 }
 
+/**
+ * Notifies the backend that the frontend is ready.
+ */
 export async function onFrontendReady(): Promise<void> {
   await emit("frontend-ready");
 }
 
+/**
+ * Triggers a fetch for releases of a specific game variant.
+ *
+ * @param variant - The game variant to fetch releases for.
+ */
 export async function triggerFetchReleasesForVariant(
   variant: GameVariant,
 ): Promise<void> {
@@ -80,6 +118,11 @@ export async function triggerFetchReleasesForVariant(
   });
 }
 
+/**
+ * Fetches information about all supported game variants.
+ *
+ * @returns A promise that resolves to an array of {@link GameVariantInfo}.
+ */
 export async function fetchGameVariantsInfo(): Promise<
   GameVariantInfo[]
 > {
@@ -89,18 +132,34 @@ export async function fetchGameVariantsInfo(): Promise<
   return response;
 }
 
+/**
+ * Deletes a backup entry by its unique identifier.
+ *
+ * @param id - The unique identifier of the backup.
+ */
 export async function deleteBackupById(id: bigint): Promise<void> {
   await invoke("delete_backup_by_id", {
     id,
   });
 }
 
+/**
+ * Restores a backup entry by its unique identifier.
+ *
+ * @param id - The unique identifier of the backup to restore.
+ */
 export async function restoreBackupById(id: bigint): Promise<void> {
   await invoke("restore_backup_by_id", {
     id,
   });
 }
 
+/**
+ * Fetches game tips for a specific variant.
+ *
+ * @param variant - The game variant to fetch tips for.
+ * @returns A promise that resolves to an array of strings representing tips.
+ */
 export async function getTips(
   variant: GameVariant,
 ): Promise<string[]> {
@@ -111,6 +170,12 @@ export async function getTips(
   return response;
 }
 
+/**
+ * Lists all manual backups available for a specific variant.
+ *
+ * @param variant - The game variant to list manual backups for.
+ * @returns A promise that resolves to an array of {@link ManualBackupEntry}.
+ */
 export async function listManualBackupsForVariant(
   variant: GameVariant,
 ): Promise<ManualBackupEntry[]> {
@@ -124,6 +189,13 @@ export async function listManualBackupsForVariant(
   return response;
 }
 
+/**
+ * Creates a manual backup for a specific game variant.
+ *
+ * @param variant - The game variant to create a backup for.
+ * @param name - The name of the manual backup.
+ * @param notes - Optional notes associated with the backup.
+ */
 export async function createManualBackupForVariant(
   variant: GameVariant,
   name: string,
@@ -136,6 +208,11 @@ export async function createManualBackupForVariant(
   });
 }
 
+/**
+ * Deletes a manual backup entry by its unique identifier.
+ *
+ * @param id - The unique identifier of the manual backup.
+ */
 export async function deleteManualBackupById(
   id: bigint,
 ): Promise<void> {
@@ -144,6 +221,11 @@ export async function deleteManualBackupById(
   });
 }
 
+/**
+ * Restores a manual backup entry by its unique identifier.
+ *
+ * @param id - The unique identifier of the manual backup to restore.
+ */
 export async function restoreManualBackupById(
   id: bigint,
 ): Promise<void> {
@@ -152,6 +234,12 @@ export async function restoreManualBackupById(
   });
 }
 
+/**
+ * Lists all automatic backups available for a specific variant.
+ *
+ * @param variant - The game variant to list backups for.
+ * @returns A promise that resolves to an array of {@link BackupEntry}.
+ */
 export async function listBackupsForVariant(
   variant: GameVariant,
 ): Promise<BackupEntry[]> {
@@ -165,6 +253,11 @@ export async function listBackupsForVariant(
   return response;
 }
 
+/**
+ * Updates the display order of game variants.
+ *
+ * @param variants - The new ordered list of game variants.
+ */
 export async function updateGameVariantOrder(
   variants: GameVariant[],
 ): Promise<void> {
@@ -173,6 +266,12 @@ export async function updateGameVariantOrder(
   });
 }
 
+/**
+ * Gets the total play time for a specific game variant.
+ *
+ * @param variant - The game variant to get the play time for.
+ * @returns A promise that resolves to the total play time in seconds.
+ */
 export async function getPlayTimeForVariant(
   variant: GameVariant,
 ): Promise<number> {
@@ -183,6 +282,13 @@ export async function getPlayTimeForVariant(
   return response;
 }
 
+/**
+ * Gets the play time for a specific version of a game variant.
+ *
+ * @param variant - The game variant.
+ * @param version - The specific version string.
+ * @returns A promise that resolves to the play time in seconds.
+ */
 export async function getPlayTimeForVersion(
   variant: GameVariant,
   version: string,
@@ -195,6 +301,13 @@ export async function getPlayTimeForVersion(
   return response;
 }
 
+/**
+ * Logs the play time for a specific version of a game variant.
+ *
+ * @param variant - The game variant.
+ * @param version - The specific version string.
+ * @param durationInSeconds - The duration of the session in seconds.
+ */
 export async function logPlayTime(
   variant: GameVariant,
   version: string,
@@ -207,6 +320,12 @@ export async function logPlayTime(
   });
 }
 
+/**
+ * Gets the currently active (installed/selected) release ID for a variant.
+ *
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the active release ID, or an empty string if none.
+ */
 export async function getActiveRelease(
   variant: GameVariant,
 ): Promise<string> {
@@ -218,6 +337,13 @@ export async function getActiveRelease(
   return response ?? "";
 }
 
+/**
+ * Fetches the release notes for a specific release of a game variant.
+ *
+ * @param variant - The game variant.
+ * @param releaseId - The unique identifier of the release.
+ * @returns A promise that resolves to the release notes as a string, or null if not found.
+ */
 export async function fetchReleaseNotes(
   variant: GameVariant,
   releaseId: string,
@@ -232,6 +358,14 @@ export async function fetchReleaseNotes(
   return response;
 }
 
+/**
+ * Installs a specific release for a game variant, with progress tracking.
+ *
+ * @param releaseId - The unique identifier of the release to install.
+ * @param variant - The game variant.
+ * @param onDownloadProgress - Callback function for download progress updates.
+ * @returns A promise that resolves to the installed {@link GameRelease}.
+ */
 export async function installReleaseForVariant(
   releaseId: string,
   variant: GameVariant,
@@ -251,6 +385,13 @@ export async function installReleaseForVariant(
   return response;
 }
 
+/**
+ * Launches the game with the specified release and optional world.
+ *
+ * @param variant - The game variant.
+ * @param releaseId - The unique identifier of the release to launch.
+ * @param world - Optional world name to load directly.
+ */
 export async function launchGame(
   variant: GameVariant,
   releaseId: string,
@@ -263,6 +404,13 @@ export async function launchGame(
   });
 }
 
+/**
+ * Gets the installation status of a specific release for a game variant.
+ *
+ * @param variant - The game variant.
+ * @param releaseId - The unique identifier of the release.
+ * @returns A promise that resolves to the {@link GameReleaseStatus}.
+ */
 export async function getInstallationStatus(
   variant: GameVariant,
   releaseId: string,
@@ -278,6 +426,12 @@ export async function getInstallationStatus(
   return response;
 }
 
+/**
+ * Gets the name of the last played world for a specific variant.
+ *
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the name of the last played world, or null if none.
+ */
 export async function getLastPlayedWorld(
   variant: GameVariant,
 ): Promise<string | null> {
@@ -291,6 +445,11 @@ export async function getLastPlayedWorld(
   return response;
 }
 
+/**
+ * Gets the user's preferred theme setting.
+ *
+ * @returns A promise that resolves to the {@link ThemePreference}.
+ */
 export async function getPreferredTheme(): Promise<ThemePreference> {
   const response = await invoke<ThemePreference>(
     "get_preferred_theme",
@@ -298,17 +457,32 @@ export async function getPreferredTheme(): Promise<ThemePreference> {
   return response;
 }
 
+/**
+ * Sets the user's preferred theme.
+ *
+ * @param theme - The theme to set as preferred.
+ */
 export async function setPreferredTheme(theme: Theme): Promise<void> {
   await invoke("set_preferred_theme", {
     theme,
   });
 }
 
+/**
+ * Gets the user's unique identifier.
+ *
+ * @returns A promise that resolves to the user ID string.
+ */
 export async function getUserId(): Promise<string> {
   const response = await invoke<string>("get_user_id");
   return response;
 }
 
+/**
+ * Triggers a fetch for available mods for a specific variant.
+ *
+ * @param variant - The game variant to fetch mods for.
+ */
 export async function triggerFetchModsForVariant(
   variant: GameVariant,
 ): Promise<void> {
@@ -317,6 +491,13 @@ export async function triggerFetchModsForVariant(
   });
 }
 
+/**
+ * Installs a third-party mod for a game variant.
+ *
+ * @param modId - The unique identifier of the mod to install.
+ * @param variant - The game variant.
+ * @param onDownloadProgress - Callback function for download progress updates.
+ */
 export async function installThirdPartyMod(
   modId: string,
   variant: GameVariant,
@@ -334,6 +515,13 @@ export async function installThirdPartyMod(
   });
 }
 
+/**
+ * Gets the installation status of a third-party mod.
+ *
+ * @param modId - The unique identifier of the mod.
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the {@link ModInstallationStatus}.
+ */
 export async function getThirdPartyModInstallationStatus(
   modId: string,
   variant: GameVariant,
@@ -348,6 +536,12 @@ export async function getThirdPartyModInstallationStatus(
   return response;
 }
 
+/**
+ * Uninstalls a third-party mod.
+ *
+ * @param modId - The unique identifier of the mod to uninstall.
+ * @param variant - The game variant.
+ */
 export async function uninstallThirdPartyMod(
   modId: string,
   variant: GameVariant,
@@ -358,6 +552,13 @@ export async function uninstallThirdPartyMod(
   });
 }
 
+/**
+ * Gets the last activity recorded for a third-party mod.
+ *
+ * @param modId - The unique identifier of the mod.
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the {@link LastModActivity}.
+ */
 export async function getLastModActivity(
   modId: string,
   variant: GameVariant,
@@ -372,6 +573,12 @@ export async function getLastModActivity(
   return response;
 }
 
+/**
+ * Lists all available tilesets for a specific variant.
+ *
+ * @param variant - The game variant.
+ * @returns A promise that resolves to an array of {@link Tileset}.
+ */
 export async function listAllTilesets(
   variant: GameVariant,
 ): Promise<Tileset[]> {
@@ -384,6 +591,13 @@ export async function listAllTilesets(
   return response;
 }
 
+/**
+ * Installs a third-party tileset for a game variant.
+ *
+ * @param tilesetId - The unique identifier of the tileset to install.
+ * @param variant - The game variant.
+ * @param onDownloadProgress - Callback function for download progress updates.
+ */
 export async function installThirdPartyTileset(
   tilesetId: string,
   variant: GameVariant,
@@ -401,6 +615,13 @@ export async function installThirdPartyTileset(
   });
 }
 
+/**
+ * Gets the installation status of a third-party tileset.
+ *
+ * @param tilesetId - The unique identifier of the tileset.
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the {@link TilesetInstallationStatus}.
+ */
 export async function getThirdPartyTilesetInstallationStatus(
   tilesetId: string,
   variant: GameVariant,
@@ -415,6 +636,12 @@ export async function getThirdPartyTilesetInstallationStatus(
   return response;
 }
 
+/**
+ * Uninstalls a third-party tileset.
+ *
+ * @param tilesetId - The unique identifier of the tileset to uninstall.
+ * @param variant - The game variant.
+ */
 export async function uninstallThirdPartyTileset(
   tilesetId: string,
   variant: GameVariant,
@@ -425,6 +652,12 @@ export async function uninstallThirdPartyTileset(
   });
 }
 
+/**
+ * Lists all available soundpacks for a specific variant.
+ *
+ * @param variant - The game variant.
+ * @returns A promise that resolves to an array of {@link Soundpack}.
+ */
 export async function listAllSoundpacks(
   variant: GameVariant,
 ): Promise<Soundpack[]> {
@@ -437,6 +670,13 @@ export async function listAllSoundpacks(
   return response;
 }
 
+/**
+ * Installs a third-party soundpack for a game variant.
+ *
+ * @param soundpackId - The unique identifier of the soundpack to install.
+ * @param variant - The game variant.
+ * @param onDownloadProgress - Callback function for download progress updates.
+ */
 export async function installThirdPartySoundpack(
   soundpackId: string,
   variant: GameVariant,
@@ -454,6 +694,13 @@ export async function installThirdPartySoundpack(
   });
 }
 
+/**
+ * Gets the installation status of a third-party soundpack.
+ *
+ * @param soundpackId - The unique identifier of the soundpack.
+ * @param variant - The game variant.
+ * @returns A promise that resolves to the {@link SoundpackInstallationStatus}.
+ */
 export async function getThirdPartySoundpackInstallationStatus(
   soundpackId: string,
   variant: GameVariant,
@@ -468,6 +715,12 @@ export async function getThirdPartySoundpackInstallationStatus(
   return response;
 }
 
+/**
+ * Uninstalls a third-party soundpack.
+ *
+ * @param soundpackId - The unique identifier of the soundpack to uninstall.
+ * @param variant - The game variant.
+ */
 export async function uninstallThirdPartySoundpack(
   soundpackId: string,
   variant: GameVariant,
@@ -478,42 +731,81 @@ export async function uninstallThirdPartySoundpack(
   });
 }
 
+/**
+ * Confirms that the application can quit.
+ */
 export async function confirmQuit(): Promise<void> {
   await invoke("confirm_quit");
 }
 
+/**
+ * Fetches all available system/application fonts.
+ *
+ * @returns A promise that resolves to an array of {@link Font}.
+ */
 export async function getFonts(): Promise<Font[]> {
   const response = await invoke<Font[]>("get_fonts");
   return response;
 }
 
+/**
+ * Fetches all available color themes.
+ *
+ * @returns A promise that resolves to an array of {@link ColorTheme}.
+ */
 export async function getColorThemes(): Promise<ColorTheme[]> {
   const response = await invoke<ColorTheme[]>("get_color_themes");
   return response;
 }
 
+/**
+ * Fetches the current application settings.
+ *
+ * @returns A promise that resolves to the current {@link Settings}.
+ */
 export async function getSettings(): Promise<Settings> {
   const response = await invoke<Settings>("get_settings");
   return response;
 }
 
+/**
+ * Fetches the default application settings.
+ *
+ * @returns A promise that resolves to the default {@link Settings}.
+ */
 export async function getDefaultSettings(): Promise<Settings> {
   const response = await invoke<Settings>("get_default_settings");
   return response;
 }
 
+/**
+ * Updates the application settings.
+ *
+ * @param settings - The new settings to apply.
+ */
 export async function updateSettings(
   settings: Settings,
 ): Promise<void> {
   await invoke("update_settings", { settings });
 }
 
+/**
+ * Resets a game variant to its initial state, deleting all associated data.
+ *
+ * @param variant - The game variant to reset.
+ */
 export async function masterReset(
   variant: GameVariant,
 ): Promise<void> {
   await invoke("master_reset", { variant });
 }
 
+/**
+ * Fetches character achievements for a specific variant.
+ *
+ * @param variant - The game variant.
+ * @returns A promise that resolves to an array of {@link CharacterAchievements}.
+ */
 export async function getAchievementsForVariant(
   variant: GameVariant,
 ): Promise<CharacterAchievements[]> {

--- a/cat-launcher/src/lib/constants.ts
+++ b/cat-launcher/src/lib/constants.ts
@@ -1,10 +1,19 @@
 import type { ReleaseType } from "@/generated-types/ReleaseType";
 
+/**
+ * The base URL for checking CatLauncher updates.
+ */
 export const UPDATE_LINK =
   "https://github.com/abhi-kr-2100/CatLauncher/releases/";
 
+/**
+ * The interval in milliseconds at which the "Tip of the Day" is automatically shuffled.
+ */
 export const TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS = 10 * 1000; // 10 seconds
 
+/**
+ * Human-friendly labels for different game release types.
+ */
 export const RELEASE_TYPE_LABELS: Record<ReleaseType, string> = {
   Stable: "Stable",
   ReleaseCandidate: "Release Candidate",

--- a/cat-launcher/src/lib/queryKeys.ts
+++ b/cat-launcher/src/lib/queryKeys.ts
@@ -1,50 +1,110 @@
 import type { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * A collection of query key factories for use with React Query.
+ */
 export const queryKeys = {
+  /**
+   * Key for the active release of a specific game variant.
+   */
   activeRelease: (variant: GameVariant) =>
     ["active_release", variant] as const,
 
+  /**
+   * Key for the installation status of a specific release and variant.
+   */
   installationStatus: (
     variant: GameVariant,
     releaseId: string | undefined,
   ) => ["installation_status", variant, releaseId] as const,
 
+  /**
+   * Key for the list of releases for a specific game variant.
+   */
   releases: (variant: GameVariant) => ["releases", variant] as const,
 
+  /**
+   * Key for release notes of a specific version and variant.
+   */
   releaseNotes: (variant: GameVariant, version: string) =>
     ["release_notes", variant, version] as const,
 
+  /**
+   * Key for game tips of a specific variant.
+   */
   tips: (variant: GameVariant) => ["tips", variant] as const,
 
+  /**
+   * Key for total play time of a specific variant.
+   */
   playTimeForVariant: (variant: GameVariant) =>
     ["play_time_for_variant", variant] as const,
 
+  /**
+   * Key for play time of a specific version and variant.
+   */
   playTimeForVersion: (
     variant: GameVariant,
     releaseId: string | undefined,
   ) => ["play_time_for_version", variant, releaseId] as const,
 
+  /**
+   * Key for general game variants information.
+   */
   gameVariantsInfo: () => ["gameVariantsInfo"] as const,
 
+  /**
+   * Key for the user's unique identifier.
+   */
   userId: () => ["userId"] as const,
 
+  /**
+   * Key for the list of backups for a specific variant.
+   */
   backups: (variant: GameVariant) => ["backups", variant] as const,
 
+  /**
+   * Key for the list of manual backups for a specific variant.
+   */
   manualBackups: (variant: GameVariant) =>
     ["manual-backups", variant] as const,
 
+  /**
+   * Key for the user's theme preference.
+   */
   themePreference: () => ["theme_preference"] as const,
 
+  /**
+   * Query keys for mod-related queries.
+   */
   mods: {
+    /**
+     * Key for listing all mods for a specific variant.
+     */
     listAll: (variant: GameVariant) => ["mods", variant] as const,
+    /**
+     * Key for the installation status of a specific mod and variant.
+     */
     installationStatus: (variant: GameVariant, modId: string) =>
       ["mods", "installation_status", variant, modId] as const,
+    /**
+     * Key for the last activity on a specific mod and variant.
+     */
     lastActivity: (variant: GameVariant, modId: string) =>
       ["mods", "last_activity", variant, modId] as const,
   },
 
+  /**
+   * Query keys for tileset-related queries.
+   */
   tilesets: {
+    /**
+     * Key for listing all tilesets for a specific variant.
+     */
     listAll: (variant: GameVariant) => ["tilesets", variant] as const,
+    /**
+     * Key for the installation status of a specific tileset and variant.
+     */
     installationStatus: (variant: GameVariant, tilesetId: string) =>
       [
         "tilesets",
@@ -54,9 +114,18 @@ export const queryKeys = {
       ] as const,
   },
 
+  /**
+   * Query keys for soundpack-related queries.
+   */
   soundpacks: {
+    /**
+     * Key for listing all soundpacks for a specific variant.
+     */
     listAll: (variant: GameVariant) =>
       ["soundpacks", variant] as const,
+    /**
+     * Key for the installation status of a specific soundpack and variant.
+     */
     installationStatus: (variant: GameVariant, soundpackId: string) =>
       [
         "soundpacks",
@@ -66,15 +135,33 @@ export const queryKeys = {
       ] as const,
   },
 
+  /**
+   * Key for the last played world of a specific variant.
+   */
   lastPlayedWorld: (variant: GameVariant) =>
     ["last_played_world", variant] as const,
 
+  /**
+   * Key for the list of available fonts.
+   */
   fonts: () => ["fonts"] as const,
+  /**
+   * Key for the list of available color themes.
+   */
   colorThemes: () => ["color_themes"] as const,
+  /**
+   * Key for the application settings.
+   */
   settings: () => ["settings"] as const,
 
+  /**
+   * Key for the default application settings.
+   */
   defaultSettings: () => ["default_settings"] as const,
 
+  /**
+   * Key for character achievements of a specific variant.
+   */
   achievements: (variant: GameVariant) =>
     ["achievements", variant] as const,
 };

--- a/cat-launcher/src/lib/types.ts
+++ b/cat-launcher/src/lib/types.ts
@@ -1,10 +1,26 @@
 import type { DownloadProgress } from "@/generated-types/DownloadProgress";
 
+/**
+ * A serializable version of the {@link DownloadProgress} interface.
+ * Useful for passing progress data between different parts of the application where BigInt might not be supported.
+ */
 export interface SerializableDownloadProgress {
+  /**
+   * The number of bytes downloaded so far.
+   */
   bytes_downloaded: number;
+  /**
+   * The total number of bytes to download.
+   */
   total_bytes: number;
 }
 
+/**
+ * Converts a {@link DownloadProgress} object to a {@link SerializableDownloadProgress} object.
+ *
+ * @param progress - The download progress object to convert.
+ * @returns A serializable version of the download progress.
+ */
 export function toSerializableDownloadProgress(
   progress: DownloadProgress,
 ): SerializableDownloadProgress {

--- a/cat-launcher/src/lib/utils.ts
+++ b/cat-launcher/src/lib/utils.ts
@@ -6,10 +6,22 @@ import { twMerge } from "tailwind-merge";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * Merges class names using `clsx` and `tailwind-merge`.
+ *
+ * @param inputs - A list of class values to be merged.
+ * @returns A string of merged class names.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Returns a human-friendly label for a given {@link GameVariant}.
+ *
+ * @param variant - The game variant to get the label for.
+ * @returns The human-friendly label.
+ */
 export function getVariantLabel(variant: GameVariant): string {
   switch (variant) {
     case "DarkDaysAhead":
@@ -21,6 +33,14 @@ export function getVariantLabel(variant: GameVariant): string {
   }
 }
 
+/**
+ * Displays a toast message with a specific level and optional error details.
+ * In development mode, if an error is provided, it also displays the error as an info toast.
+ *
+ * @param level - The severity level of the toast.
+ * @param message - The primary message to display.
+ * @param error - Optional error object for debugging purposes.
+ */
 export function toastCL(
   level: "error" | "warning" | "info" | "success",
   message: string,
@@ -33,14 +53,36 @@ export function toastCL(
   }
 }
 
+/**
+ * Opens a URL in the user's default browser.
+ *
+ * @param url - The URL to open.
+ * @returns A promise that resolves when the URL is opened.
+ */
 export function openLink(url: string) {
   return openUrl(url);
 }
 
+/**
+ * Copies the provided text to the system clipboard.
+ *
+ * @param text - The text to copy.
+ * @returns A promise that resolves when the text is copied.
+ */
 export function copyToClipboard(text: string) {
   return navigator.clipboard.writeText(text);
 }
 
+/**
+ * Sets up an event listener using a provided listen function and handler.
+ * Manages the unlisten lifecycle and handles potential errors.
+ *
+ * @param listenFn - A function that sets up the listener and returns an unlisten function.
+ * @param handler - The function to be called when the event occurs.
+ * @param listenErrorMessage - The error message to display if the listener fails to set up.
+ * @param onError - Optional callback for error handling.
+ * @returns A cleanup function to unlisten from the event.
+ */
 export function setupEventListener<T>(
   listenFn: (handler: (payload: T) => void) => Promise<() => void>,
   handler: (payload: T) => void,
@@ -71,10 +113,23 @@ export function setupEventListener<T>(
   };
 }
 
+/**
+ * Generates a random integer between 0 and n - 1.
+ *
+ * @param n - The upper bound (exclusive).
+ * @returns A random integer.
+ */
 export function randomInt(n: number): number {
   return Math.floor(Math.random() * n);
 }
 
+/**
+ * Sets an interval that executes the callback immediately and then at the specified timeout.
+ *
+ * @param callback - The function to execute.
+ * @param timeout - The interval timeout in milliseconds.
+ * @returns The interval ID.
+ */
 export function setImmediateInterval(
   callback: () => void,
   timeout?: number,
@@ -84,10 +139,22 @@ export function setImmediateInterval(
   return setInterval(callback, timeout);
 }
 
+/**
+ * Converts a snake_case or messy string into a human-friendly format by replacing underscores with spaces and collapsing extra whitespace.
+ *
+ * @param text - The string to format.
+ * @returns The human-friendly string.
+ */
 export function getHumanFriendlyText(text: string): string {
   return text.replace(/_/g, " ").replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Formats a number of bytes into a more readable format (e.g., KB, MB, GB).
+ *
+ * @param bytes - The number of bytes to format.
+ * @returns A tuple containing the formatted number and its unit.
+ */
 export function formatBytes(bytes: number): [number, string] {
   if (bytes == 0) {
     return [0, "B"];
@@ -110,6 +177,9 @@ const loadedFonts = new Set<string>();
 
 /**
  * Generates a stable, CSS-safe font family name for a given font path.
+ *
+ * @param path - The file path of the font.
+ * @returns A CSS-safe font family name.
  */
 function getFontFamily(path: string) {
   let hash = 0;
@@ -120,6 +190,13 @@ function getFontFamily(path: string) {
   return `fp-${Math.abs(hash)}`;
 }
 
+/**
+ * Ensures that a font at the specified path is loaded into the document.
+ * If the font is already loaded, it returns the existing font family name.
+ *
+ * @param path - The file path of the font to load.
+ * @returns A promise that resolves to the font family name.
+ */
 export async function ensureFontLoaded(path: string) {
   const family = getFontFamily(path);
   if (loadedFonts.has(family)) {

--- a/cat-launcher/src/main.tsx
+++ b/cat-launcher/src/main.tsx
@@ -5,6 +5,10 @@ import App from "@/App";
 import "@/styles/global.css";
 import Providers from "@/providers";
 
+/**
+ * The main entry point for the CatLauncher frontend application.
+ * Initializes the React root and renders the App wrapped in necessary providers.
+ */
 ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 ).render(

--- a/cat-launcher/src/pages/AboutPage.tsx
+++ b/cat-launcher/src/pages/AboutPage.tsx
@@ -2,6 +2,10 @@ import pkg from "../../package.json";
 import { openLink } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
+/**
+ * External links for the CatLauncher project.
+ * Includes GitHub repository, issue reporting, and feature requests.
+ */
 const LINKS = [
   {
     label: "⭐ Star CatLauncher on GitHub",
@@ -20,6 +24,12 @@ const LINKS = [
   },
 ];
 
+/**
+ * AboutPage component that displays information about CatLauncher.
+ * It shows the application name, description, version, and helpful links.
+ *
+ * @returns A React component that renders the About page.
+ */
 export default function AboutPage() {
   return (
     <div className="flex flex-col items-center gap-4 py-4 max-w-lg mx-auto">

--- a/cat-launcher/src/pages/AchievementsPage/components/AchievementsList.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/AchievementsList.tsx
@@ -7,10 +7,23 @@ import {
 } from "@/components/ui/card";
 import type { CharacterAchievements } from "@/generated-types/CharacterAchievements";
 
+/**
+ * Props for the {@link AchievementsList} component.
+ */
 interface AchievementsListProps {
+  /**
+   * An array of achievement data grouped by character.
+   */
   achievements: CharacterAchievements[];
 }
 
+/**
+ * A component that renders a list of achievements for multiple characters.
+ * Each character's achievements are displayed in a card.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the list of achievements.
+ */
 export default function AchievementsList({
   achievements,
 }: AchievementsListProps) {

--- a/cat-launcher/src/pages/AchievementsPage/components/AchievementsSidebar.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/AchievementsSidebar.tsx
@@ -1,11 +1,26 @@
 import { Sidebar } from "@/components/Sidebar";
 import { achievementsRoutes } from "../routes";
 
+/**
+ * Props for the {@link AchievementsSidebar} component.
+ */
 interface AchievementsSidebarProps {
+  /**
+   * Whether the sidebar is currently collapsed.
+   */
   isCollapsed: boolean;
+  /**
+   * Callback function to toggle the sidebar collapse state.
+   */
   onToggleCollapse: () => void;
 }
 
+/**
+ * A sidebar component specifically for the Achievements page navigation.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the achievements sidebar.
+ */
 export default function AchievementsSidebar({
   isCollapsed,
   onToggleCollapse,

--- a/cat-launcher/src/pages/AchievementsPage/components/GameAchievements.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/GameAchievements.tsx
@@ -10,6 +10,12 @@ import { toastCL } from "@/lib/utils";
 import AchievementsList from "./AchievementsList";
 import { useAchievements } from "../hooks/useAchievements";
 
+/**
+ * A component that displays achievements for a selected game variant.
+ * Includes a variant selector and a search input to filter achievements by character name.
+ *
+ * @returns A React element representing the game achievements view.
+ */
 export default function GameAchievements() {
   const {
     gameVariants,

--- a/cat-launcher/src/pages/AchievementsPage/components/PlayTime.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/PlayTime.tsx
@@ -1,6 +1,11 @@
 import { useGameVariants } from "@/hooks/useGameVariants";
 import PlayTimeChart from "./PlayTimeChart";
 
+/**
+ * A component that displays play time statistics across different game variants.
+ *
+ * @returns A React element representing the play time view.
+ */
 export default function PlayTime() {
   const {
     gameVariants,

--- a/cat-launcher/src/pages/AchievementsPage/components/PlayTimeChart.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/components/PlayTimeChart.tsx
@@ -10,16 +10,37 @@ import {
 import type { GameVariantInfo } from "@/generated-types/GameVariantInfo";
 import { usePlayTimeData } from "../hooks/usePlayTimeData";
 
+/**
+ * Props for the {@link PlayTimeChart} component.
+ */
 interface PlayTimeChartProps {
+  /**
+   * Information about the game variants to include in the chart.
+   */
   variants: GameVariantInfo[];
 }
 
+/**
+ * Represents an item in the pie chart data.
+ */
 interface PieDataItem {
+  /**
+   * The name of the game variant.
+   */
   name: string;
+  /**
+   * The total play time in hours.
+   */
   playTime: number;
+  /**
+   * Additional properties allowed by the charting library.
+   */
   [key: string]: string | number;
 }
 
+/**
+ * A predefined set of colors for the pie chart slices.
+ */
 const COLORS = [
   "#8884d8",
   "#82ca9d",
@@ -31,16 +52,34 @@ const COLORS = [
   "#ffa58f",
 ];
 
+/**
+ * Props for the {@link PlayTimePieTooltip} component.
+ */
 interface PlayTimePieTooltipProps {
+  /**
+   * Whether the tooltip is currently active (visible).
+   */
   active?: boolean;
+  /**
+   * The data payload for the currently hovered slice.
+   */
   payload?: Array<{
     name: string;
     value: number;
     payload: { name: string };
   }>;
+  /**
+   * The total play time across all variants, used for percentage calculation.
+   */
   totalTime: number;
 }
 
+/**
+ * A custom tooltip component for the play time pie chart.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the tooltip, or null if not active.
+ */
 function PlayTimePieTooltip({
   active,
   payload,
@@ -63,6 +102,12 @@ function PlayTimePieTooltip({
   return null;
 }
 
+/**
+ * A component that renders a pie chart showing play time distribution across game variants.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the play time pie chart.
+ */
 export default function PlayTimeChart({
   variants,
 }: PlayTimeChartProps) {

--- a/cat-launcher/src/pages/AchievementsPage/hooks/useAchievements.ts
+++ b/cat-launcher/src/pages/AchievementsPage/hooks/useAchievements.ts
@@ -5,6 +5,13 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { getAchievementsForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook to fetch achievements for a specific game variant.
+ *
+ * @param variant - The game variant to fetch achievements for, or null if none selected.
+ * @param onAchievementsError - An optional callback function to handle errors during fetching.
+ * @returns The query result from react-query.
+ */
 export function useAchievements(
   variant: GameVariant | null,
   onAchievementsError?: (error: Error) => void,

--- a/cat-launcher/src/pages/AchievementsPage/hooks/usePlayTimeData.ts
+++ b/cat-launcher/src/pages/AchievementsPage/hooks/usePlayTimeData.ts
@@ -6,11 +6,27 @@ import { getPlayTimeForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 import { toastCL } from "@/lib/utils";
 
+/**
+ * Represents a data point for play time visualization.
+ */
 interface PlayTimeDataPoint {
+  /**
+   * The name of the game variant.
+   */
   name: string;
+  /**
+   * The play time in hours.
+   */
   playTime: number;
 }
 
+/**
+ * A custom hook to fetch and process play time data for a list of game variants.
+ *
+ * @param variants - An array of game variant information to fetch play time for.
+ * @param onError - An optional callback function to handle errors.
+ * @returns An object containing the processed play time data and loading state.
+ */
 export function usePlayTimeData(
   variants: GameVariantInfo[],
   onError?: (error: unknown) => void,

--- a/cat-launcher/src/pages/AchievementsPage/index.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/index.tsx
@@ -4,6 +4,12 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import AchievementsSidebar from "./components/AchievementsSidebar";
 import { achievementsRoutes } from "./routes";
 
+/**
+ * The main page component for the Achievements section.
+ * Manages the layout with a sidebar and a content area for different achievement-related views.
+ *
+ * @returns A React element representing the achievements page.
+ */
 function AchievementsPage() {
   const [isCollapsed, setIsCollapsed] = useState(true);
 

--- a/cat-launcher/src/pages/AchievementsPage/routes.tsx
+++ b/cat-launcher/src/pages/AchievementsPage/routes.tsx
@@ -4,8 +4,15 @@ import { Clock, Trophy } from "lucide-react";
 import PlayTime from "./components/PlayTime";
 import GameAchievements from "./components/GameAchievements";
 
+/**
+ * Represents a route within the achievements section.
+ */
 export type AchievementsRoute = BaseRoute;
 
+/**
+ * The collection of routes available within the achievements page.
+ * Each route includes a path, element, label, and icon for navigation.
+ */
 export const achievementsRoutes: AchievementsRoute[] = [
   {
     path: "play-time",

--- a/cat-launcher/src/pages/AssetsPage/AssetTypeSelector.tsx
+++ b/cat-launcher/src/pages/AssetsPage/AssetTypeSelector.tsx
@@ -10,11 +10,22 @@ const ASSET_TYPE_LABELS: Record<AssetType, string> = {
   tilesets: "Tilesets",
 };
 
+/**
+ * Props for the {@link AssetTypeSelector} component.
+ */
 interface AssetTypeSelectorProps {
+  /** The currently selected asset type. */
   selectedAssetType: AssetType;
+  /** Callback triggered when the asset type selection changes. */
   onAssetTypeChange: (assetType: AssetType) => void;
 }
 
+/**
+ * A dropdown component that allows the user to select the type of game assets to display.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the asset type selector.
+ */
 export default function AssetTypeSelector({
   selectedAssetType,
   onAssetTypeChange,

--- a/cat-launcher/src/pages/AssetsPage/index.tsx
+++ b/cat-launcher/src/pages/AssetsPage/index.tsx
@@ -7,6 +7,12 @@ import { setSelectedVariant } from "@/store/selectedVariantSlice";
 import AssetTypeSelector from "./AssetTypeSelector";
 import { type AssetType, ASSET_COMPONENTS } from "./types";
 
+/**
+ * The main page component for managing game assets like mods, soundpacks, and tilesets.
+ * It allows users to select a game variant and the type of asset they want to view or manage.
+ *
+ * @returns A React element representing the assets page.
+ */
 function AssetsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();

--- a/cat-launcher/src/pages/AssetsPage/types.ts
+++ b/cat-launcher/src/pages/AssetsPage/types.ts
@@ -2,10 +2,19 @@ import ModsList from "../ModsPage/ModsList";
 import SoundpacksList from "../SoundpacksPage/SoundpacksList";
 import TilesetsList from "../TilesetsPage/TilesetsList";
 
+/**
+ * Represents the types of assets available in the launcher.
+ */
 export type AssetType = "mods" | "soundpacks" | "tilesets";
 
+/**
+ * Type definition for a component that displays a list of assets.
+ */
 export type AssetListComponent = typeof ModsList;
 
+/**
+ * A mapping from {@link AssetType} to its corresponding list component.
+ */
 export const ASSET_COMPONENTS: Record<AssetType, AssetListComponent> =
   {
     mods: ModsList,
@@ -13,6 +22,12 @@ export const ASSET_COMPONENTS: Record<AssetType, AssetListComponent> =
     tilesets: TilesetsList,
   };
 
+/**
+ * Retrieves the component responsible for rendering a specific asset type.
+ *
+ * @param assetType - The type of asset.
+ * @returns The list component for the given asset type.
+ */
 export const getAssetComponent = (
   assetType: AssetType,
 ): AssetListComponent => ASSET_COMPONENTS[assetType];

--- a/cat-launcher/src/pages/BackupsPage/BackupFilter.tsx
+++ b/cat-launcher/src/pages/BackupsPage/BackupFilter.tsx
@@ -4,18 +4,34 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { CombinedBackup } from "./types/backups";
 
+/**
+ * A function that takes a backup and returns true if it should be included in the filtered results.
+ */
 export type BackupFilterFn = (backup: CombinedBackup) => boolean;
 
+/**
+ * Defines a filter type with its display label and logic.
+ */
 export type BackupFilterType = {
+  /** Unique identifier for the filter. */
   id: "automatic" | "manual";
+  /** Human-readable label for the filter. */
   label: string;
+  /** The function to apply when this filter is active. */
   apply: BackupFilterFn;
 };
 
+/**
+ * Props for the {@link BackupFilter} component.
+ */
 interface BackupFilterProps {
+  /** Callback triggered when the active filter changes. */
   onChange: (filterFn: BackupFilterFn) => void;
 }
 
+/**
+ * Predefined backup filters for automatic and manual backups.
+ */
 const FILTERS: BackupFilterType[] = [
   {
     id: "automatic",
@@ -29,6 +45,12 @@ const FILTERS: BackupFilterType[] = [
   },
 ];
 
+/**
+ * Component that provides checkboxes to filter backups by their type (Automatic/Manual).
+ *
+ * @param props - Component properties.
+ * @returns A React element containing filter controls.
+ */
 export default function BackupFilter({
   onChange,
 }: BackupFilterProps) {

--- a/cat-launcher/src/pages/BackupsPage/BackupsTable.tsx
+++ b/cat-launcher/src/pages/BackupsPage/BackupsTable.tsx
@@ -2,12 +2,25 @@ import { DataTable } from "@/components/DataTable";
 import { columns } from "./columns";
 import { CombinedBackup } from "./types/backups";
 
+/**
+ * Props for the {@link BackupsTable} component.
+ */
 interface BackupsTableProps {
+  /** The list of backup entries to display in the table. */
   rows: CombinedBackup[];
+  /** Callback triggered when the delete button is clicked for a backup. */
   onDeleteClick: (backup: CombinedBackup) => void;
+  /** Callback triggered when the restore button is clicked for a backup. */
   onRestoreClick: (backup: CombinedBackup) => void;
 }
 
+/**
+ * A table component that displays game backups.
+ * Utilizes the {@link DataTable} component and predefined columns.
+ *
+ * @param props - Component properties.
+ * @returns A React element rendering the backups data table.
+ */
 export function BackupsTable({
   rows,
   onDeleteClick,

--- a/cat-launcher/src/pages/BackupsPage/DeleteBackupDialog.tsx
+++ b/cat-launcher/src/pages/BackupsPage/DeleteBackupDialog.tsx
@@ -1,11 +1,24 @@
 import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 
+/**
+ * Props for the {@link DeleteBackupDialog} component.
+ */
 interface DeleteBackupDialogProps {
+  /** Whether the dialog is currently open. */
   open: boolean;
+  /** Callback triggered when the dialog's open state changes. */
   onOpenChange: (open: boolean) => void;
+  /** Callback triggered when the user confirms the deletion. */
   onDelete: () => void;
 }
 
+/**
+ * A confirmation dialog for deleting a backup.
+ * Warns the user that this action is permanent and cannot be undone.
+ *
+ * @param props - Component properties.
+ * @returns A React element rendering the deletion dialog.
+ */
 export function DeleteBackupDialog({
   open,
   onOpenChange,

--- a/cat-launcher/src/pages/BackupsPage/NewBackupDialog.tsx
+++ b/cat-launcher/src/pages/BackupsPage/NewBackupDialog.tsx
@@ -27,14 +27,29 @@ const formSchema = z.object({
   notes: z.string().optional(),
 });
 
+/**
+ * Props for the {@link NewBackupDialog} component.
+ */
 interface NewBackupDialogProps {
+  /** Whether the dialog is currently open. */
   open: boolean;
+  /** Callback triggered when the dialog's open state changes. */
   onOpenChange: (open: boolean) => void;
+  /** Callback triggered when the form is submitted successfully. */
   onSave: (values: z.infer<typeof formSchema>) => void;
+  /** The game variant for which the backup is being created. */
   variant: GameVariant;
+  /** Whether the backup creation process is currently in progress. */
   isCreating: boolean;
 }
 
+/**
+ * A dialog component for creating a new manual backup.
+ * Provides a form for entering a name and optional notes.
+ *
+ * @param props - Component properties.
+ * @returns A React element rendering the creation dialog and form.
+ */
 export function NewBackupDialog({
   open,
   onOpenChange,

--- a/cat-launcher/src/pages/BackupsPage/RestoreBackupDialog.tsx
+++ b/cat-launcher/src/pages/BackupsPage/RestoreBackupDialog.tsx
@@ -1,11 +1,24 @@
 import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 
+/**
+ * Props for the {@link RestoreBackupDialog} component.
+ */
 interface RestoreBackupDialogProps {
+  /** Whether the dialog is currently open. */
   open: boolean;
+  /** Callback triggered when the dialog's open state changes. */
   onOpenChange: (open: boolean) => void;
+  /** Callback triggered when the user confirms the restoration. */
   onRestore: () => void;
 }
 
+/**
+ * A confirmation dialog for restoring a backup.
+ * Warns the user that this action will overwrite current save files.
+ *
+ * @param props - Component properties.
+ * @returns A React element rendering the restoration dialog.
+ */
 export function RestoreBackupDialog({
   open,
   onOpenChange,

--- a/cat-launcher/src/pages/BackupsPage/columns.tsx
+++ b/cat-launcher/src/pages/BackupsPage/columns.tsx
@@ -5,11 +5,20 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CombinedBackup } from "./types/backups";
 
+/**
+ * Type definition for a factory function that creates column definitions for the backups table.
+ */
 type ColumnsFactory = (options: {
+  /** Callback to open the delete confirmation dialog for a backup. */
   openDeleteDialog: (backup: CombinedBackup) => void;
+  /** Callback to open the restore confirmation dialog for a backup. */
   openRestoreDialog: (backup: CombinedBackup) => void;
 }) => ColumnDef<CombinedBackup>[];
 
+/**
+ * Defines the columns for the {@link BackupsTable}.
+ * Includes columns for name (sortable), type (badge), notes, date (sortable), and actions.
+ */
 export const columns: ColumnsFactory = ({
   openDeleteDialog,
   openRestoreDialog,

--- a/cat-launcher/src/pages/BackupsPage/index.tsx
+++ b/cat-launcher/src/pages/BackupsPage/index.tsx
@@ -16,6 +16,13 @@ import { NewBackupDialog } from "./NewBackupDialog";
 import { RestoreBackupDialog } from "./RestoreBackupDialog";
 import { CombinedBackup } from "./types/backups";
 
+/**
+ * Formats a Unix timestamp (in seconds) into a human-readable string for search purposes.
+ * Format: "DD Month, YYYY, HH:MM:SS"
+ *
+ * @param timestamp - The bigint Unix timestamp to format.
+ * @returns A formatted date and time string.
+ */
 function formatTimestampForSearch(timestamp: bigint): string {
   const date = new Date(Number(timestamp) * 1000);
 
@@ -29,6 +36,13 @@ function formatTimestampForSearch(timestamp: bigint): string {
   return `${day} ${month}, ${year}, ${hours}:${minutes}:${seconds}`;
 }
 
+/**
+ * BackupsPage component providing the user interface for managing game backups.
+ * Allows users to view, search, filter, create, restore, and delete backups
+ * for different game variants.
+ *
+ * @returns A React component for the Backups page.
+ */
 function BackupsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();

--- a/cat-launcher/src/pages/BackupsPage/types/backups.ts
+++ b/cat-launcher/src/pages/BackupsPage/types/backups.ts
@@ -1,6 +1,10 @@
 import { BackupEntry } from "@/generated-types/BackupEntry";
 import { ManualBackupEntry } from "@/generated-types/ManualBackupEntry";
 
+/**
+ * Represents a backup entry that can be either an automatic backup or a manual backup.
+ * It combines data from {@link BackupEntry} and {@link ManualBackupEntry} with a discriminator `type`.
+ */
 export type CombinedBackup =
   | (BackupEntry & { type: "automatic"; name: string; notes: string })
   | (ManualBackupEntry & { type: "manual" });

--- a/cat-launcher/src/pages/ModsPage/ModCard.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModCard.tsx
@@ -22,27 +22,67 @@ import {
 import { ModInstallationConfirmationDialog } from "./ModInstallationConfirmationDialog";
 import { PreInstalledButton } from "@/components/PreInstalledButton";
 
+/**
+ * Props for the {@link ModCard} component.
+ */
 interface ModCardProps {
+  /**
+   * The game variant associated with the mod.
+   */
   variant: GameVariant;
+  /**
+   * The mod data to display.
+   */
   mod: Mod;
 }
 
+/**
+ * Extracts the display name from a mod.
+ *
+ * @param mod - The mod object.
+ * @returns The name of the mod.
+ */
 function getModName(mod: Mod): string {
   return mod.content.name;
 }
 
+/**
+ * Extracts the description from a mod.
+ *
+ * @param mod - The mod object.
+ * @returns The description of the mod.
+ */
 function getModDescription(mod: Mod): string {
   return mod.content.description;
 }
 
+/**
+ * Determines the display type of a mod (Pre-Installed or Third-Party).
+ *
+ * @param mod - The mod object.
+ * @returns A string representing the mod type.
+ */
 function getModType(mod: Mod): string {
   return mod.type === "Stock" ? "Pre-Installed" : "Third-Party";
 }
 
+/**
+ * Extracts and formats the category of a mod.
+ *
+ * @param mod - The mod object.
+ * @returns A human-friendly category string.
+ */
 function getModCategory(mod: Mod): string {
   return getHumanFriendlyText(mod.content.category);
 }
 
+/**
+ * A card component that displays information about a single mod and provides installation/uninstallation controls.
+ * For third-party mods, it includes a confirmation dialog before installation.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the mod card.
+ */
 export default function ModCard({ variant, mod }: ModCardProps) {
   const [confirmationDialogOpen, setConfirmationDialogOpen] =
     useState(false);

--- a/cat-launcher/src/pages/ModsPage/ModInstallationConfirmationDialog.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModInstallationConfirmationDialog.tsx
@@ -10,14 +10,38 @@ import {
 } from "./lib/stabilityRating";
 import { getRelativeTimeDisplay } from "./lib/timeFormatting";
 
+/**
+ * Props for the {@link ModInstallationConfirmationDialog} component.
+ */
 interface ModInstallationConfirmationDialogProps {
+  /**
+   * Whether the dialog is currently open.
+   */
   open: boolean;
+  /**
+   * Callback function to handle opening/closing the dialog.
+   */
   onOpenChange: (open: boolean) => void;
+  /**
+   * Callback function to execute when the installation is confirmed.
+   */
   onConfirm: () => void;
+  /**
+   * The unique identifier of the mod to be installed.
+   */
   modId: string;
+  /**
+   * The game variant for which the mod is being installed.
+   */
   variant: GameVariant;
 }
 
+/**
+ * Determines the color scheme for the stability rating display based on the stability level.
+ *
+ * @param level - The stability level (low, medium, or high).
+ * @returns An object containing tailwind color classes.
+ */
 const getStabilityColors = (level: StabilityRating["level"]) => {
   switch (level) {
     case "high":
@@ -44,6 +68,13 @@ const getStabilityColors = (level: StabilityRating["level"]) => {
   }
 };
 
+/**
+ * A confirmation dialog shown before installing a third-party mod.
+ * Displays stability information based on the mod's last activity.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the confirmation dialog.
+ */
 export function ModInstallationConfirmationDialog({
   open,
   onOpenChange,

--- a/cat-launcher/src/pages/ModsPage/ModsList.tsx
+++ b/cat-launcher/src/pages/ModsPage/ModsList.tsx
@@ -7,10 +7,23 @@ import ModCard from "./ModCard";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle } from "lucide-react";
 
+/**
+ * Props for the {@link ModsList} component.
+ */
 interface ModsListProps {
+  /**
+   * The game variant for which to list mods.
+   */
   variant: GameVariant;
 }
 
+/**
+ * A component that displays a searchable list of mods for a specific game variant.
+ * Includes a warning about third-party mods and handles search functionality.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the mods list.
+ */
 export default function ModsList({ variant }: ModsListProps) {
   const variantLabel = getVariantLabel(variant);
   const { mods, isLoading } = useMods(

--- a/cat-launcher/src/pages/ModsPage/hooks/index.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/index.ts
@@ -1,3 +1,8 @@
+/**
+ * This module exports custom hooks for managing mods, including fetching,
+ * installing, uninstalling, and monitoring mod-related activity.
+ */
+
 export * from "./useMods";
 export * from "./useInstallThirdPartyMod";
 export * from "./useGetThirdPartyModInstallationStatus";

--- a/cat-launcher/src/pages/ModsPage/hooks/useGetLastModActivity.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useGetLastModActivity.ts
@@ -5,6 +5,16 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { getLastModActivity } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook to fetch the last recorded activity for a specific mod.
+ * Useful for determining mod stability and update recency.
+ *
+ * @param enabled - Whether the query should be active.
+ * @param modId - The unique identifier of the mod.
+ * @param variant - The game variant associated with the mod.
+ * @param onError - An optional callback function to handle errors.
+ * @returns An object containing the last activity data and loading state.
+ */
 export function useGetLastModActivity(
   enabled: boolean,
   modId: string,

--- a/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useGetThirdPartyModInstallationStatus.ts
@@ -4,6 +4,13 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { getThirdPartyModInstallationStatus } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook to fetch the installation status of a third-party mod.
+ *
+ * @param modId - The unique identifier of the mod.
+ * @param variant - The game variant the mod belongs to.
+ * @returns An object containing the installation status.
+ */
 export function useGetThirdPartyModInstallationStatus(
   modId: string,
   variant: GameVariant,

--- a/cat-launcher/src/pages/ModsPage/hooks/useInstallThirdPartyMod.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useInstallThirdPartyMod.ts
@@ -6,6 +6,15 @@ import { useInstallAndMonitor } from "@/hooks/useInstallAndMonitor";
 import { installThirdPartyMod } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook to handle the installation and progress monitoring of a third-party mod.
+ *
+ * @param variant - The game variant associated with the mod.
+ * @param modId - The unique identifier of the mod, or undefined if not yet known.
+ * @param onSuccess - An optional callback function to execute on successful installation.
+ * @param onError - An optional callback function to handle errors.
+ * @returns An object containing the installation function, progress status, and download details.
+ */
 export function useInstallThirdPartyMod(
   variant: GameVariant,
   modId: string | undefined,

--- a/cat-launcher/src/pages/ModsPage/hooks/useMods.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useMods.ts
@@ -15,8 +15,20 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { setupEventListener } from "@/lib/utils";
 
+/**
+ * Represents the current status of the mod fetching process.
+ */
 export type ModFetchStatus = "idle" | "loading" | "success" | "error";
 
+/**
+ * A custom hook to manage and fetch the list of mods for a specific game variant.
+ * Listens for real-time updates via events and handles the initial triggering of the fetch.
+ *
+ * @param variant - The game variant to fetch mods for.
+ * @param onModsLoadError - An optional callback function for loading errors.
+ * @param onModsTriggerError - An optional callback function for triggering errors.
+ * @returns An object containing the mods list and loading state.
+ */
 export function useMods(
   variant: GameVariant,
   onModsLoadError?: (error: unknown) => void,

--- a/cat-launcher/src/pages/ModsPage/hooks/useUninstallThirdPartyMod.ts
+++ b/cat-launcher/src/pages/ModsPage/hooks/useUninstallThirdPartyMod.ts
@@ -4,6 +4,14 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { uninstallThirdPartyMod } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook to handle the uninstallation of a third-party mod.
+ *
+ * @param variant - The game variant associated with the mod.
+ * @param onSuccess - An optional callback function to execute on successful uninstallation.
+ * @param onError - An optional callback function to handle errors.
+ * @returns An object containing the uninstallation function and pending state.
+ */
 export function useUninstallThirdPartyMod(
   variant: GameVariant,
   onSuccess?: () => void,

--- a/cat-launcher/src/pages/ModsPage/index.tsx
+++ b/cat-launcher/src/pages/ModsPage/index.tsx
@@ -5,6 +5,12 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { useGameVariants } from "@/hooks/useGameVariants";
 import ModsList from "./ModsList";
 
+/**
+ * The main page component for the Mods section.
+ * Provides a variant selector and displays a list of mods for the selected variant.
+ *
+ * @returns A React element representing the mods page.
+ */
 function ModsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();

--- a/cat-launcher/src/pages/ModsPage/lib/stabilityRating.ts
+++ b/cat-launcher/src/pages/ModsPage/lib/stabilityRating.ts
@@ -1,20 +1,47 @@
+/**
+ * Represents the stability rating of a mod.
+ */
 export interface StabilityRating {
-  score: number; // 0-100
+  /**
+   * The numerical stability score from 0 to 100.
+   */
+  score: number;
+  /**
+   * The qualitative stability level.
+   */
   level: "low" | "medium" | "high";
 }
 
+/**
+ * Calculates a stability score based on the age of the last update.
+ *
+ * @param ageInDays - The number of days since the last update.
+ * @returns A score between 0 and 100.
+ */
 const calculateScore = (ageInDays: number): number => {
   // Linear decay from 100 (0 days) to 0 (365+ days)
   const maxAge = 365;
   return Math.max(0, Math.round(100 * (1 - ageInDays / maxAge)));
 };
 
+/**
+ * Maps a numerical score to a stability level.
+ *
+ * @param score - The stability score.
+ * @returns The stability level.
+ */
 const getLevel = (score: number): "low" | "medium" | "high" => {
   if (score >= 70) return "high";
   if (score >= 40) return "medium";
   return "low";
 };
 
+/**
+ * Computes the stability rating for a given timestamp.
+ *
+ * @param timestamp - The last update timestamp as a bigint.
+ * @returns The calculated stability rating.
+ */
 export const getStabilityRating = (
   timestamp: bigint,
 ): StabilityRating => {
@@ -28,6 +55,12 @@ export const getStabilityRating = (
   return { score, level };
 };
 
+/**
+ * Returns a human-readable label for a stability level.
+ *
+ * @param level - The stability level.
+ * @returns A capitalized label string.
+ */
 export const getStabilityLevelLabel = (
   level: "low" | "medium" | "high",
 ): string => {

--- a/cat-launcher/src/pages/ModsPage/lib/timeFormatting.ts
+++ b/cat-launcher/src/pages/ModsPage/lib/timeFormatting.ts
@@ -1,5 +1,14 @@
+/**
+ * Represents a relative duration of time with a value and a unit.
+ */
 export interface RelativeTime {
+  /**
+   * The numerical value of the duration.
+   */
   value: number;
+  /**
+   * The unit of time.
+   */
   unit:
     | "seconds"
     | "minutes"
@@ -10,6 +19,12 @@ export interface RelativeTime {
     | "years";
 }
 
+/**
+ * Calculates the relative time from a given timestamp to now.
+ *
+ * @param timestamp - The timestamp as a bigint.
+ * @returns A {@link RelativeTime} object.
+ */
 export const calculateRelativeTime = (
   timestamp: bigint,
 ): RelativeTime => {
@@ -34,6 +49,13 @@ export const calculateRelativeTime = (
   return { value: years, unit: "years" };
 };
 
+/**
+ * Returns the appropriate singular or plural label for a time unit.
+ *
+ * @param unit - The time unit.
+ * @param value - The value to determine plurality.
+ * @returns The unit label string.
+ */
 const getUnitLabel = (
   unit: RelativeTime["unit"],
   value: number,
@@ -54,6 +76,12 @@ const getUnitLabel = (
   return value === 1 ? labels[unit].singular : labels[unit].plural;
 };
 
+/**
+ * Formats a {@link RelativeTime} object into a human-readable string.
+ *
+ * @param relativeTime - The relative time object.
+ * @returns A formatted string (e.g., "5 days ago").
+ */
 export const formatRelativeTime = (
   relativeTime: RelativeTime,
 ): string => {
@@ -63,6 +91,12 @@ export const formatRelativeTime = (
   return `${relativeTime.value} ${getUnitLabel(relativeTime.unit, relativeTime.value)} ago`;
 };
 
+/**
+ * Gets a human-readable relative time display string for a given timestamp.
+ *
+ * @param timestamp - The timestamp as a bigint.
+ * @returns The relative time display string.
+ */
 export const getRelativeTimeDisplay = (timestamp: bigint): string => {
   const relativeTime = calculateRelativeTime(timestamp);
   return formatRelativeTime(relativeTime);

--- a/cat-launcher/src/pages/PlayPage/GameVariantCard.tsx
+++ b/cat-launcher/src/pages/PlayPage/GameVariantCard.tsx
@@ -15,10 +15,22 @@ import { PlayTime } from "./PlayTime";
 import ReleaseSelector from "./ReleaseSelector";
 import { TipOfTheDay } from "../game-tips/TipOfTheDay";
 
+/**
+ * Props for the {@link GameVariantCard} component.
+ */
 export interface GameVariantProps {
+  /** Information about the game variant to display. */
   variantInfo: GameVariantInfo;
 }
 
+/**
+ * A card component that displays information about a specific game variant.
+ * It includes a draggable handle, a tip of the day, a release selector,
+ * an interaction button (e.g., Play/Install), and playtime statistics.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the game variant card.
+ */
 export default function GameVariantCard({
   variantInfo,
 }: GameVariantProps) {

--- a/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/InteractionButton.tsx
@@ -19,6 +19,14 @@ import {
   useUpgradeInfo,
 } from "./hooks";
 
+/**
+ * Component that renders the primary interaction buttons for a game variant.
+ * Handles Play, Install, Resume, and Upgrade actions based on the current
+ * installation and running status of the selected release.
+ *
+ * @param props - Component properties.
+ * @returns A React element containing the interaction buttons.
+ */
 export default function InteractionButton({
   variant,
   selectedReleaseId,
@@ -150,12 +158,27 @@ export default function InteractionButton({
   return button;
 }
 
+/**
+ * Props for the {@link InteractionButton} component.
+ */
 interface InteractionButtonProps {
+  /** The game variant this button is associated with. */
   variant: GameVariant;
+  /** The currently selected release ID for this variant. */
   selectedReleaseId: string | undefined;
+  /** Callback to update the selected release ID. */
   setSelectedReleaseId: (value: string) => void;
 }
 
+/**
+ * Determines the appropriate label for the main action button based on the game's state.
+ *
+ * @param selectedReleaseId - The ID of the currently selected release.
+ * @param isRunning - Whether the game is currently running.
+ * @param installationStatus - The current installation status of the release.
+ * @param installationProgressStatus - The progress status if an installation is active.
+ * @returns A string label for the action button.
+ */
 function getActionButtonLabel(
   selectedReleaseId: string | undefined,
   isRunning: boolean,

--- a/cat-launcher/src/pages/PlayPage/PlayTime.tsx
+++ b/cat-launcher/src/pages/PlayPage/PlayTime.tsx
@@ -4,11 +4,22 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { cn } from "@/lib/utils";
 import { usePlayTime } from "./hooks";
 
+/**
+ * Props for the {@link PlayTime} component.
+ */
 interface PlayTimeProps extends HTMLAttributes<HTMLDivElement> {
+  /** The game variant to show playtime for. */
   variant: GameVariant;
+  /** The specific release version ID to show playtime for. */
   releaseId?: string;
 }
 
+/**
+ * Formats a duration in seconds into a human-readable string (e.g., "2h 15m").
+ *
+ * @param totalSeconds - The duration in seconds.
+ * @returns A formatted duration string.
+ */
 function formatPlayTime(totalSeconds: number): string {
   if (totalSeconds === 0) {
     return "0h";
@@ -23,6 +34,12 @@ function formatPlayTime(totalSeconds: number): string {
   return `${hours}h ${minutes}m`;
 }
 
+/**
+ * Displays the total and version-specific playtime for a given game variant and release.
+ *
+ * @param props - The component props.
+ * @returns A React element showing playtime statistics.
+ */
 export function PlayTime({
   variant,
   releaseId,

--- a/cat-launcher/src/pages/PlayPage/QuickSelectButtons.tsx
+++ b/cat-launcher/src/pages/PlayPage/QuickSelectButtons.tsx
@@ -3,12 +3,25 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { QUICK_SELECT_BUTTONS } from "./constants";
 import type { QuickSelectKey } from "./hooks/useReleaseNotesRange";
 
+/**
+ * Props for the {@link QuickSelectButtons} component.
+ */
 interface QuickSelectButtonsProps {
+  /** The game variant for which to show quick select buttons. */
   variant: GameVariant;
+  /** A record of version strings mapped to quick select keys (e.g., 'latest', 'active'). */
   targetVersions: Partial<Record<QuickSelectKey, string>>;
+  /** Callback triggered when a version is selected via a button click. */
   onSelect: (version: string) => void;
 }
 
+/**
+ * Renders a grid of buttons for quickly selecting specific game versions
+ * (e.g., Latest Stable, Latest Experimental, Active Version) based on the game variant.
+ *
+ * @param props - The component props.
+ * @returns A React element containing the quick select buttons.
+ */
 export default function QuickSelectButtons({
   variant,
   targetVersions,

--- a/cat-launcher/src/pages/PlayPage/ReleaseDropdown.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseDropdown.tsx
@@ -12,14 +12,30 @@ import { useActiveRelease, useReleases } from "./hooks";
 import type { FilterFn } from "./ReleaseFilter";
 import ReleaseLabel from "./ReleaseLabel";
 
+/**
+ * Props for the {@link ReleaseDropdown} component.
+ */
 export interface ReleaseDropdownProps {
+  /** The game variant to list releases for. */
   variant: GameVariant;
+  /** The currently selected release ID (version string). */
   selectedReleaseId: string | undefined;
+  /** Callback to update the selected release ID. */
   setSelectedReleaseId: (value: string | undefined) => void;
+  /** Optional filter function to restrict the list of visible releases. */
   appliedFilter?: FilterFn;
+  /** Whether to hide the "Active" label next to the currently active version. */
   hideActiveLabel?: boolean;
 }
 
+/**
+ * A searchable, virtualized dropdown component for selecting a specific game release.
+ * It automatically handles loading releases, identifying the active release,
+ * and managing installation statuses.
+ *
+ * @param props - The component props.
+ * @returns A React element containing the release selection dropdown.
+ */
 export default function ReleaseDropdown({
   variant,
   selectedReleaseId,

--- a/cat-launcher/src/pages/PlayPage/ReleaseFilter.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseFilter.tsx
@@ -7,19 +7,37 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import type { ReleaseType } from "@/generated-types/ReleaseType";
 import { useAppSelector } from "@/store/hooks";
 
+/** A function type used to filter game releases. */
 export type FilterFn = (r: GameRelease) => boolean;
 
+/**
+ * Represents a filter option for game releases.
+ */
 export type Filter = {
+  /** The unique identifier for the filter, corresponding to a release type. */
   id: ReleaseType;
+  /** The display label for the filter. */
   label: string;
+  /** The function to apply when this filter is active. */
   apply: FilterFn;
 };
 
+/**
+ * Props for the {@link ReleaseFilter} component.
+ */
 interface ReleaseFilterProps {
+  /** The game variant for which filters are being applied. */
   variant: GameVariant;
+  /** Callback triggered when the active filter function changes. */
   onChange: (filterFn: FilterFn) => void;
 }
 
+/**
+ * Retrieves the available release filters for a specific game variant.
+ *
+ * @param variant - The game variant.
+ * @returns An array of available filters.
+ */
 function getFilters(variant: GameVariant): Filter[] {
   const stableFilter = {
     id: "Stable",
@@ -53,6 +71,12 @@ function getFilters(variant: GameVariant): Filter[] {
   }
 }
 
+/**
+ * A component that provides checkboxes to filter game releases by type (e.g., Stable, Experimental).
+ *
+ * @param props - The component props.
+ * @returns A React element containing the filter controls.
+ */
 export default function ReleaseFilter({
   variant,
   onChange,

--- a/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseLabel.tsx
@@ -3,12 +3,25 @@ import { Badge } from "@/components/ui/badge";
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { useMemo } from "react";
 
+/**
+ * Props for the {@link ReleaseLabel} component.
+ */
 interface ReleaseLabelProps {
+  /** The game variant the release belongs to. */
   variant: GameVariant;
+  /** The version string of the release. */
   version: string;
+  /** Whether this release is currently active. */
   isActive: boolean;
 }
 
+/**
+ * Formats a full version string into a shorter, more readable format for display.
+ *
+ * @param variant - The game variant.
+ * @param version - The full version string.
+ * @returns A shortened version string.
+ */
 function getShortReleaseName(
   variant: GameVariant,
   version: string,
@@ -35,6 +48,12 @@ function getShortReleaseName(
   }
 }
 
+/**
+ * Displays a release version name with an optional "Active" badge.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the release label.
+ */
 export default function ReleaseLabel({
   variant,
   version,

--- a/cat-launcher/src/pages/PlayPage/ReleaseNotesButton.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseNotesButton.tsx
@@ -19,10 +19,21 @@ import { useReleaseNotesRange } from "./hooks";
 import ReleaseSelectionColumn from "./ReleaseSelectionColumn";
 import { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * Props for the {@link ReleaseNotesButton} component.
+ */
 interface ReleaseNotesButtonProps {
+  /** The game variant to fetch and display release notes for. */
   variant: GameVariant;
 }
 
+/**
+ * Component that renders a button to open a dialog showing release notes.
+ * Allows users to compare notes between different versions of the game.
+ *
+ * @param props - Component properties.
+ * @returns A React element rendering the release notes button and dialog.
+ */
 export default function ReleaseNotesButton({
   variant,
 }: ReleaseNotesButtonProps) {

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelectionColumn.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelectionColumn.tsx
@@ -3,14 +3,29 @@ import type { QuickSelectKey } from "./hooks/useReleaseNotesRange";
 import QuickSelectButtons from "./QuickSelectButtons";
 import ReleaseDropdown from "./ReleaseDropdown";
 
+/**
+ * Props for the {@link ReleaseSelectionColumn} component.
+ */
 interface ReleaseSelectionColumnProps {
+  /** The label for the selection column (e.g., "From", "To"). */
   label: string;
+  /** The game variant for which releases are being selected. */
   variant: GameVariant;
+  /** The currently selected release ID. */
   selectedReleaseId: string | undefined;
+  /** Callback triggered when a release is selected. */
   onSelect: (version: string | undefined) => void;
+  /** A record of version strings mapped to quick select keys. */
   targetVersions: Partial<Record<QuickSelectKey, string>>;
 }
 
+/**
+ * A layout component that groups a label, a release dropdown, and quick select buttons
+ * into a single column for selecting a version.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the selection column.
+ */
 export default function ReleaseSelectionColumn({
   label,
   variant,

--- a/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
+++ b/cat-launcher/src/pages/PlayPage/ReleaseSelector.tsx
@@ -7,6 +7,25 @@ import ReleaseDropdown from "./ReleaseDropdown";
 import ReleaseFilter, { FilterFn } from "./ReleaseFilter";
 import ReleaseNotesButton from "./ReleaseNotesButton";
 
+/**
+ * Props for the {@link ReleaseSelector} component.
+ */
+interface ReleaseSelectorProps {
+  /** The game variant to select a release for. */
+  variant: GameVariant;
+  /** The currently selected release ID (version string). */
+  selectedReleaseId: string | undefined;
+  /** Callback to update the selected release ID. */
+  setSelectedReleaseId: (value: string | undefined) => void;
+}
+
+/**
+ * A compound component for selecting a game release, including filtering by type
+ * and viewing release notes.
+ *
+ * @param props - The component props.
+ * @returns A React element containing the release selector UI.
+ */
 export default function ReleaseSelector({
   variant,
   selectedReleaseId,
@@ -43,10 +62,4 @@ export default function ReleaseSelector({
       </div>
     </div>
   );
-}
-
-interface ReleaseSelectorProps {
-  variant: GameVariant;
-  selectedReleaseId: string | undefined;
-  setSelectedReleaseId: (value: string | undefined) => void;
 }

--- a/cat-launcher/src/pages/PlayPage/constants.ts
+++ b/cat-launcher/src/pages/PlayPage/constants.ts
@@ -1,6 +1,10 @@
 import type { GameVariant } from "@/generated-types/GameVariant";
 import type { QuickSelectKey } from "./hooks/useReleaseNotesRange";
 
+/**
+ * Defines the quick select buttons available for each game variant.
+ * Each button has a label for display and a key used to identify the target version.
+ */
 export const QUICK_SELECT_BUTTONS: Record<
   GameVariant,
   { label: string; key: QuickSelectKey }[]

--- a/cat-launcher/src/pages/PlayPage/hooks/index.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/index.ts
@@ -1,3 +1,7 @@
+/**
+ * This module exports all custom hooks used in the PlayPage.
+ */
+
 export * from "./useReleases";
 export * from "./useReleaseNotes";
 export * from "./useAllReleasesInstallationStatuses";

--- a/cat-launcher/src/pages/PlayPage/hooks/useActiveRelease.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useActiveRelease.ts
@@ -5,6 +5,13 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { getActiveRelease } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * Custom hook to fetch the currently active (installed and selected) release for a game variant.
+ *
+ * @param variant - The game variant.
+ * @param onActiveReleaseError - Optional callback triggered if the active release fails to load.
+ * @returns An object containing the active release ID, loading state, and error state.
+ */
 export function useActiveRelease(
   variant: GameVariant,
   onActiveReleaseError?: (error: unknown) => void,

--- a/cat-launcher/src/pages/PlayPage/hooks/useAllReleasesInstallationStatuses.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useAllReleasesInstallationStatuses.ts
@@ -7,6 +7,13 @@ import { getInstallationStatus } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 import { useReleases } from "./useReleases";
 
+/**
+ * Custom hook to retrieve the installation status for all releases of a specific game variant.
+ * It caches the statuses and provides them as a record mapping release IDs to statuses.
+ *
+ * @param variant - The game variant.
+ * @returns A record where keys are version strings and values are installation statuses.
+ */
 export function useAllReleasesInstallationStatuses(
   variant: GameVariant,
 ) {

--- a/cat-launcher/src/pages/PlayPage/hooks/useInstallAndMonitorRelease.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useInstallAndMonitorRelease.ts
@@ -8,6 +8,14 @@ import { installReleaseForVariant } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 import { toastCL } from "@/lib/utils";
 
+/**
+ * Custom hook to trigger and monitor the installation progress of a specific game release.
+ * It coordinates with the backend to perform the installation and updates the local state on completion.
+ *
+ * @param variant - The game variant.
+ * @param selectedReleaseId - The version ID of the release to install.
+ * @returns An object containing the install function and various progress indicators.
+ */
 export function useInstallAndMonitorRelease(
   variant: GameVariant,
   selectedReleaseId: string | undefined,

--- a/cat-launcher/src/pages/PlayPage/hooks/useInstallationStatus.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useInstallationStatus.ts
@@ -7,6 +7,13 @@ import { getInstallationStatus } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 import { toastCL } from "@/lib/utils";
 
+/**
+ * Custom hook to retrieve and monitor the installation status of a specific game release.
+ *
+ * @param variant - The game variant.
+ * @param selectedReleaseId - The specific release version ID.
+ * @returns An object containing the installation status and any error that occurred.
+ */
 export function useInstallationStatus(
   variant: GameVariant,
   selectedReleaseId: string | undefined,

--- a/cat-launcher/src/pages/PlayPage/hooks/useLastPlayedWorld.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useLastPlayedWorld.ts
@@ -5,6 +5,14 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { getLastPlayedWorld } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * Custom hook to fetch and poll for the name of the last played world for a specific game variant.
+ *
+ * @param variant - The game variant.
+ * @param options - Hook options.
+ * @param options.onError - Callback triggered if the world name fails to load.
+ * @returns An object containing the name of the last played world.
+ */
 export function useLastPlayedWorld(
   variant: GameVariant,
   {

--- a/cat-launcher/src/pages/PlayPage/hooks/useLaunchGame.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useLaunchGame.ts
@@ -7,6 +7,15 @@ import { toastCL } from "@/lib/utils";
 import { useAppDispatch } from "@/store/hooks";
 import { setCurrentlyPlaying } from "@/store/gameSessionSlice";
 
+/**
+ * Custom hook to handle launching a specific game release.
+ *
+ * @param variant - The game variant to launch.
+ * @param options - Launch configuration options.
+ * @param options.worldName - Optional name of the world to load upon launch.
+ * @param options.onError - Optional callback triggered if the game fails to launch.
+ * @returns An object containing the launch function and a loading state.
+ */
 export function useLaunchGame(
   variant: GameVariant,
   {

--- a/cat-launcher/src/pages/PlayPage/hooks/usePlayGame.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/usePlayGame.ts
@@ -1,6 +1,13 @@
 import type { GameVariant } from "@/generated-types/GameVariant";
 import { useLaunchGame } from "./useLaunchGame";
 
+/**
+ * Custom hook to handle starting the game for a specific variant.
+ * It's a convenience wrapper around {@link useLaunchGame}.
+ *
+ * @param variant - The game variant to play.
+ * @returns An object containing the play function and a loading state.
+ */
 export function usePlayGame(variant: GameVariant) {
   const { launch, isStartingGame } = useLaunchGame(variant);
   return { play: launch, isStartingGame };

--- a/cat-launcher/src/pages/PlayPage/hooks/usePlayTime.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/usePlayTime.ts
@@ -11,6 +11,14 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { setupEventListener, toastCL } from "@/lib/utils";
 
+/**
+ * Custom hook to track and retrieve playtime statistics for a specific game variant and release.
+ * It updates the statistics in real-time by listening for game exit events.
+ *
+ * @param variant - The game variant.
+ * @param releaseId - Optional release version ID.
+ * @returns An object containing the total playtime for the variant and playtime for the specific version.
+ */
 export function usePlayTime(
   variant: GameVariant,
   releaseId?: string,

--- a/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotes.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotes.ts
@@ -5,6 +5,13 @@ import type { GameRelease } from "@/generated-types/GameRelease";
 import { fetchReleaseNotes } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * Custom hook to fetch and provide release notes for a specific game release.
+ *
+ * @param release - The game release object to fetch notes for.
+ * @param onReleaseNotesError - Optional callback triggered if the notes fail to load.
+ * @returns An object containing the release notes, loading state, and error state.
+ */
 export default function useReleaseNotes(
   release: GameRelease,
   onReleaseNotesError?: (error: Error) => void,

--- a/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotesRange.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useReleaseNotesRange.ts
@@ -7,6 +7,9 @@ import { queryKeys } from "@/lib/queryKeys";
 import { useActiveRelease } from "./useActiveRelease";
 import { useReleases } from "./useReleases";
 
+/**
+ * Represents predefined keys for quickly selecting specific versions in release notes.
+ */
 export type QuickSelectKey =
   | "Active"
   | "Latest"
@@ -14,6 +17,13 @@ export type QuickSelectKey =
   | "ReleaseCandidate"
   | "Experimental";
 
+/**
+ * Custom hook to manage the selection and display of release notes for a range of versions.
+ * It handles the loading of notes for multiple versions and provides functions to manipulate the range.
+ *
+ * @param variant - The game variant.
+ * @returns An object containing the range boundaries, combined notes, loading state, and helper functions.
+ */
 export function useReleaseNotesRange(variant: GameVariant) {
   const { releases } = useReleases(variant);
   const { activeRelease } = useActiveRelease(variant);

--- a/cat-launcher/src/pages/PlayPage/hooks/useReleases.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useReleases.ts
@@ -15,12 +15,24 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { setupEventListener } from "@/lib/utils";
 
+/**
+ * Represents the status of the release fetching process.
+ */
 export type ReleaseFetchStatus =
   | "idle"
   | "loading"
   | "success"
   | "error";
 
+/**
+ * Custom hook to fetch and manage the list of available releases for a specific game variant.
+ * It listens for real-time updates from the backend and manages the local cache.
+ *
+ * @param variant - The game variant to fetch releases for.
+ * @param onReleasesLoadError - Optional callback triggered if releases fail to load from cache.
+ * @param onReleasesTriggerError - Optional callback triggered if the fetch request fails.
+ * @returns An object containing the list of releases and a loading state.
+ */
 export function useReleases(
   variant: GameVariant,
   onReleasesLoadError?: (error: unknown) => void,

--- a/cat-launcher/src/pages/PlayPage/hooks/useResumeLastWorld.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useResumeLastWorld.ts
@@ -2,6 +2,15 @@ import type { GameVariant } from "@/generated-types/GameVariant";
 import { useLastPlayedWorld } from "./useLastPlayedWorld";
 import { useLaunchGame } from "./useLaunchGame";
 
+/**
+ * Custom hook to resume the last played world for a given game variant.
+ * It identifies the last played world and provides a function to launch it.
+ *
+ * @param variant - The game variant.
+ * @param options - Configuration options.
+ * @param options.onError - Callback triggered if an error occurs during world retrieval or launch.
+ * @returns An object containing the resume function, starting state, and last played world name.
+ */
 export function useResumeLastWorld(
   variant: GameVariant,
   {

--- a/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
+++ b/cat-launcher/src/pages/PlayPage/hooks/useUpgradeInfo.ts
@@ -15,6 +15,16 @@ const RELEASE_TYPE_ORDER: ReleaseType[] = [
   "Experimental",
 ];
 
+/**
+ * Custom hook to provide information and options for upgrading a game variant to newer versions.
+ *
+ * @param variant - The game variant.
+ * @param selectedReleaseId - The currently selected release version ID.
+ * @param setSelectedReleaseId - Callback to update the selected release ID.
+ * @param install - Function to trigger the installation of a release.
+ * @param onActiveReleaseError - Optional callback triggered if the active release fails to load.
+ * @returns An object containing the latest release ID, available upgrade options, and whether an upgrade is allowed.
+ */
 export function useUpgradeInfo(
   variant: GameVariant,
   selectedReleaseId: string | undefined,

--- a/cat-launcher/src/pages/PlayPage/index.tsx
+++ b/cat-launcher/src/pages/PlayPage/index.tsx
@@ -18,6 +18,13 @@ import { useGameVariants } from "@/hooks/useGameVariants";
 import { toastCL } from "@/lib/utils";
 import GameVariantCard from "./GameVariantCard";
 
+/**
+ * The PlayPage component is the main hub for launching games.
+ * It displays a list of game variants as cards, which can be reordered
+ * via drag-and-drop using `@dnd-kit`.
+ *
+ * @returns A React component rendering the Play page.
+ */
 function PlayPage() {
   const {
     gameVariants: orderedItems,

--- a/cat-launcher/src/pages/SettingsPage/components/ColorSettings.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/ColorSettings.tsx
@@ -12,10 +12,23 @@ import { Settings } from "@/generated-types/Settings";
 import { toastCL } from "@/lib/utils";
 import { useColorThemes } from "../hooks";
 
+/**
+ * Props for the {@link ColorSettings} component.
+ */
 interface ColorSettingsProps {
+  /** The form control for settings. */
   control: Control<Settings>;
 }
 
+/**
+ * A component that allows selecting a color theme from a list of available themes.
+ *
+ * @param props - The component props.
+ * @param props.control - The form control for settings.
+ * @param props.themes - The list of available color themes.
+ * @param props.isLoading - Whether the themes are still loading.
+ * @returns A field containing a color theme selector.
+ */
 function ColorSelector({
   control,
   themes,
@@ -68,6 +81,12 @@ function ColorSelector({
   );
 }
 
+/**
+ * The color settings section, allowing users to choose color themes for the game.
+ *
+ * @param props - The component props.
+ * @returns The color settings UI.
+ */
 export function ColorSettings({ control }: ColorSettingsProps) {
   const onThemesError = useCallback(
     (e: Error) => toastCL("error", "Failed to load color themes.", e),

--- a/cat-launcher/src/pages/SettingsPage/components/FontSettings.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/FontSettings.tsx
@@ -12,10 +12,21 @@ import { Settings } from "@/generated-types/Settings";
 import { toastCL } from "@/lib/utils";
 import { useFontFamily, useFonts } from "../hooks";
 
+/**
+ * Props for the {@link FontSettings} component.
+ */
 interface FontSettingsProps {
+  /** The form control for settings. */
   control: Control<Settings>;
 }
 
+/**
+ * A label component that previews a font in its own typeface.
+ *
+ * @param props - The component props.
+ * @param props.font - The font to preview.
+ * @returns A span displaying the font name in the corresponding typeface.
+ */
 function FontPreviewLabel({ font }: { font: Font }) {
   const onFontLoadError = useCallback(
     (e: unknown) => {
@@ -43,6 +54,15 @@ function FontPreviewLabel({ font }: { font: Font }) {
   );
 }
 
+/**
+ * A component that allows selecting a font from a list of available fonts.
+ *
+ * @param props - The component props.
+ * @param props.control - The form control for settings.
+ * @param props.fonts - The list of available fonts.
+ * @param props.isLoading - Whether the fonts are still loading.
+ * @returns A field containing a font selector.
+ */
 function FontSelector({
   control,
   fonts,
@@ -97,6 +117,13 @@ function FontSelector({
   );
 }
 
+/**
+ * A component that displays a larger preview of a selected font with sample text.
+ *
+ * @param props - The component props.
+ * @param props.selectedFont - The font to preview.
+ * @returns A preview section showing sample text in the selected font.
+ */
 function FontPreview({ selectedFont }: { selectedFont: Font }) {
   const onFontLoadError = useCallback(
     (e: unknown) => {
@@ -139,6 +166,12 @@ function FontPreview({ selectedFont }: { selectedFont: Font }) {
   );
 }
 
+/**
+ * The font settings section, allowing users to choose and preview fonts for the game.
+ *
+ * @param props - The component props.
+ * @returns The font settings UI.
+ */
 export function FontSettings({ control }: FontSettingsProps) {
   const onFontsError = useCallback(
     (e: Error) => toastCL("error", "Failed to load fonts.", e),

--- a/cat-launcher/src/pages/SettingsPage/components/MasterReset.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/MasterReset.tsx
@@ -12,6 +12,12 @@ import { useGameVariants } from "@/hooks/useGameVariants";
 import { toastCL } from "@/lib/utils";
 import { useMasterResetMutation } from "../hooks";
 
+/**
+ * A component that provides a "Master Reset" feature for a selected game variant.
+ * This will delete custom configurations, mods, soundpacks, etc., while preserving saves and backups.
+ *
+ * @returns The master reset UI.
+ */
 export function MasterReset() {
   const onVariantsFetchError = useCallback((error: unknown) => {
     toastCL("error", "Failed to fetch game variants.", error);

--- a/cat-launcher/src/pages/SettingsPage/components/SettingsPageFooter.tsx
+++ b/cat-launcher/src/pages/SettingsPage/components/SettingsPageFooter.tsx
@@ -2,14 +2,29 @@ import { SyntheticEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 
+/**
+ * Props for the SettingsPageFooter component.
+ */
 interface SettingsPageFooterProps {
+  /** Indicates if any form fields have been modified. */
   isDirty: boolean;
+  /** Indicates if a settings update is currently in progress. */
   isUpdating: boolean;
+  /** Function to apply the current changes. */
   apply: (e: SyntheticEvent) => void;
+  /** Function to cancel changes and revert to the last saved state. */
   cancel: () => void;
+  /** Function to reset all settings to their default values. */
   resetToDefault: () => void;
 }
 
+/**
+ * The SettingsPageFooter component renders a fixed footer containing action buttons
+ * for the settings form, such as "Reset to Default", "Cancel", and "Apply".
+ *
+ * @param props - The component props.
+ * @returns A React component that renders the footer with settings actions.
+ */
 export function SettingsPageFooter({
   isDirty,
   isUpdating,

--- a/cat-launcher/src/pages/SettingsPage/hooks/useColorThemes.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useColorThemes.ts
@@ -4,6 +4,12 @@ import { useEffect, useRef } from "react";
 import { getColorThemes } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that fetches available color themes for the application.
+ *
+ * @param onThemesError - Optional callback fired if there's an error fetching color themes.
+ * @returns An object containing the list of color themes and loading status.
+ */
 export function useColorThemes(
   onThemesError?: (error: Error) => void,
 ) {

--- a/cat-launcher/src/pages/SettingsPage/hooks/useFontFamily.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useFontFamily.ts
@@ -3,6 +3,13 @@ import { useEffect, useRef, useState } from "react";
 import { Font } from "@/generated-types/Font";
 import { ensureFontLoaded } from "@/lib/utils";
 
+/**
+ * A custom hook that ensures a font is loaded and returns its font-family name.
+ *
+ * @param font - The font object to load.
+ * @param onFontLoadError - Optional callback fired if the font fails to load.
+ * @returns The font-family name if loaded, otherwise undefined.
+ */
 export function useFontFamily(
   font: Font | null | undefined,
   onFontLoadError?: (error: unknown) => void,

--- a/cat-launcher/src/pages/SettingsPage/hooks/useFonts.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useFonts.ts
@@ -4,6 +4,12 @@ import { useEffect, useRef } from "react";
 import { getFonts } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that fetches available fonts for the application.
+ *
+ * @param onFontsError - Optional callback fired if there's an error fetching fonts.
+ * @returns An object containing the list of fonts and loading status.
+ */
 export function useFonts(onFontsError?: (error: Error) => void) {
   const onFontsErrorRef = useRef(onFontsError);
 

--- a/cat-launcher/src/pages/SettingsPage/hooks/useMasterResetMutation.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useMasterResetMutation.ts
@@ -5,6 +5,14 @@ import { GameVariant } from "@/generated-types/GameVariant";
 import { masterReset } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * A custom hook that provides a mutation for performing a master reset on a game variant.
+ * It invalidates relevant queries (mods, tilesets, soundpacks, settings) upon success.
+ *
+ * @param onSuccess - Optional callback to be called when the reset is successful.
+ * @param onError - Optional callback to be called when the reset fails.
+ * @returns An object containing the `reset` function and `isResetting` status.
+ */
 export function useMasterResetMutation(
   onSuccess?: () => void,
   onError?: (error: Error) => void,

--- a/cat-launcher/src/pages/SettingsPage/hooks/useSettingsForm.ts
+++ b/cat-launcher/src/pages/SettingsPage/hooks/useSettingsForm.ts
@@ -14,13 +14,28 @@ import {
 } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * Configuration options for the {@link useSettingsForm} hook.
+ */
 export interface UseSettingsFormProps {
+  /** Callback fired when there's an error fetching current settings. */
   onSettingsError?: (error: Error) => void;
+  /** Callback fired when there's an error fetching default settings. */
   onDefaultSettingsError?: (error: Error) => void;
+  /** Callback fired when there's an error updating settings. */
   onUpdateError?: (error: Error) => void;
+  /** Callback fired when settings are successfully updated. */
   onUpdateSuccess?: () => void;
 }
 
+/**
+ * A custom hook for managing the settings form.
+ * It handles fetching current and default settings, form state management,
+ * and applying/canceling/resetting changes.
+ *
+ * @param props - Configuration options for the hook.
+ * @returns An object containing form state and methods to apply, cancel, or reset settings.
+ */
 export function useSettingsForm({
   onSettingsError,
   onDefaultSettingsError,

--- a/cat-launcher/src/pages/SettingsPage/index.tsx
+++ b/cat-launcher/src/pages/SettingsPage/index.tsx
@@ -7,6 +7,14 @@ import { MasterReset } from "./components/MasterReset";
 import { SettingsPageFooter } from "./components/SettingsPageFooter";
 import { useSettingsForm } from "./hooks";
 
+/**
+ * The SettingsPage component provides a comprehensive interface for users to
+ * modify application settings, such as fonts, colors, and performing a master reset.
+ * It manages the settings form, including loading initial values, updating settings,
+ * and handling errors or success notifications.
+ *
+ * @returns A React component that renders the settings form and footer actions.
+ */
 export default function SettingsPage() {
   const onSettingsError = useCallback(
     (e: Error) => toastCL("error", "Failed to load settings.", e),

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpackCard.tsx
@@ -17,19 +17,47 @@ import {
 } from "./hooks";
 import { PreInstalledButton } from "@/components/PreInstalledButton";
 
+/**
+ * Props for the SoundpackCard component.
+ */
 interface SoundpackCardProps {
+  /**
+   * The game variant associated with the soundpack.
+   */
   variant: GameVariant;
+  /**
+   * The soundpack data to display.
+   */
   soundpack: Soundpack;
 }
 
+/**
+ * Extracts the display name from a soundpack object.
+ *
+ * @param soundpack - The soundpack object.
+ * @returns The name of the soundpack.
+ */
 function getSoundpackName(soundpack: Soundpack): string {
   return soundpack.content.name;
 }
 
+/**
+ * Determines the display type of a soundpack (e.g., Pre-Installed or Third-Party).
+ *
+ * @param soundpack - The soundpack object.
+ * @returns A string representing the soundpack type.
+ */
 function getSoundpackType(soundpack: Soundpack): string {
   return soundpack.type === "Stock" ? "Pre-Installed" : "Third-Party";
 }
 
+/**
+ * The SoundpackCard component displays detailed information about a specific soundpack
+ * and provides actions to install or uninstall it if it's a third-party soundpack.
+ *
+ * @param props - The component props.
+ * @returns A React component that renders the soundpack card.
+ */
 export default function SoundpackCard({
   variant,
   soundpack,

--- a/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/SoundpacksList.tsx
@@ -7,10 +7,24 @@ import SoundpackCard from "./SoundpackCard";
 import { useListAllSoundpacks } from "./hooks";
 import { useSearch } from "@/hooks/useSearch";
 
+/**
+ * Props for the SoundpacksList component.
+ */
 interface SoundpacksListProps {
+  /**
+   * The game variant for which to display soundpacks.
+   */
   variant: GameVariant;
 }
 
+/**
+ * The SoundpacksList component renders a searchable grid of soundpacks available
+ * for a specific game variant. It handles fetching the soundpacks, filtering
+ * based on user input, and displaying loading or empty states.
+ *
+ * @param props - The component props.
+ * @returns A React component that renders the list of soundpacks and a search input.
+ */
 export default function SoundpacksList({
   variant,
 }: SoundpacksListProps) {

--- a/cat-launcher/src/pages/SoundpacksPage/hooks.ts
+++ b/cat-launcher/src/pages/SoundpacksPage/hooks.ts
@@ -15,6 +15,15 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { SoundpackInstallationStatus } from "@/generated-types/SoundpackInstallationStatus";
 
+/**
+ * Hook to install a third-party soundpack for a specific game variant.
+ *
+ * @param variant - The game variant to install the soundpack for.
+ * @param soundpackId - The unique identifier of the soundpack.
+ * @param onSuccess - Optional callback triggered on successful installation.
+ * @param onError - Optional callback triggered when an error occurs during installation.
+ * @returns An object containing the install function and installation status/progress.
+ */
 export function useInstallThirdPartySoundpack(
   variant: GameVariant,
   soundpackId: string | undefined,
@@ -53,6 +62,13 @@ export function useInstallThirdPartySoundpack(
   };
 }
 
+/**
+ * Hook to fetch the installation status of a third-party soundpack.
+ *
+ * @param soundpackId - The unique identifier of the soundpack.
+ * @param variant - The game variant the soundpack belongs to.
+ * @returns An object containing the installation status and loading state.
+ */
 export function useGetThirdPartySoundpackInstallationStatus(
   soundpackId: string,
   variant: GameVariant,
@@ -72,6 +88,14 @@ export function useGetThirdPartySoundpackInstallationStatus(
   };
 }
 
+/**
+ * Hook to uninstall a third-party soundpack.
+ *
+ * @param variant - The game variant to uninstall the soundpack from.
+ * @param onSuccess - Optional callback triggered on successful uninstallation.
+ * @param onError - Optional callback triggered when an error occurs during uninstallation.
+ * @returns An object containing the uninstall function and uninstallation state.
+ */
 export function useUninstallThirdPartySoundpack(
   variant: GameVariant,
   onSuccess?: () => void,
@@ -103,6 +127,12 @@ export function useUninstallThirdPartySoundpack(
   };
 }
 
+/**
+ * Hook to list all available soundpacks for a specific game variant.
+ *
+ * @param variant - The game variant to list soundpacks for.
+ * @returns An object containing the list of soundpacks, loading state, and any potential error.
+ */
 export function useListAllSoundpacks(variant: GameVariant) {
   const query = useQuery({
     queryKey: queryKeys.soundpacks.listAll(variant),

--- a/cat-launcher/src/pages/SoundpacksPage/index.tsx
+++ b/cat-launcher/src/pages/SoundpacksPage/index.tsx
@@ -5,6 +5,13 @@ import { GameVariant } from "@/generated-types/GameVariant";
 import { useGameVariants } from "@/hooks/useGameVariants";
 import SoundpacksList from "./SoundpacksList";
 
+/**
+ * The SoundpacksPage component provides a user interface for browsing and managing soundpacks
+ * for different game variants. It allows users to select a game variant and displays
+ * the corresponding list of soundpacks.
+ *
+ * @returns A React component that renders the soundpack selection and listing interface.
+ */
 function SoundpacksPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();

--- a/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetCard.tsx
@@ -17,19 +17,46 @@ import {
 } from "./hooks";
 import { PreInstalledButton } from "@/components/PreInstalledButton";
 
+/**
+ * Props for the {@link TilesetCard} component.
+ */
 interface TilesetCardProps {
+  /**
+   * The game variant associated with the tileset.
+   */
   variant: GameVariant;
+  /**
+   * The tileset data to display.
+   */
   tileset: Tileset;
 }
 
+/**
+ * Extracts the display name from a tileset.
+ *
+ * @param tileset - The tileset object.
+ * @returns The name of the tileset.
+ */
 function getTilesetName(tileset: Tileset): string {
   return tileset.content.name;
 }
 
+/**
+ * Determines the display type of a tileset (Pre-Installed or Third-Party).
+ *
+ * @param tileset - The tileset object.
+ * @returns A string representing the tileset type.
+ */
 function getTilesetType(tileset: Tileset): string {
   return tileset.type === "Stock" ? "Pre-Installed" : "Third-Party";
 }
 
+/**
+ * A card component that displays information about a single tileset and provides installation/uninstallation controls.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the tileset card.
+ */
 export default function TilesetCard({
   variant,
   tileset,

--- a/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/TilesetsList.tsx
@@ -7,10 +7,22 @@ import TilesetCard from "./TilesetCard";
 import { useListAllTilesets } from "./hooks";
 import { useSearch } from "@/hooks/useSearch";
 
+/**
+ * Props for the {@link TilesetsList} component.
+ */
 interface TilesetsListProps {
+  /**
+   * The game variant for which to list tilesets.
+   */
   variant: GameVariant;
 }
 
+/**
+ * A component that displays a searchable list of tilesets for a specific game variant.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the tilesets list.
+ */
 export default function TilesetsList({ variant }: TilesetsListProps) {
   const { tilesets, isLoading, error } = useListAllTilesets(variant);
 

--- a/cat-launcher/src/pages/TilesetsPage/hooks.ts
+++ b/cat-launcher/src/pages/TilesetsPage/hooks.ts
@@ -15,6 +15,15 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { TilesetInstallationStatus } from "@/generated-types/TilesetInstallationStatus";
 
+/**
+ * A custom hook that handles the installation and monitoring of a third-party tileset.
+ *
+ * @param variant - The game variant to install the tileset for.
+ * @param tilesetId - The unique identifier of the tileset.
+ * @param onSuccess - Optional callback fired when installation is successful.
+ * @param onError - Optional callback fired if installation fails.
+ * @returns An object containing installation methods and status.
+ */
 export function useInstallAndMonitorThirdPartyTileset(
   variant: GameVariant,
   tilesetId: string | undefined,
@@ -53,6 +62,13 @@ export function useInstallAndMonitorThirdPartyTileset(
   };
 }
 
+/**
+ * A custom hook that fetches the installation status of a third-party tileset.
+ *
+ * @param tilesetId - The unique identifier of the tileset.
+ * @param variant - The game variant.
+ * @returns An object containing the installation status and loading state.
+ */
 export function useGetThirdPartyTilesetInstallationStatus(
   tilesetId: string,
   variant: GameVariant,
@@ -72,6 +88,14 @@ export function useGetThirdPartyTilesetInstallationStatus(
   };
 }
 
+/**
+ * A custom hook that provides a mutation for uninstalling a third-party tileset.
+ *
+ * @param variant - The game variant to uninstall the tileset from.
+ * @param onSuccess - Optional callback fired when uninstallation is successful.
+ * @param onError - Optional callback fired if uninstallation fails.
+ * @returns An object containing the `uninstall` function and `isUninstalling` status.
+ */
 export function useUninstallThirdPartyTileset(
   variant: GameVariant,
   onSuccess?: () => void,
@@ -103,6 +127,12 @@ export function useUninstallThirdPartyTileset(
   };
 }
 
+/**
+ * A custom hook that fetches all available tilesets for a game variant.
+ *
+ * @param variant - The game variant to list tilesets for.
+ * @returns An object containing the list of tilesets, loading status, and any error.
+ */
 export function useListAllTilesets(variant: GameVariant) {
   const query = useQuery({
     queryKey: queryKeys.tilesets.listAll(variant),

--- a/cat-launcher/src/pages/TilesetsPage/index.tsx
+++ b/cat-launcher/src/pages/TilesetsPage/index.tsx
@@ -5,6 +5,12 @@ import { GameVariant } from "@/generated-types/GameVariant";
 import { useGameVariants } from "@/hooks/useGameVariants";
 import TilesetsList from "./TilesetsList";
 
+/**
+ * The Tilesets page component, which allows users to select a game variant
+ * and view/manage tilesets for that variant.
+ *
+ * @returns The tilesets page UI.
+ */
 function TilesetsPage() {
   const { gameVariants, isLoading: gameVariantsLoading } =
     useGameVariants();

--- a/cat-launcher/src/pages/ToolsPage/components/Guide.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/Guide.tsx
@@ -1,3 +1,8 @@
+/**
+ * A component that displays the user guide and documentation (Coming soon).
+ *
+ * @returns A React element representing the guide view.
+ */
 export default function Guide() {
   return (
     <div className="space-y-4">

--- a/cat-launcher/src/pages/ToolsPage/components/ToolsSidebar.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/ToolsSidebar.tsx
@@ -1,11 +1,26 @@
 import { Sidebar } from "@/components/Sidebar";
 import { toolRoutes } from "../routes";
 
+/**
+ * Props for the {@link ToolsSidebar} component.
+ */
 interface ToolsSidebarProps {
+  /**
+   * Whether the sidebar is currently collapsed.
+   */
   isCollapsed: boolean;
+  /**
+   * Callback function to toggle the sidebar collapse state.
+   */
   onToggleCollapse: () => void;
 }
 
+/**
+ * A sidebar component specifically for the Tools page navigation.
+ *
+ * @param props - The component props.
+ * @returns A React element representing the tools sidebar.
+ */
 export default function ToolsSidebar({
   isCollapsed,
   onToggleCollapse,

--- a/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
+++ b/cat-launcher/src/pages/ToolsPage/components/WorldOptions.tsx
@@ -1,3 +1,8 @@
+/**
+ * A component for configuring world-specific options (Coming soon).
+ *
+ * @returns A React element representing the world options view.
+ */
 export default function WorldOptions() {
   return (
     <div className="space-y-4">

--- a/cat-launcher/src/pages/ToolsPage/index.tsx
+++ b/cat-launcher/src/pages/ToolsPage/index.tsx
@@ -4,6 +4,12 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import ToolsSidebar from "./components/ToolsSidebar";
 import { toolRoutes } from "./routes";
 
+/**
+ * The main page component for the Tools section.
+ * Manages the layout with a sidebar and a content area for different utility views.
+ *
+ * @returns A React element representing the tools page.
+ */
 export default function ToolsPage() {
   const [isCollapsed, setIsCollapsed] = useState(true);
 

--- a/cat-launcher/src/pages/ToolsPage/routes.tsx
+++ b/cat-launcher/src/pages/ToolsPage/routes.tsx
@@ -4,8 +4,15 @@ import { Settings2, BookOpen } from "lucide-react";
 import WorldOptions from "./components/WorldOptions";
 import Guide from "./components/Guide";
 
+/**
+ * Represents a route within the tools section.
+ */
 export type ToolRoute = BaseRoute;
 
+/**
+ * The collection of routes available within the tools page.
+ * Each route includes a path, element, label, and icon for navigation.
+ */
 export const toolRoutes: ToolRoute[] = [
   {
     path: "world-options",

--- a/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
+++ b/cat-launcher/src/pages/game-tips/TipOfTheDay.tsx
@@ -12,10 +12,20 @@ import { useGetTips } from "./hooks/useGetTips";
 import { NO_TIPS_AVAILABLE } from "./lib/constants";
 import { TIP_OF_THE_DAY_AUTOSHUFFLE_INTERVAL_MS } from "@/lib/constants";
 
+/**
+ * Props for the {@link TipOfTheDayContent} component.
+ */
 interface TipOfTheDayContentProps {
+  /** The tip text to display. */
   tip: string;
 }
 
+/**
+ * Renders the visual content of a game tip within an Alert component.
+ *
+ * @param props - Component properties.
+ * @returns A React element displaying the tip.
+ */
 function TipOfTheDayContent({ tip }: TipOfTheDayContentProps) {
   return (
     <Alert className="flex flex-col bg-secondary text-secondary-foreground">
@@ -30,10 +40,21 @@ function TipOfTheDayContent({ tip }: TipOfTheDayContentProps) {
   );
 }
 
+/**
+ * Props for the {@link TipOfTheDay} component.
+ */
 interface TipOfTheDayProps {
+  /** The game variant to fetch and display tips for. */
   variant: GameVariant;
 }
 
+/**
+ * Component that displays a randomly selected game tip for a given variant.
+ * The tip is automatically shuffled at regular intervals.
+ *
+ * @param props - Component properties.
+ * @returns A React element that manages tip selection and display.
+ */
 export function TipOfTheDay({ variant }: TipOfTheDayProps) {
   const { data, status } = useGetTips(variant);
 

--- a/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
+++ b/cat-launcher/src/pages/game-tips/hooks/useGetTips.ts
@@ -4,6 +4,13 @@ import { queryKeys } from "@/lib/queryKeys";
 import { getTips } from "@/lib/commands";
 import type { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * Custom hook to fetch game tips for a specific game variant.
+ * Uses TanStack Query for data fetching and caching.
+ *
+ * @param variant - The game variant to fetch tips for.
+ * @returns A query object containing the status and data of the tips.
+ */
 export function useGetTips(variant: GameVariant) {
   return useQuery({
     queryKey: queryKeys.tips(variant),

--- a/cat-launcher/src/pages/game-tips/lib/constants.ts
+++ b/cat-launcher/src/pages/game-tips/lib/constants.ts
@@ -1,2 +1,6 @@
+/**
+ * Message displayed when no tips are available to show.
+ * This typically happens when no game is installed yet.
+ */
 export const NO_TIPS_AVAILABLE =
   "Install a game to start getting tips and hints.";

--- a/cat-launcher/src/providers/CatLauncherVersionTracker.tsx
+++ b/cat-launcher/src/providers/CatLauncherVersionTracker.tsx
@@ -3,10 +3,23 @@ import { ReactNode, useEffect, useRef } from "react";
 
 import pkg from "../../package.json";
 
+/**
+ * Props for the {@link CatLauncherVersionTracker} component.
+ */
 export interface CatLauncherVersionTrackerProps {
+  /**
+   * The child components to be rendered.
+   */
   children: ReactNode;
 }
 
+/**
+ * A component that tracks the application version and captures a "launch" event in PostHog.
+ * This ensures that every time the application is started, its version is reported.
+ *
+ * @param props - The component props.
+ * @returns A React component that wraps its children.
+ */
 export default function CatLauncherVersionTracker({
   children,
 }: CatLauncherVersionTrackerProps) {

--- a/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
+++ b/cat-launcher/src/providers/PostHogProviderWithIdentifiedUser.tsx
@@ -5,16 +5,32 @@ import { ReactNode } from "react";
 import { queryKeys } from "@/lib/queryKeys";
 import { getUserId } from "@/lib/commands";
 
+/**
+ * Configuration options for the PostHog client.
+ */
 const posthogOptions = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   defaults: "2025-11-30",
   persistence: "localStorage",
 } as const;
 
+/**
+ * Props for the {@link PostHogProviderWithIdentifiedUser} component.
+ */
 export interface PostHogProviderWithIdentifiedUserProps {
+  /**
+   * The child components to be rendered.
+   */
   children: ReactNode;
 }
 
+/**
+ * A component that initializes PostHog and identifies the user using a unique ID retrieved from the backend.
+ * It waits for the user ID to be available before rendering its children within the {@link PostHogProvider}.
+ *
+ * @param props - The component props.
+ * @returns A React component that wraps its children with PostHog context, or null while loading.
+ */
 export default function PostHogProviderWithIdentifiedUser({
   children,
 }: PostHogProviderWithIdentifiedUserProps) {

--- a/cat-launcher/src/providers/QuitConfirmationProvider.tsx
+++ b/cat-launcher/src/providers/QuitConfirmationProvider.tsx
@@ -5,6 +5,15 @@ import { confirmQuit, listenToQuitRequested } from "@/lib/commands";
 import { setupEventListener } from "@/lib/utils";
 import { useAppSelector } from "@/store/hooks";
 
+/**
+ * A provider component that intercepts the application's quit request.
+ * If a game is currently running, it displays a confirmation dialog to warn the user
+ * about the consequences of quitting (e.g., play time not recorded, logs not saved).
+ * If no game is running, it allows the application to quit immediately.
+ *
+ * @param props - The component props containing children to be rendered.
+ * @returns A React component that wraps its children and handles quit confirmation.
+ */
 export default function QuitConfirmationProvider({
   children,
 }: {

--- a/cat-launcher/src/providers/hooks.ts
+++ b/cat-launcher/src/providers/hooks.ts
@@ -11,19 +11,35 @@ import { setupEventListener } from "@/lib/utils";
 import { clearCurrentlyPlaying } from "@/store/gameSessionSlice";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 
+/**
+ * Hook that notifies the backend that the frontend is ready.
+ * This should be called once when the application starts.
+ */
 export function useFrontendReady() {
   useEffect(() => {
     onFrontendReady();
   }, []);
 }
 
+/**
+ * Represents the status of a game session.
+ */
 export enum GameStatus {
+  /** The game is not running or has exited normally. */
   IDLE = "IDLE",
+  /** The game crashed with a non-zero exit code. */
   CRASHED = "CRASHED",
+  /** An error occurred while trying to launch or monitor the game. */
   ERROR = "ERROR",
+  /** The game was terminated by an external signal. */
   TERMINATED = "TERMINATED",
 }
 
+/**
+ * Hook that listens for game session events (logs, exits, errors) and manages the game status and logs.
+ *
+ * @returns An object containing the current game status, logs as text, exit code, and a function to reset the monitor.
+ */
 export function useGameSessionEvents() {
   const [gameStatus, setGameStatus] = useState<GameStatus>(
     GameStatus.IDLE,
@@ -96,11 +112,21 @@ export function useGameSessionEvents() {
   return { gameStatus, logsText, exitCode, resetGameSessionMonitor };
 }
 
+/**
+ * Represents the status of the application's auto-update process.
+ */
 export enum AutoUpdateStatus {
+  /** No update is in progress or an update succeeded. */
   IDLE = "IDLE",
+  /** The auto-update process failed. */
   FAILURE = "FAILURE",
 }
 
+/**
+ * Hook that listens for auto-update status events and manages the auto-update status.
+ *
+ * @returns An object containing the current auto-update status and a function to reset it.
+ */
 export function useAutoUpdateEvents() {
   const [autoUpdateStatus, setAutoUpdateStatus] =
     useState<AutoUpdateStatus>(AutoUpdateStatus.IDLE);

--- a/cat-launcher/src/providers/index.tsx
+++ b/cat-launcher/src/providers/index.tsx
@@ -17,12 +17,28 @@ import PostHogProviderWithIdentifiedUser from "./PostHogProviderWithIdentifiedUs
 import ThemeBootstrapper from "@/theme/ThemeBootstrapper";
 import QuitConfirmationProvider from "./QuitConfirmationProvider";
 
+/**
+ * Props for the {@link Providers} component.
+ */
 export interface ProvidersProps {
+  /**
+   * The child components to be wrapped by the providers.
+   */
   children: ReactNode;
 }
 
+/**
+ * The React Query client used for data fetching and caching.
+ */
 const queryClient = new QueryClient();
 
+/**
+ * A component that wraps the application with all necessary React context providers.
+ * Includes Redux, React Query, Tooltip, PostHog, Version Tracking, Theme, and more.
+ *
+ * @param props - The component props.
+ * @returns A React component that provides the context for the application.
+ */
 export default function Providers({ children }: ProvidersProps) {
   useFrontendReady();
 

--- a/cat-launcher/src/routes.tsx
+++ b/cat-launcher/src/routes.tsx
@@ -19,15 +19,39 @@ import BackupsPage from "@/pages/BackupsPage";
 import PlayPage from "@/pages/PlayPage";
 import SettingsPage from "@/pages/SettingsPage";
 
+/**
+ * Defines the structure for a route in the application.
+ */
 export interface BaseRoute {
+  /**
+   * The URL path for the route.
+   */
   path: string;
+  /**
+   * The React component to render for this route.
+   */
   element: ReactNode;
+  /**
+   * The display label for the route, often used in navigation.
+   */
   label: string;
+  /**
+   * The icon associated with the route.
+   */
   icon: LucideIcon;
+  /**
+   * The layout type for this route. Defaults to "default".
+   */
   layout?: "sidebar" | "default";
+  /**
+   * Whether the route should be hidden from navigation.
+   */
   hidden?: boolean;
 }
 
+/**
+ * The collection of primary routes for the application.
+ */
 export const routes: BaseRoute[] = [
   {
     path: "/",

--- a/cat-launcher/src/store/gameSessionSlice.ts
+++ b/cat-launcher/src/store/gameSessionSlice.ts
@@ -2,20 +2,41 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import type { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * State structure for the {@link gameSessionSlice}.
+ */
 interface GameSessionState {
+  /**
+   * The game variant currently being played, or null if no session is active.
+   */
   currentlyPlaying: GameVariant | null;
+  /**
+   * The version of the game variant currently being played, or null if no session is active.
+   */
   currentlyPlayingVersion: string | null;
 }
 
+/**
+ * The initial state for the {@link gameSessionSlice}.
+ */
 const initialState: GameSessionState = {
   currentlyPlaying: null,
   currentlyPlayingVersion: null,
 };
 
+/**
+ * A Redux slice that manages the state of the active game session.
+ */
 export const gameSessionSlice = createSlice({
   name: "gameSession",
   initialState,
   reducers: {
+    /**
+     * Sets the currently playing game variant and version.
+     *
+     * @param state - The current state.
+     * @param action - The action containing the variant and version.
+     */
     setCurrentlyPlaying: (
       state,
       action: PayloadAction<{
@@ -26,6 +47,11 @@ export const gameSessionSlice = createSlice({
       state.currentlyPlaying = action.payload.variant;
       state.currentlyPlayingVersion = action.payload.version;
     },
+    /**
+     * Clears the currently playing game session state.
+     *
+     * @param state - The current state.
+     */
     clearCurrentlyPlaying: (state) => {
       state.currentlyPlaying = null;
       state.currentlyPlayingVersion = null;

--- a/cat-launcher/src/store/hooks.ts
+++ b/cat-launcher/src/store/hooks.ts
@@ -2,5 +2,11 @@ import { useDispatch, useSelector } from "react-redux";
 
 import type { AppDispatch, RootState } from "./store";
 
+/**
+ * A custom hook that provides a typed `dispatch` function for the Redux store.
+ */
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+/**
+ * A custom hook that provides a typed `useSelector` function for the Redux store.
+ */
 export const useAppSelector = useSelector.withTypes<RootState>();

--- a/cat-launcher/src/store/installationProgressSlice.ts
+++ b/cat-launcher/src/store/installationProgressSlice.ts
@@ -3,15 +3,27 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { SerializableDownloadProgress } from "@/lib/types";
 import type { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * Represents the type of component being installed.
+ */
 type InstallationType = "release" | "mod" | "soundpack" | "tileset";
 
+/**
+ * Possible statuses for an ongoing installation.
+ */
 export type InstallationProgressStatus =
   | "Downloading"
   | "Installing"
   | "Success"
   | "Error";
 
+/**
+ * State structure for the {@link installationProgressSlice}.
+ */
 interface InstallationProgressState {
+  /**
+   * A nested record mapping installation type, game variant, and item ID to its installation status.
+   */
   installationStatusByVariant: Record<
     InstallationType,
     Record<
@@ -19,6 +31,9 @@ interface InstallationProgressState {
       Record<string, InstallationProgressStatus | null>
     >
   >;
+  /**
+   * A nested record mapping installation type, game variant, and item ID to its download progress.
+   */
   downloadProgressByVariant: Record<
     InstallationType,
     Record<
@@ -28,6 +43,9 @@ interface InstallationProgressState {
   >;
 }
 
+/**
+ * The initial state for the {@link installationProgressSlice}.
+ */
 const initialState: InstallationProgressState = {
   installationStatusByVariant: {
     release: {
@@ -75,10 +93,19 @@ const initialState: InstallationProgressState = {
   },
 };
 
+/**
+ * A Redux slice that manages the progress and status of ongoing installations.
+ */
 export const installationProgressSlice = createSlice({
   name: "installationProgress",
   initialState,
   reducers: {
+    /**
+     * Updates the download progress and derives the installation status for a specific item.
+     *
+     * @param state - The current state.
+     * @param action - The action containing progress details.
+     */
     setDownloadProgress: (
       state,
       action: PayloadAction<{
@@ -105,6 +132,12 @@ export const installationProgressSlice = createSlice({
       }
     },
 
+    /**
+     * Clears the installation progress and status for a specific item.
+     *
+     * @param state - The current state.
+     * @param action - The action containing the item details to clear.
+     */
     clearInstallationProgress: (
       state,
       action: PayloadAction<{

--- a/cat-launcher/src/store/selectedVariantSlice.ts
+++ b/cat-launcher/src/store/selectedVariantSlice.ts
@@ -2,18 +2,36 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 import { GameVariant } from "@/generated-types/GameVariant";
 
+/**
+ * State structure for the {@link selectedVariantSlice}.
+ */
 interface SelectedVariantState {
+  /**
+   * The currently selected game variant, or null if none is selected.
+   */
   variant: GameVariant | null;
 }
 
+/**
+ * The initial state for the {@link selectedVariantSlice}.
+ */
 const initialState: SelectedVariantState = {
   variant: null,
 };
 
+/**
+ * A Redux slice that manages the currently selected game variant.
+ */
 export const selectedVariantSlice = createSlice({
   name: "selectedVariant",
   initialState,
   reducers: {
+    /**
+     * Sets the currently selected game variant.
+     *
+     * @param state - The current state.
+     * @param action - The action containing the new variant.
+     */
     setSelectedVariant: (
       state,
       action: PayloadAction<GameVariant | null>,

--- a/cat-launcher/src/store/store.ts
+++ b/cat-launcher/src/store/store.ts
@@ -4,6 +4,9 @@ import gameSessionReducer from "./gameSessionSlice";
 import installationProgressReducer from "./installationProgressSlice";
 import selectedVariantReducer from "./selectedVariantSlice";
 
+/**
+ * The root Redux store for the application.
+ */
 export const store = configureStore({
   reducer: {
     gameSession: gameSessionReducer,
@@ -12,5 +15,11 @@ export const store = configureStore({
   },
 });
 
+/**
+ * The root state type of the Redux store.
+ */
 export type RootState = ReturnType<typeof store.getState>;
+/**
+ * The dispatch type for the Redux store.
+ */
 export type AppDispatch = typeof store.dispatch;

--- a/cat-launcher/src/theme/useTheme.ts
+++ b/cat-launcher/src/theme/useTheme.ts
@@ -9,23 +9,48 @@ import type { Theme } from "@/generated-types/Theme";
 import { getPreferredTheme, setPreferredTheme } from "@/lib/commands";
 import { queryKeys } from "@/lib/queryKeys";
 
+/**
+ * The key used for storing the theme preference in local storage.
+ */
 export const THEME_STORAGE_KEY = "cat-launcher-theme";
 
+/**
+ * Retrieves the theme currently stored in local storage.
+ *
+ * @returns The stored theme, or null if none is set or if it's invalid.
+ */
 export function getStoredTheme(): Theme | null {
   const stored = localStorage.getItem(THEME_STORAGE_KEY);
   return stored === "Dark" || stored === "Light" ? stored : null;
 }
 
+/**
+ * Persists the provided theme to local storage.
+ *
+ * @param theme - The theme to store.
+ */
 export function setStoredTheme(theme: Theme): void {
   localStorage.setItem(THEME_STORAGE_KEY, theme);
 }
 
+/**
+ * Applies the specified theme to the DOM by toggling classes and setting CSS styles.
+ *
+ * @param theme - The theme to apply.
+ */
 export function applyThemeToDom(theme: Theme): void {
   const root = document.documentElement;
   root.classList.toggle("dark", theme !== "Light");
   root.style.colorScheme = theme === "Light" ? "light" : "dark";
 }
 
+/**
+ * A custom hook that manages the application's color theme.
+ * It handles fetching from the backend, persisting to local storage, and applying it to the DOM.
+ *
+ * @param onError - Optional callback for handling errors during theme operations.
+ * @returns An object containing the current theme, a toggle function, and the update state.
+ */
 export function useTheme(onError?: (error: unknown) => void) {
   const queryClient = useQueryClient();
 

--- a/scripts/bump_version/src/bump_version/__init__.py
+++ b/scripts/bump_version/src/bump_version/__init__.py
@@ -1,1 +1,4 @@
+"""Version information for the bump_version script."""
+
 __version__ = "0.1.0"
+"""str: The current version of the bump_version package."""

--- a/scripts/bump_version/src/bump_version/cli.py
+++ b/scripts/bump_version/src/bump_version/cli.py
@@ -10,10 +10,19 @@ from typing import Optional
 import semver
 import tomlkit
 
+"""Command-line interface for bumping the version across the project."""
+
 BASE_PATH = Path(__file__).parent.parent.parent.parent.parent
+"""Path: The root directory of the project."""
 
 
 def update_readme(readme_path: Path, new_version: str) -> None:
+    """Updates the version number in the README.md file.
+
+    Args:
+        readme_path: The path to the README.md file.
+        new_version: The new version string to insert.
+    """
     content = readme_path.read_text()
     content = re.sub(
         r"cat-launcher_\d+\.\d+(\.\d+)?_amd64\.AppImage",
@@ -24,6 +33,12 @@ def update_readme(readme_path: Path, new_version: str) -> None:
 
 
 def update_json(json_path: Path, new_version: str) -> None:
+    """Updates the version field in a JSON file.
+
+    Args:
+        json_path: The path to the JSON file.
+        new_version: The new version string to set.
+    """
     with json_path.open("r") as f:
         content = json.load(f)
     content["version"] = new_version
@@ -33,6 +48,12 @@ def update_json(json_path: Path, new_version: str) -> None:
 
 
 def update_cargo_toml(toml_path: Path, new_version: str) -> None:
+    """Updates the package version in a Cargo.toml file.
+
+    Args:
+        toml_path: The path to the Cargo.toml file.
+        new_version: The new version string to set.
+    """
     with toml_path.open("r") as f:
         doc = tomlkit.load(f)
     doc["package"]["version"] = new_version
@@ -40,6 +61,12 @@ def update_cargo_toml(toml_path: Path, new_version: str) -> None:
 
 
 def update_cargo_lock(lock_path: Path, new_version: str) -> None:
+    """Updates the cat-launcher package version in a Cargo.lock file.
+
+    Args:
+        lock_path: The path to the Cargo.lock file.
+        new_version: The new version string to set.
+    """
     with lock_path.open("r") as f:
         doc = tomlkit.load(f)
 
@@ -52,6 +79,14 @@ def update_cargo_lock(lock_path: Path, new_version: str) -> None:
 
 
 def main(args: Optional[list[str]] = None) -> None:
+    """Main entry point for the version bumping script.
+
+    Parses command line arguments, validates the new version, and updates
+    all necessary files in the project.
+
+    Args:
+        args: Optional list of command line arguments. Defaults to sys.argv[1:].
+    """
     parser = argparse.ArgumentParser(description="Bump version in all project files")
     parser.add_argument("version", help="New version (e.g., 0.13.0 or 0.13)")
     parsed_args = parser.parse_args(args)

--- a/scripts/schema_validator/src/schema_validator/__init__.py
+++ b/scripts/schema_validator/src/schema_validator/__init__.py
@@ -1,1 +1,4 @@
+"""Version information for the schema_validator script."""
+
 __version__ = "0.1.0"
+"""str: The current version of the schema_validator package."""

--- a/scripts/schema_validator/src/schema_validator/cli.py
+++ b/scripts/schema_validator/src/schema_validator/cli.py
@@ -8,16 +8,37 @@ from typing import Optional
 
 from git import Repo
 
+"""Command-line interface for validating SQLite schema compatibility."""
+
 SCHEMA_PATH = "cat-launcher/src-tauri/schemas/schema.sql"
+"""str: The relative path to the SQLite schema file in the repository."""
 
 
 def get_schema_at_commit(repo: Repo, commit_sha: str) -> str:
+    """Retrieves the schema file content at a specific git commit.
+
+    Args:
+        repo: The git repository object.
+        commit_sha: The SHA-1 hash of the commit to retrieve the schema from.
+
+    Returns:
+        The content of the schema file as a string.
+    """
     commit = repo.commit(commit_sha)
     blob = commit.tree / SCHEMA_PATH
     return blob.data_stream.read().decode("utf-8")
 
 
 def execute_schema(conn: sqlite3.Connection, schema: str) -> bool:
+    """Executes a SQL schema script on a database connection.
+
+    Args:
+        conn: The SQLite database connection.
+        schema: The SQL script to execute.
+
+    Returns:
+        True if the schema was executed successfully, False otherwise.
+    """
     try:
         cursor = conn.cursor()
         cursor.executescript(schema)
@@ -28,6 +49,14 @@ def execute_schema(conn: sqlite3.Connection, schema: str) -> bool:
 
 
 def main(args: Optional[list[str]] = None) -> None:
+    """Main entry point for the schema validation script.
+
+    Compares the SQLite schema between two commits to ensure that the current
+    schema can be applied on top of the previous one (simulating a migration).
+
+    Args:
+        args: Optional list of command line arguments. Defaults to sys.argv[1:].
+    """
     parser = argparse.ArgumentParser(
         description="Verify SQLite schema compatibility between two commits"
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add doc comments across Rust and React: commands, error enums, repositories, infra (archive/download/http/autoupdate), domain types (achievements/releases/mods/tilesets/soundpacks/settings/theme/play time), and the `CommandErrorSerialize` proc macro; plus JSDoc on `App`, `AutoUpdateNotifier`, `DataTable`, and `DownloadProgress`. Improves readability and `ts-rs` TS exports with no runtime or API changes.

<sup>Written for commit ceeb2e050104dadc2a891eb0769b4a22f988992a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

