### PR TITLE
chore: simplify flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,30 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,121 +3,35 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    { nixpkgs, ... }:
-    let
-      systems = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
 
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-    in
-    {
-      devShells = forAllSystems (
-        system:
-        let
-          pkgs = import nixpkgs { inherit system; };
-          lib = pkgs.lib;
-
-          nodejs =
-            if builtins.hasAttr "nodejs_24" pkgs then
-              pkgs.nodejs_24
-            else
-              pkgs.nodejs;
-
-          pnpm =
-            if builtins.hasAttr "pnpm_10" pkgs then
-              pkgs.pnpm_10
-            else
-              pkgs.pnpm;
-
-          openssl = pkgs.openssl;
-
-          webkitgtk =
-            if builtins.hasAttr "webkitgtk_4_1" pkgs then
-              pkgs.webkitgtk_4_1
-            else
-              pkgs.webkitgtk;
-
-          appIndicatorLibs =
-            lib.optionals (builtins.hasAttr "libayatana-appindicator" pkgs) [
-              pkgs.libayatana-appindicator
-            ]
-            ++ lib.optionals (builtins.hasAttr "libappindicator-gtk3" pkgs) [
-              pkgs."libappindicator-gtk3"
-            ];
-
-          tauriNativeLibs =
-            (with pkgs; [
-              at-spi2-atk
-              atk
-              cairo
-              dbus
-              gdk-pixbuf
-              glib
-              glib-networking
-              gsettings-desktop-schemas
-              gtk3
-              harfbuzz
-              hicolor-icon-theme
-              libdrm
-              libepoxy
-              libglvnd
-              librsvg
-              libsoup_3
-              libxkbcommon
-              openssl
-              pango
-              shared-mime-info
-              wayland
-              webkitgtk
-              xdotool
-              libX11
-              libXcursor
-              libXi
-              libXrandr
-            ])
-            ++ appIndicatorLibs;
-
-          xdgDataDirs = lib.concatStringsSep ":" [
-            "${pkgs.gsettings-desktop-schemas}/share"
-            "${pkgs.gtk3}/share"
-            "${pkgs.hicolor-icon-theme}/share"
-            "${pkgs.shared-mime-info}/share"
-          ];
-        in
-        {
+        tauriDependencies = with pkgs; [
+          pkg-config
+          webkitgtk_4_1
+        ];
+      in
+      {
+        devShells = {
           default = pkgs.mkShell {
-            packages =
-              (with pkgs; [
-                cargo
-                cargo-edit
-                clippy
-                curl
-                file
-                gcc
-                gnumake
-                nodejs
-                pkg-config
-                pnpm
-                rustc
-                rustfmt
-                uv
-                wget
-              ])
-              ++ tauriNativeLibs;
-
-            env = {
-              GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
-              LD_LIBRARY_PATH = lib.makeLibraryPath tauriNativeLibs;
-              WEBKIT_DISABLE_COMPOSITING_MODE = "1";
-              XDG_DATA_DIRS = xdgDataDirs;
-            };
+            packages = with pkgs; [
+              cargo
+              cargo-edit
+              clippy
+              nodejs
+              pnpm
+              rustc
+              rustfmt
+              uv
+            ] ++ tauriDependencies;
           };
-        }
-      );
-    };
+        };
+      }
+    );
 }


### PR DESCRIPTION
Simplify the Nix flake configuration by using flake-utils for system iteration and reducing the package list to essentials.

Generated by Mistral Vibe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Nix flake by using `flake-utils` for system iteration and a leaner dev shell. Removed heavy native library wiring while keeping essential Tauri build deps.

- **Refactors**
  - Replaced manual system list with `flake-utils.lib.eachDefaultSystem`.
  - Switched to `nixpkgs.legacyPackages.${system}` and trimmed devShell to Rust, Node, `pnpm`, `uv`, plus minimal Tauri deps (`pkg-config`, `webkitgtk_4_1`).
  - Removed custom env vars and large native lib lists.

- **Dependencies**
  - Added `flake-utils` (and `nix-systems/default`) input.
  - Updated `nixpkgs` pin and refreshed `flake.lock`.

<sup>Written for commit 563d62e115f70c5a69da9f67c3a84fb7e4853d6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

