### PR TITLE
test(variants): add game variants info integration tests

### DIFF
--- a/cat-launcher/package.json
+++ b/cat-launcher/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "test": "cargo test --manifest-path ./src-tauri/Cargo.toml",
     "lint": "eslint . --max-warnings 0 && pnpm tsc --noEmit && cargo clippy --manifest-path ./src-tauri/Cargo.toml -- -D warnings",
     "lint:fix": "eslint . --fix && cargo clippy --manifest-path ./src-tauri/Cargo.toml --fix --allow-dirty",
     "format": "prettier --write . && cargo fmt --manifest-path ./src-tauri/Cargo.toml",

--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "ts-rs",

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -48,5 +48,8 @@ urlencoding = "2.1.3"
 ttf-parser = "0.25.1"
 walkdir = "2.5.0"
 
+[dev-dependencies]
+tempfile = "3.23.0"
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/cat-launcher/src-tauri/src/infra/repository/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/repository/mod.rs
@@ -5,3 +5,6 @@ pub mod db_helper;
 
 /// Database schema initialization logic.
 pub mod db_schema;
+
+/// SQLite connection pool creation.
+pub mod sqlite_pool;

--- a/cat-launcher/src-tauri/src/infra/repository/sqlite_pool.rs
+++ b/cat-launcher/src-tauri/src/infra/repository/sqlite_pool.rs
@@ -1,0 +1,38 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+
+use crate::infra::repository::db_schema::{
+  InitializeSchemaError, initialize_schema,
+};
+
+pub type SqlitePool = Pool<SqliteConnectionManager>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CreateSqlitePoolError {
+  #[error("failed to create connection pool: {0}")]
+  ConnectionPool(#[from] r2d2::Error),
+
+  #[error("failed to initialize schema: {0}")]
+  Schema(#[from] InitializeSchemaError),
+}
+
+pub fn create_sqlite_pool(
+  db_path: &Path,
+  schema_paths: &[PathBuf],
+) -> Result<SqlitePool, CreateSqlitePoolError> {
+  let manager =
+    SqliteConnectionManager::file(db_path).with_init(|conn| {
+      conn.pragma_update(None, "journal_mode", "WAL")?;
+      conn.pragma_update(None, "foreign_keys", "ON")?;
+      conn.busy_timeout(Duration::from_secs(5))
+    });
+  let pool = Pool::new(manager)?;
+
+  let conn = pool.get()?;
+  initialize_schema(&conn, schema_paths)?;
+
+  Ok(pool)
+}

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -21,7 +21,13 @@ mod theme;
 mod tilesets;
 mod users;
 mod utils;
-mod variants;
+pub mod variants;
+
+pub mod database {
+  pub use crate::infra::repository::sqlite_pool::{
+    SqlitePool, create_sqlite_pool,
+  };
+}
 
 use crate::achievements::commands::get_achievements_for_variant;
 use crate::active_release::commands::get_active_release;

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -1,8 +1,6 @@
 use std::fs;
 use std::io;
-use std::time::Duration;
 
-use r2d2_sqlite::SqliteConnectionManager;
 use tauri::{App, Emitter, Listener, Manager, WindowEvent};
 
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
@@ -14,8 +12,9 @@ use crate::filesystem::utils::{copy_dir_all, CopyDirError};
 use crate::infra::autoupdate::update::run_updater;
 use crate::infra::download::Downloader;
 use crate::infra::http_client::create_http_client;
-use crate::infra::repository::db_schema::initialize_schema;
-use crate::infra::repository::db_schema::InitializeSchemaError;
+use crate::infra::repository::sqlite_pool::{
+  CreateSqlitePoolError, create_sqlite_pool,
+};
 use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::launch_game::repository::sqlite_backup_repository::SqliteBackupRepository;
 use crate::manual_backups::repository::sqlite_manual_backup_repository::SqliteManualBackupRepository;
@@ -66,17 +65,11 @@ pub enum RepositoryError {
   #[error("failed to get system directory: {0}")]
   SystemDir(#[from] tauri::Error),
 
-  #[error("failed to initialize database: {0}")]
-  Database(#[from] rusqlite::Error),
-
-  #[error("failed to initialize schema: {0}")]
-  Schema(#[from] InitializeSchemaError),
-
   #[error("failed to get schema file path: {0}")]
   SchemaFilePath(#[from] GetSchemaFilePathError),
 
-  #[error("failed to create connection pool: {0}")]
-  ConnectionPool(#[from] r2d2::Error),
+  #[error("failed to create database connection pool: {0}")]
+  ConnectionPool(#[from] CreateSqlitePoolError),
 }
 
 pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
@@ -86,16 +79,7 @@ pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
   let resources_dir = app.path().resource_dir()?;
   let schema_path = get_schema_file_path(&resources_dir)?;
 
-  let manager =
-    SqliteConnectionManager::file(&db_path).with_init(|conn| {
-      conn.pragma_update(None, "journal_mode", "WAL")?;
-      conn.pragma_update(None, "foreign_keys", "ON")?;
-      conn.busy_timeout(Duration::from_secs(5))
-    });
-  let pool = r2d2::Pool::new(manager)?;
-
-  let conn = pool.get()?;
-  initialize_schema(&conn, &[schema_path])?;
+  let pool = create_sqlite_pool(&db_path, &[schema_path])?;
 
   app.manage(SqliteReleasesRepository::new(pool.clone()));
   app.manage(SqliteBackupRepository::new(pool.clone()));

--- a/cat-launcher/src-tauri/tests/get_game_variants_info.rs
+++ b/cat-launcher/src-tauri/tests/get_game_variants_info.rs
@@ -1,0 +1,82 @@
+mod support;
+
+use cat_launcher_lib::variants::GameVariant;
+use cat_launcher_lib::variants::get_game_variants_info::get_game_variants_info;
+use cat_launcher_lib::variants::repository::game_variant_order_repository::GameVariantOrderRepository;
+use cat_launcher_lib::variants::repository::sqlite_game_variant_order_repository::SqliteGameVariantOrderRepository;
+
+use support::db::TestDatabase;
+
+#[tokio::test]
+async fn returns_all_variants_in_enum_order_when_no_order_is_saved() {
+  let db = TestDatabase::new();
+  let repository =
+    SqliteGameVariantOrderRepository::new(db.pool.clone());
+
+  let variants = get_game_variants_info(&repository)
+    .await
+    .expect("get variants");
+
+  let ids = variants
+    .iter()
+    .map(|variant| variant.id)
+    .collect::<Vec<_>>();
+  let names = variants
+    .iter()
+    .map(|variant| variant.name.as_str())
+    .collect::<Vec<_>>();
+
+  assert_eq!(
+    ids,
+    vec![
+      GameVariant::DarkDaysAhead,
+      GameVariant::BrightNights,
+      GameVariant::TheLastGeneration,
+    ]
+  );
+  assert_eq!(
+    names,
+    vec!["Dark Days Ahead", "Bright Nights", "The Last Generation"]
+  );
+}
+
+#[tokio::test]
+async fn returns_variants_in_saved_order() {
+  let db = TestDatabase::new();
+  let repository =
+    SqliteGameVariantOrderRepository::new(db.pool.clone());
+  repository
+    .update_order(&[
+      GameVariant::TheLastGeneration,
+      GameVariant::DarkDaysAhead,
+      GameVariant::BrightNights,
+    ])
+    .await
+    .expect("save variant order");
+
+  let variants = get_game_variants_info(&repository)
+    .await
+    .expect("get variants");
+
+  let ids = variants
+    .iter()
+    .map(|variant| variant.id)
+    .collect::<Vec<_>>();
+  let names = variants
+    .iter()
+    .map(|variant| variant.name.as_str())
+    .collect::<Vec<_>>();
+
+  assert_eq!(
+    ids,
+    vec![
+      GameVariant::TheLastGeneration,
+      GameVariant::DarkDaysAhead,
+      GameVariant::BrightNights,
+    ]
+  );
+  assert_eq!(
+    names,
+    vec!["The Last Generation", "Dark Days Ahead", "Bright Nights"]
+  );
+}

--- a/cat-launcher/src-tauri/tests/support/db.rs
+++ b/cat-launcher/src-tauri/tests/support/db.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use cat_launcher_lib::database::{SqlitePool, create_sqlite_pool};
+use tempfile::TempDir;
+
+pub struct TestDatabase {
+  pub pool: SqlitePool,
+  _temp_dir: TempDir,
+}
+
+impl TestDatabase {
+  pub fn new() -> Self {
+    let temp_dir =
+      tempfile::tempdir().expect("create temp database dir");
+    let db_path = temp_dir.path().join("cat-launcher-test.sqlite3");
+    let schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("schemas")
+      .join("schema.sql");
+    let pool = create_sqlite_pool(&db_path, &[schema_path])
+      .expect("create test database pool");
+
+    Self {
+      pool,
+      _temp_dir: temp_dir,
+    }
+  }
+}
+
+impl Default for TestDatabase {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/cat-launcher/src-tauri/tests/support/mod.rs
+++ b/cat-launcher/src-tauri/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod db;


### PR DESCRIPTION
Motivation:
- Establish the first integration test foundation without replacing real code with mocks.

Changes:
- Add a reusable SQLite pool helper shared by application repository setup and tests.
- Add an isolated test database helper for Rust integration tests.
- Add integration tests for get_game_variants_info default and saved ordering behavior.
- Add a package test script for running all current tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first integration tests for `get_game_variants_info` (default and saved ordering) and a shared SQLite pool helper to create isolated test databases.

- **Refactors**
  - Added `infra/repository/sqlite_pool.rs` with `create_sqlite_pool` and `SqlitePool`; applies PRAGMAs and initializes schema.
  - Replaced inline DB pool setup in `manage_repositories` with `create_sqlite_pool`.
  - Exposed `database` and `variants` modules from the crate for tests.

- **Dependencies**
  - Added dev-dependency `tempfile`.

<sup>Written for commit 6e8654f5a814fb0b89a399fb61d2c82812b434f6. Summary will update on new commits. <a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

