### PR TITLE
chore: remove GITHUB_PAT support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-GITHUB_PAT=
-
 TS_RS_EXPORT_DIR=../src/generated-types/
 
 TAURI_SIGNING_PRIVATE_KEY=/home/abhishek/.tauri/cat-launcher/updater.key

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,30 +1,8 @@
-use std::env;
 
 use reqwest::Client;
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
-
-fn create_github_pat_headers() -> Option<HeaderMap> {
-  if let Ok(github_pat) = env::var("GITHUB_PAT")
-    && !github_pat.is_empty()
-  {
-    let authorization = format!("Bearer {}", github_pat);
-    if let Ok(header_value) = HeaderValue::from_str(&authorization) {
-      let mut headers = HeaderMap::new();
-      headers.insert(AUTHORIZATION, header_value);
-      return Some(headers);
-    }
-  }
-  None
-}
 
 /// Creates and returns a `reqwest::Client` instance configured with a user-agent
-/// and authorization headers if `GITHUB_PAT` is available in the environment.
 pub fn create_http_client() -> Client {
-  let mut builder = Client::builder().user_agent("cat-launcher");
-
-  if let Some(headers) = create_github_pat_headers() {
-    builder = builder.default_headers(headers);
-  }
-
+  let builder = Client::builder().user_agent("cat-launcher");
   builder.build().expect("Failed to build reqwest client")
 }


### PR DESCRIPTION
Motivation:
- GITHUB_PAT was used with a general HttpClient, not a specific GitHubClient, which could lead to the PAT leaking to other websites.

Changes:
- Remove GITHUB_PAT from .env.example
- Remove create_github_pat_headers() function from http_client.rs
- Simplify create_http_client() to not use GITHUB_PAT

Generated by Mistral Vibe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `GITHUB_PAT` support from the shared HTTP client to prevent tokens from being sent to non-GitHub hosts. This simplifies the client and avoids accidental credential leakage.

- **Bug Fixes**
  - Remove `GITHUB_PAT` from `.env.example`.
  - Delete token header logic and build a `reqwest::Client` with only a user-agent.

<sup>Written for commit 45febc005c2fa82b828e04be5b537b42976ab973. Summary will update on new commits. <a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/451?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

