### PR TITLE
test(fetch_release_notes): add integration tests with mock GitHub API

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -68,6 +68,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +519,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "walkdir",
+ "wiremock",
  "zip 8.6.0",
 ]
 
@@ -926,6 +937,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,7 +1074,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1262,7 +1291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1959,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2016,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2412,6 +2448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,7 +2656,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2660,6 +2702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3687,7 +3739,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3745,7 +3797,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4172,7 +4224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4747,7 +4799,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5136,7 +5188,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5199,7 +5251,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5678,7 +5730,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6120,6 +6172,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 tempfile = "3.23.0"
+wiremock = "0.6.5"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -51,7 +51,7 @@ pub async fn fetch_releases_for_variant(
 
   variant
     .fetch_releases(
-      &client,
+      &*client,
       &resources_dir,
       &*releases_repository,
       on_releases,
@@ -79,7 +79,7 @@ pub async fn fetch_release_notes(
   client: State<'_, Client>,
 ) -> Result<Option<String>, FetchReleaseNotesCommandError> {
   let notes = variant
-    .fetch_release_notes(&release_id, &client, &*releases_repository)
+    .fetch_release_notes(&release_id, &*client, &*releases_repository)
     .await?;
 
   Ok(notes)

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::path::Path;
 
-use reqwest::Client;
 use serde::Serialize;
 use ts_rs::TS;
 
@@ -16,6 +15,7 @@ use crate::infra::github::utils::{
   FetchGitHubReleaseByTagError, GitHubReleaseFetchError,
   fetch_github_release_by_tag, fetch_github_releases,
 };
+use crate::infra::http_client::HttpClient;
 use crate::infra::utils::{Arch, OS, get_github_repo_for_variant};
 use crate::variants::GameVariant;
 
@@ -59,7 +59,7 @@ pub enum FetchReleaseNotesError {
 impl GameVariant {
   pub async fn fetch_releases<E, F>(
     &self,
-    client: &Client,
+    client: &dyn HttpClient,
     resources_dir: &Path,
     releases_repository: &dyn ReleasesRepository,
     on_releases: F,
@@ -122,7 +122,7 @@ impl GameVariant {
   pub async fn fetch_release_notes(
     &self,
     release_id: &str,
-    client: &Client,
+    client: &dyn HttpClient,
     releases_repository: &dyn ReleasesRepository,
   ) -> Result<Option<String>, FetchReleaseNotesError> {
     let cached_release = releases_repository

--- a/cat-launcher/src-tauri/src/game_release/mod.rs
+++ b/cat-launcher/src-tauri/src/game_release/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod game_release;
 pub mod utils;
 

--- a/cat-launcher/src-tauri/src/infra/endpoint.rs
+++ b/cat-launcher/src-tauri/src/infra/endpoint.rs
@@ -1,0 +1,32 @@
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Endpoint {
+  host: String,
+  port: Option<u16>,
+  scheme: String,
+}
+
+impl Endpoint {
+  pub fn new(
+    host: impl Into<String>,
+    port: Option<u16>,
+    scheme: impl Into<String>,
+  ) -> Self {
+    Self {
+      host: host.into(),
+      port,
+      scheme: scheme.into(),
+    }
+  }
+
+  pub fn host(&self) -> &str {
+    &self.host
+  }
+
+  pub fn port(&self) -> Option<u16> {
+    self.port
+  }
+
+  pub fn scheme(&self) -> &str {
+    &self.scheme
+  }
+}

--- a/cat-launcher/src-tauri/src/infra/github/get_last_commit.rs
+++ b/cat-launcher/src-tauri/src/infra/github/get_last_commit.rs
@@ -1,6 +1,5 @@
-use reqwest::Client;
-
 use crate::infra::github::types::GitHubCommit;
+use crate::infra::http_client::HttpClient;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetLastCommitError {
@@ -19,7 +18,7 @@ pub enum GetLastCommitError {
 
 pub async fn get_last_commit(
   repo: &str,
-  client: &Client,
+  client: &dyn HttpClient,
 ) -> Result<GitHubCommit, GetLastCommitError> {
   let api_url = format!(
     "https://api.github.com/repos/{}/commits?per_page=1",

--- a/cat-launcher/src-tauri/src/infra/github/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/github/utils.rs
@@ -1,10 +1,10 @@
 use std::sync::LazyLock;
 
 use regex::Regex;
-use reqwest::Client;
 use reqwest::header::LINK;
 
 use crate::infra::github::release::GitHubRelease;
+use crate::infra::http_client::HttpClient;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GitHubReleaseFetchError {
@@ -23,7 +23,7 @@ static NEXT_PAGE_URL_RE: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r#"<([^>]+)>; rel="next""#).unwrap());
 
 pub async fn fetch_github_releases(
-  client: &Client,
+  client: &dyn HttpClient,
   repo: &str,
   num_releases: Option<usize>,
 ) -> Result<Vec<GitHubRelease>, GitHubReleaseFetchError> {
@@ -86,7 +86,7 @@ pub enum FetchGitHubReleaseByTagError {
 }
 
 pub async fn fetch_github_release_by_tag(
-  client: &Client,
+  client: &dyn HttpClient,
   repo: &str,
   tag: &str,
 ) -> Result<GitHubRelease, FetchGitHubReleaseByTagError> {

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,5 +1,47 @@
+use reqwest::{Client, Method, RequestBuilder};
 
-use reqwest::Client;
+/// A trait abstracting over HTTP clients. Implemented by `reqwest::Client` in
+/// production and by `RewireClient` in tests. This allows test code to redirect
+/// requests to a mock server without changing production code.
+pub trait HttpClient: Send + Sync {
+  fn get(&self, url: &str) -> RequestBuilder;
+  fn post(&self, url: &str) -> RequestBuilder;
+  fn put(&self, url: &str) -> RequestBuilder;
+  fn patch(&self, url: &str) -> RequestBuilder;
+  fn delete(&self, url: &str) -> RequestBuilder;
+  fn head(&self, url: &str) -> RequestBuilder;
+  fn request(&self, method: Method, url: &str) -> RequestBuilder;
+}
+
+impl HttpClient for Client {
+  fn get(&self, url: &str) -> RequestBuilder {
+    Client::get(self, url)
+  }
+
+  fn post(&self, url: &str) -> RequestBuilder {
+    Client::post(self, url)
+  }
+
+  fn put(&self, url: &str) -> RequestBuilder {
+    Client::put(self, url)
+  }
+
+  fn patch(&self, url: &str) -> RequestBuilder {
+    Client::patch(self, url)
+  }
+
+  fn delete(&self, url: &str) -> RequestBuilder {
+    Client::delete(self, url)
+  }
+
+  fn head(&self, url: &str) -> RequestBuilder {
+    Client::head(self, url)
+  }
+
+  fn request(&self, method: Method, url: &str) -> RequestBuilder {
+    Client::request(self, method, url)
+  }
+}
 
 /// Creates and returns a `reqwest::Client` instance configured with a user-agent
 pub fn create_http_client() -> Client {

--- a/cat-launcher/src-tauri/src/infra/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/mod.rs
@@ -1,6 +1,7 @@
 pub mod archive;
 pub mod autoupdate;
 pub mod download;
+pub mod endpoint;
 pub mod github;
 pub mod http_client;
 pub mod installation_progress_monitor;

--- a/cat-launcher/src-tauri/src/lib.rs
+++ b/cat-launcher/src-tauri/src/lib.rs
@@ -5,10 +5,12 @@ pub mod settings;
 mod achievements;
 pub mod active_release;
 mod backups;
-mod fetch_releases;
-mod game_release;
-mod game_tips;
-mod infra;
+#[allow(clippy::module_inception)]
+pub mod fetch_releases;
+#[allow(clippy::module_inception)]
+pub mod game_release;
+pub mod game_tips;
+pub mod infra;
 mod install_release;
 mod last_played_world;
 mod launch_game;

--- a/cat-launcher/src-tauri/tests/fetch_release_notes.rs
+++ b/cat-launcher/src-tauri/tests/fetch_release_notes.rs
@@ -1,0 +1,235 @@
+mod support;
+
+use cat_launcher_lib::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
+use cat_launcher_lib::fetch_releases::repository::ReleasesRepository;
+use cat_launcher_lib::infra::github::release::GitHubRelease;
+use cat_launcher_lib::variants::GameVariant;
+use chrono::Utc;
+use support::db::TestDatabase;
+use support::mock_github::{MockGitHubApi, github_not_found_response, github_release_response};
+
+#[tokio::test]
+async fn returns_cached_body_when_available() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let cached_release = GitHubRelease {
+    id: 12345,
+    tag_name: "v1.0.0".to_string(),
+    prerelease: false,
+    body: Some("Cached release notes".to_string()),
+    assets: vec![],
+    created_at: Utc::now(),
+  };
+  repo
+    .update_cached_releases(
+      &GameVariant::DarkDaysAhead,
+      &[cached_release],
+    )
+    .await
+    .expect("cache release");
+
+  let mock_api = MockGitHubApi::start().await;
+  let client = mock_api.create_rewire_client();
+
+  let result = GameVariant::DarkDaysAhead
+    .fetch_release_notes("v1.0.0", &client, &repo)
+    .await
+    .expect("fetch release notes");
+
+  assert_eq!(result, Some("Cached release notes".to_string()));
+}
+
+#[tokio::test]
+async fn fetches_from_github_when_not_in_cache() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let mock_api = MockGitHubApi::start().await;
+  let response = github_release_response(
+    12345,
+    "v2.0.0",
+    Some("Fresh release notes from GitHub"),
+    false,
+  );
+  let mock = mock_api.mock_release_by_tag(
+    "CleverRaven/Cataclysm-DDA",
+    "v2.0.0",
+    response,
+  );
+  mock_api.register(mock).await;
+
+  let client = mock_api.create_rewire_client();
+
+  let result = GameVariant::DarkDaysAhead
+    .fetch_release_notes("v2.0.0", &client, &repo)
+    .await
+    .expect("fetch release notes");
+
+  assert_eq!(
+    result,
+    Some("Fresh release notes from GitHub".to_string())
+  );
+}
+
+#[tokio::test]
+async fn fetches_from_github_when_cached_but_body_is_none() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let cached_release = GitHubRelease {
+    id: 12345,
+    tag_name: "v3.0.0".to_string(),
+    prerelease: false,
+    body: None,
+    assets: vec![],
+    created_at: Utc::now(),
+  };
+  repo
+    .update_cached_releases(
+      &GameVariant::DarkDaysAhead,
+      &[cached_release],
+    )
+    .await
+    .expect("cache release");
+
+  let mock_api = MockGitHubApi::start().await;
+  let response = github_release_response(
+    12345,
+    "v3.0.0",
+    Some("Body was missing, fetched from GitHub"),
+    false,
+  );
+  let mock = mock_api.mock_release_by_tag(
+    "CleverRaven/Cataclysm-DDA",
+    "v3.0.0",
+    response,
+  );
+  mock_api.register(mock).await;
+
+  let client = mock_api.create_rewire_client();
+
+  let result = GameVariant::DarkDaysAhead
+    .fetch_release_notes("v3.0.0", &client, &repo)
+    .await
+    .expect("fetch release notes");
+
+  assert_eq!(
+    result,
+    Some("Body was missing, fetched from GitHub".to_string())
+  );
+}
+
+#[tokio::test]
+async fn updates_cache_after_fetching_from_github() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let mock_api = MockGitHubApi::start().await;
+  let response = github_release_response(
+    99999,
+    "v4.0.0",
+    Some("Release notes to be cached"),
+    false,
+  );
+  let mock = mock_api.mock_release_by_tag(
+    "CleverRaven/Cataclysm-DDA",
+    "v4.0.0",
+    response,
+  );
+  mock_api.register(mock).await;
+
+  let client = mock_api.create_rewire_client();
+
+  let _ = GameVariant::DarkDaysAhead
+    .fetch_release_notes("v4.0.0", &client, &repo)
+    .await
+    .expect("fetch release notes");
+
+  let cached: Option<GitHubRelease> = repo
+    .get_cached_release_by_tag(&GameVariant::DarkDaysAhead, "v4.0.0")
+    .await
+    .expect("get cached release");
+
+  assert!(cached.is_some());
+  let cached = cached.unwrap();
+  assert_eq!(cached.tag_name, "v4.0.0");
+  assert_eq!(
+    cached.body,
+    Some("Release notes to be cached".to_string())
+  );
+}
+
+#[tokio::test]
+async fn returns_error_when_github_returns_404() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let mock_api = MockGitHubApi::start().await;
+  let mock = mock_api.mock_release_by_tag(
+    "CleverRaven/Cataclysm-DDA",
+    "nonexistent-tag",
+    github_not_found_response(),
+  );
+  mock_api.register(mock).await;
+
+  let client = mock_api.create_rewire_client();
+
+  let result = GameVariant::DarkDaysAhead
+    .fetch_release_notes("nonexistent-tag", &client, &repo)
+    .await;
+
+  assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn works_with_different_game_variants() {
+  let db = TestDatabase::new();
+  let repo = SqliteReleasesRepository::new(db.pool.clone());
+
+  let mock_api = MockGitHubApi::start().await;
+
+  let bn_response = github_release_response(
+    111,
+    "bn-v1.0",
+    Some("Bright Nights notes"),
+    false,
+  );
+  let bn_mock = mock_api.mock_release_by_tag(
+    "cataclysmbnteam/Cataclysm-BN",
+    "bn-v1.0",
+    bn_response,
+  );
+  mock_api.register(bn_mock).await;
+
+  let tlg_response = github_release_response(
+    222,
+    "tlg-v1.0",
+    Some("The Last Generation notes"),
+    false,
+  );
+  let tlg_mock = mock_api.mock_release_by_tag(
+    "Cataclysm-TLG/Cataclysm-TLG",
+    "tlg-v1.0",
+    tlg_response,
+  );
+  mock_api.register(tlg_mock).await;
+
+  let client = mock_api.create_rewire_client();
+
+  let bn_result = GameVariant::BrightNights
+    .fetch_release_notes("bn-v1.0", &client, &repo)
+    .await
+    .expect("fetch BN release notes");
+
+  let tlg_result = GameVariant::TheLastGeneration
+    .fetch_release_notes("tlg-v1.0", &client, &repo)
+    .await
+    .expect("fetch TLG release notes");
+
+  assert_eq!(bn_result, Some("Bright Nights notes".to_string()));
+  assert_eq!(
+    tlg_result,
+    Some("The Last Generation notes".to_string())
+  );
+}

--- a/cat-launcher/src-tauri/tests/support/mock_github.rs
+++ b/cat-launcher/src-tauri/tests/support/mock_github.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cat_launcher_lib::infra::endpoint::Endpoint;
+
+use super::rewire_client::RewireClient;
+
+/// A mock GitHub API server built on wiremock. Provides helpers for setting up
+/// common GitHub API response patterns and creating a `RewireClient` that
+/// redirects `https://api.github.com` requests to this mock server.
+pub struct MockGitHubApi {
+  server: MockServer,
+}
+
+impl MockGitHubApi {
+  pub async fn start() -> Self {
+    Self {
+      server: MockServer::start().await,
+    }
+  }
+
+  pub fn uri(&self) -> String {
+    self.server.uri()
+  }
+
+  /// Creates a `RewireClient` that redirects all `https://api.github.com`
+  /// requests to this mock server.
+  pub fn create_rewire_client(&self) -> RewireClient {
+    let mut redirects = HashMap::new();
+    let mock_uri = self.uri();
+    let mock_url = url::Url::parse(&mock_uri).unwrap();
+    let mock_host = mock_url.host_str().unwrap().to_string();
+    let mock_port = mock_url.port();
+    redirects.insert(
+      Endpoint::new("api.github.com", None, "https"),
+      Endpoint::new(mock_host, mock_port, "http"),
+    );
+    RewireClient::new(redirects)
+  }
+
+  /// Mock the `GET /repos/{owner}/{repo}/releases/tags/{tag}` endpoint.
+  pub fn mock_release_by_tag(
+    &self,
+    owner_repo: &str,
+    tag: &str,
+    response: ResponseTemplate,
+  ) -> Mock {
+    let path_str = format!("/repos/{owner_repo}/releases/tags/{tag}");
+    Mock::given(method("GET"))
+      .and(path_matcher(path_str))
+      .respond_with(response)
+  }
+
+  /// Mock the `GET /repos/{owner}/{repo}/releases` endpoint.
+  pub fn mock_releases_list(
+    &self,
+    owner_repo: &str,
+    response: ResponseTemplate,
+  ) -> Mock {
+    let path_str = format!("/repos/{owner_repo}/releases");
+    Mock::given(method("GET"))
+      .and(path_matcher(path_str))
+      .respond_with(response)
+  }
+
+  /// Register a mock on the server.
+  pub async fn register(&self, mock: Mock) {
+    self.server.register(mock).await;
+  }
+}
+
+/// Helper to create a standard GitHub release JSON response.
+pub fn github_release_response(
+  id: u64,
+  tag_name: &str,
+  body: Option<&str>,
+  prerelease: bool,
+) -> ResponseTemplate {
+  let json = serde_json::json!({
+    "id": id,
+    "tag_name": tag_name,
+    "name": format!("Release {tag_name}"),
+    "prerelease": prerelease,
+    "body": body,
+    "created_at": "2024-01-01T00:00:00Z",
+    "assets": [],
+  });
+  ResponseTemplate::new(200).set_body_json(&json)
+}
+
+/// Helper to create a GitHub 404 response.
+pub fn github_not_found_response() -> ResponseTemplate {
+  ResponseTemplate::new(404)
+    .set_body_json(&serde_json::json!({ "message": "Not Found" }))
+}

--- a/cat-launcher/src-tauri/tests/support/mod.rs
+++ b/cat-launcher/src-tauri/tests/support/mod.rs
@@ -1,1 +1,3 @@
 pub mod db;
+pub mod mock_github;
+pub mod rewire_client;

--- a/cat-launcher/src-tauri/tests/support/rewire_client.rs
+++ b/cat-launcher/src-tauri/tests/support/rewire_client.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use reqwest::{Client, Method, RequestBuilder};
+use url::Url;
+
+use cat_launcher_lib::infra::endpoint::Endpoint;
+use cat_launcher_lib::infra::http_client::{
+  HttpClient, create_http_client,
+};
+
+/// An HTTP client that rewrites outgoing request URLs by replacing the
+/// hostname according to domain redirect rules (e.g. github.com -> mock.github.com).
+pub struct RewireClient {
+  inner: Client,
+  redirects: HashMap<Endpoint, Endpoint>,
+}
+
+impl RewireClient {
+  pub fn new(redirects: HashMap<Endpoint, Endpoint>) -> Self {
+    Self {
+      inner: create_http_client(),
+      redirects,
+    }
+  }
+
+  pub fn from_reqwest_client(
+    client: Client,
+    redirects: HashMap<Endpoint, Endpoint>,
+  ) -> Self {
+    Self {
+      inner: client,
+      redirects,
+    }
+  }
+
+  fn rewrite_url(&self, url: &str) -> String {
+    let mut parsed =
+      Url::parse(url).expect("rewire_client: failed to parse URL");
+
+    let key = Endpoint::new(
+      parsed.host_str().expect("rewire_client: URL has no host"),
+      parsed.port(),
+      parsed.scheme().to_string(),
+    );
+
+    let target = self.redirects.get(&key).unwrap_or_else(|| {
+      panic!("no redirect entry for host: {}", key.host())
+    });
+    parsed
+      .set_host(Some(target.host()))
+      .expect("rewire_client: failed to set host");
+
+    if let Some(port) = target.port() {
+      parsed
+        .set_port(Some(port))
+        .expect("rewire_client: failed to set port");
+    }
+
+    parsed
+      .set_scheme(target.scheme())
+      .expect("rewire_client: failed to set scheme");
+
+    parsed.to_string()
+  }
+}
+
+impl HttpClient for RewireClient {
+  fn get(&self, url: &str) -> RequestBuilder {
+    self.inner.get(self.rewrite_url(url))
+  }
+
+  fn post(&self, url: &str) -> RequestBuilder {
+    self.inner.post(self.rewrite_url(url))
+  }
+
+  fn put(&self, url: &str) -> RequestBuilder {
+    self.inner.put(self.rewrite_url(url))
+  }
+
+  fn patch(&self, url: &str) -> RequestBuilder {
+    self.inner.patch(self.rewrite_url(url))
+  }
+
+  fn delete(&self, url: &str) -> RequestBuilder {
+    self.inner.delete(self.rewrite_url(url))
+  }
+
+  fn head(&self, url: &str) -> RequestBuilder {
+    self.inner.head(self.rewrite_url(url))
+  }
+
+  fn request(&self, method: Method, url: &str) -> RequestBuilder {
+    self.inner.request(method, self.rewrite_url(url))
+  }
+}


### PR DESCRIPTION
Motivation:
- Enable testing of Tauri commands that interact with GitHub without making real network requests.
- Provide reusable mock infrastructure for future integration tests.

Changes:
- Add HttpClient trait in src/infra/http_client.rs to abstract over reqwest::Client, enabling test doubles.
- Update fetch_releases, fetch_release_notes, fetch_github_releases, fetch_github_release_by_tag, and get_last_commit to accept &dyn HttpClient instead of &Client.
- Add RewireClient in tests/support/rewire_client.rs that implements HttpClient and transparently rewrites URLs to redirect api.github.com requests to a mock server.
- Add MockGitHubApi in tests/support/mock_github.rs providing wiremock-based helpers for GitHub API endpoints and response templates.
- Add 6 integration tests for fetch_release_notes covering cached body retrieval, fetching from mock GitHub, cache updates after fetch, 404 error handling, and multiple game variants.
- Add wiremock dev dependency.
- Make fetch_releases, game_release, game_tips, and infra modules public for integration test access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds integration tests for `fetch_release_notes` using a mock GitHub API. Tests cover cache hits, fetching by tag, cache updates, 404s, and multiple variants.

- **Refactors**
  - Introduced `HttpClient` (implemented for `reqwest::Client`) and updated GitHub/release code to accept `&dyn HttpClient`.
  - Added test utilities: `RewireClient` (rewrites `api.github.com` URLs via new `Endpoint`) and `MockGitHubApi` (helpers built on `wiremock`).
  - Added `infra::endpoint::Endpoint` and exposed `fetch_releases`, `game_release`, `game_tips`, and `infra` for test access.

- **Dependencies**
  - Added dev dependency `wiremock@0.6.5`.

<sup>Written for commit 003a09215836984b6c981cceadd813e959e903de. Summary will update on new commits. <a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

