### PR TITLE
chore(coverage): add llvm-cov support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+cov-term = "llvm-cov --workspace"
+cov-lcov = "llvm-cov --lcov --output-path lcov.info --workspace"
+cov-html = "llvm-cov --html --output-dir coverage-html --workspace"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ cat-launcher/src/generated-types/*
 target/rust-analyzer/flycheck0/stderr
 target/rust-analyzer/flycheck0/stdout
 target/rust-analyzer/**
+
+# Coverage artifacts
+lcov.info
+coverage-html

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        llvm = pkgs.llvmPackages.llvm;
 
         tauriDependencies = with pkgs; [
           pkg-config
@@ -23,13 +24,20 @@
             packages = with pkgs; [
               cargo
               cargo-edit
+              cargo-llvm-cov
               clippy
+              llvm
               nodejs
               pnpm
               rustc
               rustfmt
               uv
             ] ++ tauriDependencies;
+
+            shellHook = ''
+              export LLVM_COV="${llvm}/bin/llvm-cov"
+              export LLVM_PROFDATA="${llvm}/bin/llvm-profdata"
+            '';
           };
         };
       }


### PR DESCRIPTION
Motivation:
- To enable code coverage reporting for the Rust codebase.

Changes:
- Add .cargo/config.toml with coverage aliases (cov-term, cov-lcov, cov-html)
- Add llvm-cov and cargo-llvm-cov to flake.nix dependencies
- Add shellHook to set LLVM_COV and LLVM_PROFDATA environment variables

Generated by Mistral Vibe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LLVM-based code coverage for the Rust workspace with `cargo-llvm-cov` and simple cargo aliases. You can now generate terminal, LCOV, and HTML reports from the Nix dev shell, and coverage artifacts are ignored by Git.

- **New Features**
  - Added `.cargo/config.toml` aliases: `cov-term`, `cov-lcov` (writes `lcov.info`), `cov-html` (writes to `coverage-html/`).
  - Updated `flake.nix` to include `llvm` and `cargo-llvm-cov`, and export `LLVM_COV` and `LLVM_PROFDATA` via `shellHook`.
  - Updated `.gitignore` to exclude `lcov.info` and `coverage-html/`.

<sup>Written for commit be15c61abad68f2f782bd8d2363fd5cc1fec48b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

