### PR TITLE
test(variants): add tests for get_game_variants_info

### DIFF
--- a/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
+++ b/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
@@ -52,3 +52,109 @@ pub async fn get_game_variants_info(
     .collect();
   Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+  use std::error::Error;
+
+  use strum::IntoEnumIterator;
+
+  use crate::infra::testing::test_database::TestDatabase;
+  use crate::variants::repository::game_variant_order_repository::GameVariantOrderRepository;
+  use crate::variants::repository::sqlite_game_variant_order_repository::SqliteGameVariantOrderRepository;
+  use crate::variants::GameVariant;
+
+  use super::get_game_variants_info;
+
+  #[tokio::test]
+  async fn returns_variants_in_default_enum_order_when_order_table_is_empty()
+  -> Result<(), Box<dyn Error + Send + Sync>> {
+    let repository = repository(&TestDatabase::builder().build()?);
+
+    let infos = get_game_variants_info(&repository).await?;
+
+    assert_infos_eq(infos, GameVariant::iter().collect::<Vec<_>>());
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn returns_variants_in_persisted_order_when_table_is_full()
+  -> Result<(), Box<dyn Error + Send + Sync>> {
+    let db = TestDatabase::builder().build()?;
+    let repository = repository(&db);
+
+    repository
+      .update_order(&[
+        GameVariant::BrightNights,
+        GameVariant::TheLastGeneration,
+        GameVariant::DarkDaysAhead,
+      ])
+      .await?;
+
+    let infos = get_game_variants_info(&repository).await?;
+
+    assert_infos_eq(
+      infos,
+      vec![
+        GameVariant::BrightNights,
+        GameVariant::TheLastGeneration,
+        GameVariant::DarkDaysAhead,
+      ],
+    );
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn returns_all_variants_when_order_table_is_partially_populated()
+  -> Result<(), Box<dyn Error + Send + Sync>> {
+    let db = TestDatabase::builder().build()?;
+    let repository = repository(&db);
+
+    repository
+      .update_order(&[
+        GameVariant::TheLastGeneration,
+        GameVariant::DarkDaysAhead,
+      ])
+      .await?;
+
+    let infos = get_game_variants_info(&repository).await?;
+
+    assert_infos_eq(
+      infos,
+      vec![
+        GameVariant::TheLastGeneration,
+        GameVariant::DarkDaysAhead,
+        GameVariant::BrightNights,
+      ],
+    );
+
+    Ok(())
+  }
+
+  fn assert_infos_eq(
+    actual: Vec<super::GameVariantInfo>,
+    expected_variants: Vec<GameVariant>,
+  ) {
+    let actual_variants =
+      actual.iter().map(|info| info.id).collect::<Vec<_>>();
+    assert_eq!(actual_variants, expected_variants);
+
+    let actual_names = actual
+      .iter()
+      .map(|info| info.name.as_str())
+      .collect::<Vec<_>>();
+    let expected_names = expected_variants
+      .iter()
+      .map(GameVariant::name)
+      .collect::<Vec<_>>();
+    assert_eq!(actual_names, expected_names);
+  }
+
+  fn repository(
+    db: &TestDatabase,
+  ) -> SqliteGameVariantOrderRepository {
+    SqliteGameVariantOrderRepository::new(db.pool().clone())
+  }
+}


### PR DESCRIPTION
Motivation:
- To ensure the get_game_variants_info function correctly returns variants in the persisted order.

Changes:
- Add three test cases: default enum order when table is empty, persisted order when table is full, and all variants when table is partially populated.
- Add helper functions: assert_infos_eq and repository.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three unit tests for `get_game_variants_info` to confirm ordering and names: default enum order when the table is empty, persisted order when it's full, and all variants included when it's partially populated. Add small helpers `assert_infos_eq` and `repository`.

<sup>Written for commit 9061bc4d89d0a454eb2264fd7180b27ddbb7fdf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

