### PR TITLE
fix(variants): return all variants when order table is partially popu…

### DIFF
--- a/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
+++ b/cat-launcher/src-tauri/src/variants/get_game_variants_info.rs
@@ -43,7 +43,21 @@ pub async fn get_game_variants_info(
   let variants_to_display = if ordered_variants.is_empty() {
     GameVariant::iter().collect::<Vec<_>>()
   } else {
-    ordered_variants
+    // When the order table is partially populated, return ordered variants first
+    // followed by unordered variants in default enum order
+    let all_variants: Vec<GameVariant> =
+      GameVariant::iter().collect();
+    let ordered_set: std::collections::HashSet<_> =
+      ordered_variants.iter().collect();
+    let mut unordered_variants: Vec<GameVariant> = all_variants
+      .into_iter()
+      .filter(|v| !ordered_set.contains(v))
+      .collect();
+
+    // Maintain order: ordered variants first, then unordered in default order
+    let mut result = ordered_variants;
+    result.append(&mut unordered_variants);
+    result
   };
 
   let result = variants_to_display


### PR DESCRIPTION
…lated

Motivation:
- When the game variant order table was partially populated, the function was only returning the ordered variants instead of all variants.

Changes:
- Modified get_game_variants_info to return ordered variants first, followed by unordered variants in default enum order.
- Removed unused rusqlite::params import from tests.

Generated by Mistral Vibe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return all game variants from `get_game_variants_info` when the order table is partially populated. Ordered variants come first, followed by the rest in default enum order.

- **Bug Fixes**
  - Combine ordered variants with remaining enum variants while preserving default order for unordered entries.

- **Refactors**
  - Removed unused `rusqlite::params` import from tests.

<sup>Written for commit ac4758abb5781c02f6d2832cd6a7a204de3e0c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

