### PR TITLE
test(infra): add URI-remapping test HTTP client

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -53,6 +53,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +315,58 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -484,6 +586,7 @@ dependencies = [
  "dmg",
  "downloader",
  "flate2",
+ "github-mock-api",
  "posthog-rs",
  "r2d2",
  "r2d2_sqlite",
@@ -608,6 +711,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +764,12 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1697,6 +1846,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "github-mock-api"
+version = "0.1.0"
+source = "git+https://github.com/abhi-kr-2100/github-mock-api.git?rev=51e75363e2479edd426590c2fd10d2347d83dbe4#51e75363e2479edd426590c2fd10d2347d83dbe4"
+dependencies = [
+ "axum",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2151,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2254,6 +2425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2835,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2897,6 +3095,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -3773,6 +3977,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,6 +4185,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4222,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4107,6 +4340,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4810,6 +5052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,6 +5300,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5092,6 +5344,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5115,6 +5368,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5334,6 +5613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5345,6 +5630,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/cat-launcher/src-tauri/Cargo.toml
+++ b/cat-launcher/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 tempfile = "3.23.0"
+github-mock-api = { git = "https://github.com/abhi-kr-2100/github-mock-api.git", rev = "51e75363e2479edd426590c2fd10d2347d83dbe4" }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/cat-launcher/src-tauri/src/fetch_releases/commands.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/commands.rs
@@ -1,6 +1,6 @@
 use std::env::consts::{ARCH, OS};
+use std::sync::Arc;
 
-use reqwest::Client;
 use strum::IntoStaticStr;
 use tauri::{AppHandle, Emitter, Manager, State, command};
 
@@ -10,6 +10,7 @@ use crate::fetch_releases::fetch_releases::{
   FetchReleaseNotesError, FetchReleasesError, ReleasesUpdatePayload,
 };
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
+use crate::infra::http_client::HttpClient;
 use crate::infra::utils::{
   ArchNotSupportedError, OSNotSupportedError, get_arch_enum,
   get_os_enum,
@@ -38,7 +39,7 @@ pub async fn fetch_releases_for_variant(
   app_handle: AppHandle,
   variant: GameVariant,
   releases_repository: State<'_, SqliteReleasesRepository>,
-  client: State<'_, Client>,
+  client: State<'_, Arc<dyn HttpClient>>,
 ) -> Result<(), FetchReleasesCommandError> {
   let resources_dir = app_handle.path().resource_dir()?;
   let os = get_os_enum(OS)?;
@@ -51,7 +52,7 @@ pub async fn fetch_releases_for_variant(
 
   variant
     .fetch_releases(
-      &client,
+      client.inner().as_ref(),
       &resources_dir,
       &*releases_repository,
       on_releases,
@@ -76,10 +77,14 @@ pub async fn fetch_release_notes(
   variant: GameVariant,
   release_id: String,
   releases_repository: State<'_, SqliteReleasesRepository>,
-  client: State<'_, Client>,
+  client: State<'_, Arc<dyn HttpClient>>,
 ) -> Result<Option<String>, FetchReleaseNotesCommandError> {
   let notes = variant
-    .fetch_release_notes(&release_id, &client, &*releases_repository)
+    .fetch_release_notes(
+      &release_id,
+      client.inner().as_ref(),
+      &*releases_repository,
+    )
     .await?;
 
   Ok(notes)

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::path::Path;
 
-use reqwest::Client;
 use serde::Serialize;
 use ts_rs::TS;
 
@@ -16,6 +15,7 @@ use crate::infra::github::utils::{
   FetchGitHubReleaseByTagError, GitHubReleaseFetchError,
   fetch_github_release_by_tag, fetch_github_releases,
 };
+use crate::infra::http_client::HttpClient;
 use crate::infra::utils::{Arch, OS, get_github_repo_for_variant};
 use crate::variants::GameVariant;
 
@@ -59,7 +59,7 @@ pub enum FetchReleaseNotesError {
 impl GameVariant {
   pub async fn fetch_releases<E, F>(
     &self,
-    client: &Client,
+    client: &dyn HttpClient,
     resources_dir: &Path,
     releases_repository: &dyn ReleasesRepository,
     on_releases: F,
@@ -122,7 +122,7 @@ impl GameVariant {
   pub async fn fetch_release_notes(
     &self,
     release_id: &str,
-    client: &Client,
+    client: &dyn HttpClient,
     releases_repository: &dyn ReleasesRepository,
   ) -> Result<Option<String>, FetchReleaseNotesError> {
     let cached_release = releases_repository

--- a/cat-launcher/src-tauri/src/infra/github/get_last_commit.rs
+++ b/cat-launcher/src-tauri/src/infra/github/get_last_commit.rs
@@ -1,11 +1,10 @@
-use reqwest::Client;
-
 use crate::infra::github::types::GitHubCommit;
+use crate::infra::http_client::{HttpClient, HttpClientError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetLastCommitError {
   #[error("failed to make API call: {0}")]
-  FetchGithub(#[from] reqwest::Error),
+  FetchGithub(#[from] HttpClientError),
 
   #[error("invalid GitHub response: {0}")]
   InvalidResponse(String),
@@ -19,14 +18,14 @@ pub enum GetLastCommitError {
 
 pub async fn get_last_commit(
   repo: &str,
-  client: &Client,
+  client: &dyn HttpClient,
 ) -> Result<GitHubCommit, GetLastCommitError> {
   let api_url = format!(
     "https://api.github.com/repos/{}/commits?per_page=1",
     repo
   );
 
-  let response = client.get(&api_url).send().await?;
+  let response = client.get(&api_url).await?;
 
   if !response.status().is_success() {
     return Err(GetLastCommitError::InvalidResponse(format!(
@@ -35,7 +34,8 @@ pub async fn get_last_commit(
     )));
   }
 
-  let commits: Vec<GitHubCommit> = response.json().await?;
+  let commits: Vec<GitHubCommit> =
+    response.json().await.map_err(HttpClientError::from)?;
 
   let commit = commits
     .into_iter()

--- a/cat-launcher/src-tauri/src/infra/github/utils.rs
+++ b/cat-launcher/src-tauri/src/infra/github/utils.rs
@@ -1,15 +1,15 @@
 use std::sync::LazyLock;
 
 use regex::Regex;
-use reqwest::Client;
 use reqwest::header::LINK;
 
 use crate::infra::github::release::GitHubRelease;
+use crate::infra::http_client::{HttpClient, HttpClientError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum GitHubReleaseFetchError {
   #[error("failed to fetch from GitHub: {0}")]
-  Fetch(#[from] reqwest::Error),
+  Fetch(#[from] HttpClientError),
 
   #[error("failed to parse GitHub response: {0}")]
   Parse(#[from] serde_json::Error),
@@ -23,7 +23,7 @@ static NEXT_PAGE_URL_RE: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r#"<([^>]+)>; rel="next""#).unwrap());
 
 pub async fn fetch_github_releases(
-  client: &Client,
+  client: &dyn HttpClient,
   repo: &str,
   num_releases: Option<usize>,
 ) -> Result<Vec<GitHubRelease>, GitHubReleaseFetchError> {
@@ -48,8 +48,10 @@ pub async fn fetch_github_releases(
       break;
     }
 
-    let response = client.get(&url).send().await?;
-    response.error_for_status_ref()?;
+    let response = client.get(&url).await?;
+    response
+      .error_for_status_ref()
+      .map_err(HttpClientError::from)?;
 
     let link_header = response
       .headers()
@@ -62,7 +64,8 @@ pub async fn fetch_github_releases(
         .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
     });
 
-    let response_text = response.text().await?;
+    let response_text =
+      response.text().await.map_err(HttpClientError::from)?;
     match serde_json::from_str::<Vec<GitHubRelease>>(&response_text) {
       Ok(releases) => {
         all_releases.extend(releases);
@@ -79,14 +82,14 @@ pub async fn fetch_github_releases(
 #[derive(thiserror::Error, Debug)]
 pub enum FetchGitHubReleaseByTagError {
   #[error("failed to fetch from GitHub: {0}")]
-  Fetch(#[from] reqwest::Error),
+  Fetch(#[from] HttpClientError),
 
   #[error("failed to parse GitHub response: {0}")]
   Parse(#[from] serde_json::Error),
 }
 
 pub async fn fetch_github_release_by_tag(
-  client: &Client,
+  client: &dyn HttpClient,
   repo: &str,
   tag: &str,
 ) -> Result<GitHubRelease, FetchGitHubReleaseByTagError> {
@@ -96,9 +99,12 @@ pub async fn fetch_github_release_by_tag(
     urlencoding::encode(tag)
   );
 
-  let response = client.get(&url).send().await?;
-  response.error_for_status_ref()?;
+  let response = client.get(&url).await?;
+  response
+    .error_for_status_ref()
+    .map_err(HttpClientError::from)?;
 
-  let response_text = response.text().await?;
+  let response_text =
+    response.text().await.map_err(HttpClientError::from)?;
   Ok(serde_json::from_str::<GitHubRelease>(&response_text)?)
 }

--- a/cat-launcher/src-tauri/src/infra/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/http_client.rs
@@ -1,4 +1,36 @@
-use reqwest::Client;
+use async_trait::async_trait;
+use reqwest::{Client, Response};
+
+#[derive(Debug, thiserror::Error)]
+pub enum HttpClientError {
+  #[error(transparent)]
+  Http(#[from] reqwest::Error),
+
+  #[error("invalid URL: {0}")]
+  InvalidUrl(#[from] url::ParseError),
+
+  #[error("no host mapping found for: {0}")]
+  NoMapping(String),
+
+  #[error("failed to set URL component")]
+  UrlComponentError,
+}
+
+#[async_trait]
+pub trait HttpClient: Send + Sync {
+  async fn get(&self, url: &str)
+  -> Result<Response, HttpClientError>;
+}
+
+#[async_trait]
+impl HttpClient for Client {
+  async fn get(
+    &self,
+    url: &str,
+  ) -> Result<Response, HttpClientError> {
+    self.get(url).send().await.map_err(HttpClientError::from)
+  }
+}
 
 /// Creates and returns a `reqwest::Client` instance configured with a user-agent
 pub fn create_http_client() -> Client {

--- a/cat-launcher/src-tauri/src/infra/testing/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/testing/http_client.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use reqwest::{Client, Response};
+use url::Url;
+
+use crate::infra::http_client::{
+  create_http_client, HttpClient, HttpClientError,
+};
+
+/// A test HTTP client that can rewrite URLs based on host mappings.
+pub struct TestHttpClient {
+  client: Client,
+  host_mappings: HashMap<String, String>,
+}
+
+impl TestHttpClient {
+  /// Creates a new `TestHttpClient` with the given host mappings.
+  pub fn new(host_mappings: HashMap<String, String>) -> Self {
+    Self {
+      client: create_http_client(),
+      host_mappings,
+    }
+  }
+
+  fn rewrite_url(
+    &self,
+    url_str: &str,
+  ) -> Result<String, HttpClientError> {
+    let mut url =
+      Url::parse(url_str).map_err(HttpClientError::from)?;
+
+    let host = url.host_str().ok_or_else(|| {
+      HttpClientError::NoMapping(url_str.to_string())
+    })?;
+    let mapped_host = self
+      .host_mappings
+      .get(host)
+      .ok_or_else(|| HttpClientError::NoMapping(host.to_string()))?;
+
+    // mapped_host can be "localhost:8080"
+    let mapped_url = Url::parse(&format!("http://{}", mapped_host))
+      .map_err(HttpClientError::from)?;
+
+    url.set_host(mapped_url.host_str())
+      .map_err(|_| HttpClientError::UrlComponentError)?;
+    url.set_port(mapped_url.port())
+      .map_err(|_| HttpClientError::UrlComponentError)?;
+    url.set_scheme("http")
+      .map_err(|_| HttpClientError::UrlComponentError)?;
+
+    Ok(url.to_string())
+  }
+}
+
+#[async_trait]
+impl HttpClient for TestHttpClient {
+  async fn get(
+    &self,
+    url: &str,
+  ) -> Result<Response, HttpClientError> {
+    let rewritten_url = self.rewrite_url(url)?;
+    self
+      .client
+      .get(&rewritten_url)
+      .send()
+      .await
+      .map_err(HttpClientError::from)
+  }
+}

--- a/cat-launcher/src-tauri/src/infra/testing/mod.rs
+++ b/cat-launcher/src-tauri/src/infra/testing/mod.rs
@@ -1,1 +1,2 @@
+pub mod http_client;
 pub mod test_database;

--- a/cat-launcher/src-tauri/src/mods/commands.rs
+++ b/cat-launcher/src-tauri/src/mods/commands.rs
@@ -1,7 +1,6 @@
 use std::env::consts::OS;
 use std::sync::Arc;
 
-use reqwest::Client;
 use strum::IntoStaticStr;
 use tauri::ipc::Channel;
 use tauri::{Emitter, Manager, State};
@@ -10,6 +9,7 @@ use cat_macros::CommandErrorSerialize;
 
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 use crate::infra::download::Downloader;
+use crate::infra::http_client::HttpClient;
 use crate::infra::installation_progress_monitor::channel_reporter::ChannelReporter;
 use crate::infra::utils::{get_os_enum, OSNotSupportedError};
 use crate::mods::get_last_activity_for_third_party_mod::{
@@ -60,7 +60,7 @@ pub async fn list_all_mods_command(
     '_,
     OnlineModRepositoryRegistry,
   >,
-  client: State<'_, Client>,
+  client: State<'_, Arc<dyn HttpClient>>,
 ) -> Result<(), ListAllModsCommandError> {
   let data_dir = app.path().app_local_data_dir()?;
   let resource_dir = app.path().resource_dir()?;
@@ -80,7 +80,7 @@ pub async fn list_all_mods_command(
     active_release_repository.inner(),
     mods_repository.inner(),
     online_mod_repository_registry.repositories(),
-    client.inner(),
+    client.inner().as_ref(),
     on_update,
   )
   .await?;
@@ -209,13 +209,13 @@ pub enum GetLastActivityCommandError {
 pub async fn get_last_activity_on_third_party_mod_command(
   id: String,
   variant: GameVariant,
-  client: State<'_, Client>,
+  client: State<'_, Arc<dyn HttpClient>>,
   mods_repository: State<'_, SqliteModsRepository>,
 ) -> Result<LastModActivity, GetLastActivityCommandError> {
   let last_activity = get_last_activity_for_third_party_mod(
     &id,
     &variant,
-    client.inner(),
+    client.inner().as_ref(),
     mods_repository.inner(),
   )
   .await?;

--- a/cat-launcher/src-tauri/src/mods/get_last_activity_for_third_party_mod.rs
+++ b/cat-launcher/src-tauri/src/mods/get_last_activity_for_third_party_mod.rs
@@ -1,4 +1,3 @@
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use url::Url;
@@ -6,6 +5,7 @@ use url::Url;
 use crate::infra::github::get_last_commit::{
   GetLastCommitError, get_last_commit,
 };
+use crate::infra::http_client::HttpClient;
 use crate::mods::get_third_party_mod_by_id::{
   GetThirdPartyModByIdError, get_third_party_mod_by_id,
 };
@@ -62,7 +62,7 @@ pub fn extract_repo_from_github_url(url_str: &str) -> Option<String> {
 pub async fn get_last_activity_for_third_party_mod(
   mod_id: &str,
   variant: &GameVariant,
-  client: &Client,
+  client: &dyn HttpClient,
   mods_repository: &impl ModsRepository,
 ) -> Result<LastModActivity, GetLastActivityForThirdPartyModError> {
   let mod_data =

--- a/cat-launcher/src-tauri/src/mods/list_all_mods.rs
+++ b/cat-launcher/src-tauri/src/mods/list_all_mods.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use tokio::fs::{read_dir, read_to_string};
 
 use crate::active_release::repository::ActiveReleaseRepository;
+use crate::infra::http_client::HttpClient;
 use crate::infra::utils::{OS, sort_assets};
 use crate::mods::lib::{
   GetStockModsDirError, get_mods_resource_path, get_stock_mods_dir,
@@ -98,7 +99,7 @@ pub async fn list_all_mods<F, E>(
   active_release_repository: &impl ActiveReleaseRepository,
   mods_repository: &impl ModsRepository,
   online_mod_repositories: &[Box<dyn OnlineModRepository>],
-  client: &reqwest::Client,
+  client: &dyn HttpClient,
   on_update: F,
 ) -> Result<(), ListAllModsError<E>>
 where

--- a/cat-launcher/src-tauri/src/mods/online/bright_nights/repository.rs
+++ b/cat-launcher/src-tauri/src/mods/online/bright_nights/repository.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use reqwest::Client;
 
+use crate::infra::http_client::{HttpClient, HttpClientError};
 use crate::mods::online::types::{
   FetchOnlineModsError, OnlineModRepository,
 };
@@ -23,17 +23,22 @@ impl OnlineModRepository for BrightNightsModRepository {
   async fn get_mods_for_variant(
     &self,
     variant: &GameVariant,
-    client: &Client,
+    client: &dyn HttpClient,
   ) -> Result<Vec<ThirdPartyMod>, FetchOnlineModsError> {
     if !matches!(variant, GameVariant::BrightNights) {
       return Ok(Vec::new());
     }
 
     let url = "https://mods.cataclysmbn.org/generated/mods.json";
-    let response =
-      client.get(url).send().await?.error_for_status()?;
-    let mods_values =
-      response.json::<Vec<serde_json::Value>>().await?;
+    let response = client
+      .get(url)
+      .await?
+      .error_for_status()
+      .map_err(HttpClientError::from)?;
+    let mods_values = response
+      .json::<Vec<serde_json::Value>>()
+      .await
+      .map_err(HttpClientError::from)?;
 
     let mods: Vec<ThirdPartyMod> = mods_values
       .into_iter()

--- a/cat-launcher/src-tauri/src/mods/online/types.rs
+++ b/cat-launcher/src-tauri/src/mods/online/types.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
-use reqwest::Client;
 
+use crate::infra::http_client::{HttpClient, HttpClientError};
 use crate::mods::types::ThirdPartyMod;
 use crate::variants::GameVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum FetchOnlineModsError {
   #[error("HTTP request failed: {0}")]
-  RequestFailed(#[from] reqwest::Error),
+  RequestFailed(#[from] HttpClientError),
 
   #[error("failed to fetch from repository: {0}")]
   Repository(Box<dyn std::error::Error + Send + Sync>),
@@ -18,6 +18,6 @@ pub trait OnlineModRepository: Send + Sync {
   async fn get_mods_for_variant(
     &self,
     variant: &GameVariant,
-    client: &Client,
+    client: &dyn HttpClient,
   ) -> Result<Vec<ThirdPartyMod>, FetchOnlineModsError>;
 }

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::io;
+use std::sync::Arc;
 
 use tauri::{App, Emitter, Listener, Manager, WindowEvent};
 
@@ -11,7 +12,7 @@ use crate::filesystem::paths::GetSchemaFilePathError;
 use crate::filesystem::utils::{copy_dir_all, CopyDirError};
 use crate::infra::autoupdate::update::run_updater;
 use crate::infra::download::Downloader;
-use crate::infra::http_client::create_http_client;
+use crate::infra::http_client::{HttpClient, create_http_client};
 use crate::infra::repository::sqlite_pool::{
   CreateSqlitePoolError, create_sqlite_pool,
 };
@@ -169,7 +170,9 @@ pub fn manage_downloader(app: &App) {
 
 pub fn manage_http_client(app: &App) {
   let client = create_http_client();
-  app.manage(client);
+  app.manage(client.clone());
+  let http_client: Arc<dyn HttpClient> = Arc::new(client.clone());
+  app.manage(http_client);
 }
 
 pub fn manage_posthog(app: &App) {


### PR DESCRIPTION
Motivation:
- Enable API tests to redirect GitHub and related requests to a local mock server without changing production call sites.

Changes:
- Add an `HttpClient` abstraction and a `TestHttpClient` that rewrites host mappings before sending requests.
- Thread the abstraction through release and mod GitHub fetch paths.
- Register the client in Tauri state as `Arc<dyn HttpClient>`.

Authored-by: OpenAI Codex

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `HttpClient` abstraction and a URI‑remapping `TestHttpClient` so API tests can route GitHub requests to a local mock server without changing production call sites. The client is threaded through release/mod fetch paths and registered in Tauri as `Arc<dyn HttpClient>`.

- **New Features**
  - `TestHttpClient` that rewrites hosts (e.g., api.github.com → localhost:8080) before sending requests.
  - Dev dependency `github-mock-api` for local GitHub API stubs.

- **Refactors**
  - Introduced `HttpClient` trait and `HttpClientError`; implemented for `reqwest::Client`.
  - Switched GitHub utils, releases, and mods code to accept `&dyn HttpClient`.
  - Managed both `reqwest::Client` and `Arc<dyn HttpClient>` in Tauri state for easy test swaps.

<sup>Written for commit c17f8e20f8f9ccd6ba152f0df8d90f99b3fafeeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

