### PR TITLE
chore(skills): add jj-commit skill

### DIFF
--- a/.agents/skills/jj-commit/SKILL.md
+++ b/.agents/skills/jj-commit/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: jj-commit
+description: Commit changes using Jujutsu VCS with Conventional Commits format.
+license: CC BY-NC-ND 4.0
+metadata:
+  author: abhi-kr-2100
+  version: "1.0"
+---
+
+# Jujutsu Commit Skill
+
+Use this skill to commit changes in a Jujutsu (jj) version-controlled repository following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+## When to Use
+
+- When you need to commit changes in a Jujutsu repository
+- When the user requests a commit with a specific message
+- When you need to review uncommitted changes before committing
+
+## Workflow
+
+### 1. Review Uncommitted Changes
+
+Always check the uncommitted changes first using:
+
+```bash
+jj diff --git --no-pager
+```
+
+### 2. Write the Commit Message
+
+Follow the **Conventional Commits** format strictly:
+
+#### Header (Required)
+
+```
+type(scope): description
+```
+
+- **type** (required): One of:
+  - `feat` - A new feature
+  - `fix` - A bug fix
+  - `docs` - Documentation only changes
+  - `refactor` - A code change that neither fixes a bug nor adds a feature
+  - `perf` - A code change that improves performance
+  - `style` - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+  - `test` - Adding missing tests or correcting existing tests
+  - `chore` - Other changes that don't modify src or test files
+  - `ci` - Changes to CI configuration files and scripts
+  - `revert` - Reverts a previous commit
+  - `build` - Changes that affect the build system or external dependencies
+
+- **scope** (optional): The name of the feature or module being modified (e.g., `user`, `auth`, `api`)
+
+- **description** (required): A brief summary of the change in lowercase, imperative mood (e.g., "add user authentication" not "added user authentication")
+
+#### Body (Optional)
+
+Include when the change needs more explanation. Structure it as:
+
+```
+Motivation:
+- [Reason for the change]
+
+Changes:
+- [List of specific changes made]
+```
+
+#### Footer (Optional)
+
+Include for:
+- Breaking changes: `BREAKING CHANGE: [description]`
+- Issue references: `Closes #123`, `Fixes #456`, `Resolves #789`
+- Related PRs: `See also: #123`
+
+### 3. Commit the Changes
+
+Use the following command to commit:
+
+```bash
+jj desc -m "{commit_message}"
+```
+
+Where `{commit_message}` is your full Conventional Commits formatted message.
+
+## Examples
+
+```bash
+jj desc -m "fix(api): validate input parameters
+
+Motivation:
+- Prevent SQL injection vulnerabilities.
+
+Changes:
+- Add input validation middleware.
+- Sanitize all user inputs.
+
+BREAKING CHANGE: API now rejects requests with invalid parameters."
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,34 +2,6 @@
 
 This file provides guidance to agents when working with code in this repository.
 
-## Commit Guidelines
-
-* Do not commit unless asked.
-* Use `jj diff --git --no-pager` to see uncommitted changes.
-* Use `jj desc -m {commit_message}` to commit changes.
-* Follow the Conventional Commits format:
-  - **Header**: `type(scope): description`
-    - **Type**: One of `feat`, `fix`, `docs`, `refactor`, `perf`, `style`, `test`, `chore`, `ci`, `revert`, `build`.
-    - **Scope** (optional): The name of the feature or module being modified.
-    - **Description**: A brief summary of the change.
-  - **Body** (optional): A detailed description of the change. Start with the motivation for the change and then list the changes made.
-  - **Footer** (optional): Any additional information about the change, like `BREAKING CHANGE` notices or issue references (e.g., `Closes #123`).
-
-Example:
-
-```
-feat(user): add user authentication
-
-Motivation:
-- To secure user accounts and provide personalized experiences.
-
-Changes:
-- Add a new user model.
-- Add a new user repository.
-
-BREAKING CHANGE: Authentication is now required for all API endpoints.
-```
-
 ## Verification
 
 At the end of every task, run the following commands:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "jj-commit": {
+      "source": "abhi-kr-2100/skills",
+      "sourceType": "github",
+      "skillPath": "skills/jj-commit/SKILL.md",
+      "computedHash": "f68384179f45321d07c43408e642319bf460f7981e7b7ef28a2c50bf37d1f86b"
+    }
+  }
+}


### PR DESCRIPTION
Changes:
- Add jj-commit skill definition file at .agents/skills/jj-commit/SKILL.md
- Add skills-lock.json for skill dependency tracking
- Remove commit guidelines from AGENTS.md

Generated by Mistral Vibe.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `jj-commit` skill for committing with Jujutsu using Conventional Commits, consolidating commit guidance into a reusable skill. Introduces `skills-lock.json` for skill dependency tracking and removes redundant commit guidelines from `AGENTS.md`.

<sup>Written for commit 6679b1002477d36df126035143581ca67c5fe04b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

