### PR TITLE
Add tests for fetch_release_notes

### DIFF
--- a/cat-launcher/src-tauri/Cargo.lock
+++ b/cat-launcher/src-tauri/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "github-mock-api"
 version = "0.1.0"
-source = "git+https://github.com/abhi-kr-2100/github-mock-api.git?rev=91a82ca12ca9fcad2a9e35e26d2a9d1fb71ce0e9#91a82ca12ca9fcad2a9e35e26d2a9d1fb71ce0e9"
+source = "git+https://github.com/abhi-kr-2100/github-mock-api.git?rev=58d1d7828c38b5d4137c4eaed9f500ef9a540136#58d1d7828c38b5d4137c4eaed9f500ef9a540136"
 dependencies = [
  "axum",
  "clap",

--- a/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
+++ b/cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs
@@ -151,3 +151,341 @@ impl GameVariant {
     Ok(github_release.body)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
+  use crate::infra::github::release::GitHubRelease;
+  use crate::infra::testing::http_client::TestHttpClient;
+  use crate::infra::testing::test_database::TestDatabase;
+  use chrono::Utc;
+  use github_mock_api::{MockServer, Release as MockRelease};
+  use std::collections::HashMap;
+  use std::sync::Arc;
+
+  type TestResult<T = ()> =
+    std::result::Result<T, Box<dyn std::error::Error>>;
+
+  async fn setup() -> TestResult<(TestDatabase, MockServer, Arc<TestHttpClient>)>
+  {
+    let db = TestDatabase::builder().build()?;
+    let server = MockServer::start().await?;
+
+    let mut host_mappings = HashMap::new();
+    let uri = server.uri();
+    let host_port = uri
+      .strip_prefix("http://")
+      .ok_or("uri should start with http://")?;
+    host_mappings
+      .insert("api.github.com".to_string(), host_port.to_string());
+
+    let client = Arc::new(TestHttpClient::new(host_mappings)?);
+
+    Ok((db, server, client))
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_cache_hit() -> TestResult {
+    let (db, _server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::DarkDaysAhead;
+    let tag = "v1.0.0";
+    let body = "cached notes";
+
+    // Seed cache
+    repo
+      .update_cached_releases(
+        &variant,
+        &[GitHubRelease {
+          id: 123,
+          tag_name: tag.to_string(),
+          prerelease: false,
+          body: Some(body.to_string()),
+          assets: vec![],
+          created_at: Utc::now(),
+        }],
+      )
+      .await?;
+
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await?;
+
+    if result != Some(body.to_string()) {
+      return Err(
+        format!("Expected {:?}, got {:?}", Some(body), result).into(),
+      );
+    }
+
+    // Verify NO network call was made
+    if client.request_count() != 0 {
+      return Err(
+        format!("Expected 0 network calls, got {}", client.request_count())
+          .into(),
+      );
+    }
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_cache_hit_empty_body() -> TestResult {
+    let (db, server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::DarkDaysAhead;
+    let tag = "v1.0.0";
+    let body = "github notes";
+
+    // Seed cache with empty body
+    repo
+      .update_cached_releases(
+        &variant,
+        &[GitHubRelease {
+          id: 123,
+          tag_name: tag.to_string(),
+          prerelease: false,
+          body: None,
+          assets: vec![],
+          created_at: Utc::now(),
+        }],
+      )
+      .await?;
+
+    // Seed GitHub
+    server
+      .add_release(
+        "CleverRaven",
+        "Cataclysm-DDA",
+        MockRelease::new("CleverRaven", "Cataclysm-DDA", tag)
+          .body(body),
+      )
+      .await;
+
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await?;
+
+    if result != Some(body.to_string()) {
+      return Err(
+        format!("Expected {:?}, got {:?}", Some(body), result).into(),
+      );
+    }
+
+    // Verify cache updated
+    let cached = repo
+      .get_cached_release_by_tag(&variant, tag)
+      .await?
+      .ok_or("should have cached release")?;
+    if cached.body != Some(body.to_string()) {
+      return Err(
+        format!("Cached body expected {:?}, got {:?}", Some(body), cached.body)
+          .into(),
+      );
+    }
+
+    // Verify EXACTLY one network call was made
+    if client.request_count() != 1 {
+      return Err(
+        format!("Expected 1 network call, got {}", client.request_count())
+          .into(),
+      );
+    }
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_cache_miss() -> TestResult {
+    let (db, server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::BrightNights;
+    let tag = "bn-1.0";
+    let body = "bn notes";
+
+    // Seed GitHub
+    server
+      .add_release(
+        "cataclysmbnteam",
+        "Cataclysm-BN",
+        MockRelease::new("cataclysmbnteam", "Cataclysm-BN", tag)
+          .body(body),
+      )
+      .await;
+
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await?;
+
+    if result != Some(body.to_string()) {
+      return Err(
+        format!("Expected {:?}, got {:?}", Some(body), result).into(),
+      );
+    }
+
+    // Verify cache updated
+    let cached = repo
+      .get_cached_release_by_tag(&variant, tag)
+      .await?
+      .ok_or("should have cached release")?;
+    if cached.body != Some(body.to_string()) {
+      return Err(
+        format!("Cached body expected {:?}, got {:?}", Some(body), cached.body)
+          .into(),
+      );
+    }
+    if cached.tag_name != tag {
+      return Err(
+        format!("Cached tag expected {:?}, got {:?}", tag, cached.tag_name)
+          .into(),
+      );
+    }
+
+    // Verify EXACTLY one network call was made
+    if client.request_count() != 1 {
+      return Err(
+        format!("Expected 1 network call, got {}", client.request_count())
+          .into(),
+      );
+    }
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_github_404() -> TestResult {
+    let (db, _server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::TheLastGeneration;
+    let tag = "missing-tag";
+
+    // GitHub is empty, should 404
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await;
+
+    match result {
+      Err(FetchReleaseNotesError::Fetch(_)) => Ok(()),
+      Err(e) => Err(format!("Expected Fetch error, got: {:?}", e).into()),
+      Ok(res) => {
+        Err(format!("Expected error, got success: {:?}", res).into())
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_github_500() -> TestResult {
+    let (db, server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::DarkDaysAhead;
+    let tag = "v1.0.0";
+
+    use github_mock_api::{MockBehavior, MockError};
+    server
+      .add_mock_behavior(
+        MockBehavior::builder()
+          .error(MockError::InternalServerError)
+          .build(),
+      )
+      .await?;
+
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await;
+
+    match result {
+      Err(FetchReleaseNotesError::Fetch(_)) => Ok(()),
+      Err(e) => Err(format!("Expected Fetch error, got: {:?}", e).into()),
+      Ok(res) => {
+        Err(format!("Expected error, got success: {:?}", res).into())
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_special_characters_in_tag() -> TestResult {
+    let (db, server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let variant = GameVariant::DarkDaysAhead;
+    let tag = "v1.0.0+test";
+    let body = "special notes";
+
+    // Seed GitHub
+    server
+      .add_release(
+        "CleverRaven",
+        "Cataclysm-DDA",
+        MockRelease::new("CleverRaven", "Cataclysm-DDA", tag)
+          .body(body),
+      )
+      .await;
+
+    let result = variant
+      .fetch_release_notes(tag, client.as_ref(), &repo)
+      .await?;
+
+    if result != Some(body.to_string()) {
+      return Err(
+        format!("Expected {:?}, got {:?}", Some(body), result).into(),
+      );
+    }
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_fetch_release_notes_different_game_variants() -> TestResult {
+    let (db, server, client) = setup().await?;
+    let repo = SqliteReleasesRepository::new(db.pool().clone());
+    let tag = "v1.0.0";
+
+    let variants = [
+      (
+        GameVariant::DarkDaysAhead,
+        "CleverRaven",
+        "Cataclysm-DDA",
+        "dda notes",
+      ),
+      (
+        GameVariant::BrightNights,
+        "cataclysmbnteam",
+        "Cataclysm-BN",
+        "bn notes",
+      ),
+      (
+        GameVariant::TheLastGeneration,
+        "Cataclysm-TLG",
+        "Cataclysm-TLG",
+        "tlg notes",
+      ),
+    ];
+
+    for (variant, owner, repo_name, body) in variants {
+      let mut mock_release = MockRelease::new(owner, repo_name, tag).body(body);
+      // Manually set ID to a value that fits in i64 to avoid Sqlite conversion error
+      mock_release.id = 12345 + (variant as u64);
+
+      server
+        .add_release(
+          owner,
+          repo_name,
+          mock_release,
+        )
+        .await;
+
+      let result = variant
+        .fetch_release_notes(tag, client.as_ref(), &repo)
+        .await?;
+
+      if result != Some(body.to_string()) {
+        return Err(
+          format!(
+            "Variant {:?}: Expected {:?}, got {:?}",
+            variant,
+            Some(body),
+            result
+          )
+          .into(),
+        );
+      }
+    }
+
+    Ok(())
+  }
+}

--- a/cat-launcher/src-tauri/src/infra/testing/http_client.rs
+++ b/cat-launcher/src-tauri/src/infra/testing/http_client.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use reqwest::{Client, Response};
@@ -12,6 +13,7 @@ use crate::infra::http_client::{
 pub struct TestHttpClient {
   client: Client,
   host_mappings: HashMap<String, String>,
+  request_count: AtomicUsize,
 }
 
 impl TestHttpClient {
@@ -22,7 +24,16 @@ impl TestHttpClient {
     Ok(Self {
       client: create_http_client()?,
       host_mappings,
+      request_count: AtomicUsize::new(0),
     })
+  }
+
+  pub fn request_count(&self) -> usize {
+    self.request_count.load(Ordering::Relaxed)
+  }
+
+  pub fn reset_request_count(&self) {
+    self.request_count.store(0, Ordering::Relaxed);
   }
 
   fn rewrite_url(
@@ -64,6 +75,7 @@ impl HttpClient for TestHttpClient {
     &self,
     url: &str,
   ) -> Result<Response, HttpClientError> {
+    self.request_count.fetch_add(1, Ordering::Relaxed);
     let rewritten_url = self.rewrite_url(url)?;
     self
       .client


### PR DESCRIPTION
This commit adds a comprehensive test suite for the `fetch_release_notes` function in `cat-launcher/src-tauri/src/fetch_releases/fetch_releases.rs`.

Key changes:
- Added a `#[cfg(test)]` module in `fetch_releases.rs` with tests for:
  - Cache hits (with body).
  - Cache hits (empty body, triggers fetch).
  - Cache misses (triggers fetch and cache update).
  - GitHub 404 errors.
  - Special characters in tag names.
  - Verification of no-network calls on cache hits using `TestHttpClient`.
- Ensured test isolation by using fresh `MockServer` and `TestDatabase` per test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive test suite for `fetch_release_notes` to validate cache behavior, GitHub error handling, tag encoding, and per-variant repositories. Improves reliability and prevents unnecessary network calls.

- **New Features**
  - Tests: cache hit (with body), cache hit (empty body → fetch + cache update), cache miss, GitHub 404/500 (via error injection), special tag chars, and per-variant repos.
  - Isolated per-test `MockServer` and SQLite test DB.
  - `TestHttpClient` tracks GETs via `request_count()` and supports `reset_request_count()` to assert network usage.

- **Dependencies**
  - Bumped `github-mock-api` to a newer revision to support error injection.

<sup>Written for commit c75cfcabb443d6d5e7a9ea24f36d5800cb58f130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

