### PR TITLE
feat(scripts): rename fetch_releases to setup-test-data and download …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ target/rust-analyzer/**
 # Coverage artifacts
 lcov.info
 coverage-html
+
+# Test assets
+cat-launcher/src-tauri/src/infra/testing/data/assets/
+cat-launcher/src-tauri/src/infra/testing/data/metadata/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,8 +32,14 @@ tasks:
       - pnpm --prefix {{.CODE_DIR}} exec eslint . --max-warnings 0 --quiet
       - pnpm --prefix {{.CODE_DIR}} exec tsc --noEmit
 
+  setup-tests:
+    desc: Fetch test release assets from game repositories
+    cmds:
+      - cd scripts/setup-test-data && uv run setup-test-data --quiet
+
   test:
     desc: Run all Rust tests
+    deps: [setup-tests]
     cmds:
       - cargo test {{.CARGO_FLAGS}} --manifest-path {{.CODE_DIR}}/Cargo.toml -- --nocapture
 

--- a/cat-launcher/Cargo.lock
+++ b/cat-launcher/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "cat-launcher"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "cat-macros",

--- a/cat-launcher/src-tauri/tauri.conf.json
+++ b/cat-launcher/src-tauri/tauri.conf.json
@@ -21,9 +21,7 @@
     "security": {
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "**"
-        ]
+        "scope": ["**"]
       },
       "csp": {
         "default-src": "'self' asset: http://asset.localhost",

--- a/scripts/setup-test-data/README.md
+++ b/scripts/setup-test-data/README.md
@@ -1,0 +1,91 @@
+# Setup Test Data
+
+Downloads release assets from game repositories for testing purposes.
+
+## Usage
+
+```bash
+cd scripts/setup-test-data
+uv run setup-test-data
+```
+
+### Options
+
+- `--variants`: Game variants to fetch releases for (default: all)
+- `--experimental-count`: Number of experimental releases to select per variant (default: 2)
+- `--output-dir`: Output directory for downloaded assets (default: cat-launcher/src-tauri/src/infra/testing/data/assets)
+- `--metadata-dir`: Output directory for releases metadata (default: cat-launcher/src-tauri/src/infra/testing/data/metadata)
+- `--quiet`: Suppress output and only show errors
+
+### Example
+
+```bash
+# Download assets for all variants
+uv run setup-test-data
+
+# Download assets for only DDA and BN with custom experimental count
+uv run setup-test-data --variants dda bn --experimental-count 1 --quiet
+
+# Use a custom output directory
+uv run setup-test-data --output-dir ./test-assets
+```
+
+## Release Selection
+
+The script uses a hybrid approach to select releases:
+- **Stable and Release Candidate**: These are loaded from local files in `cat-launcher/src-tauri/releases/`.
+- **Experimental**: These are fetched from the GitHub API, controlled by the `--experimental-count` option.
+
+## Release Type Classification
+
+Release types are determined per variant, matching the Rust logic in `game_variant.rs`:
+
+- **DDA**: `!prerelease` → Stable, `prerelease + "experimental" in tag` → Experimental, else → Release Candidate
+- **BN/TLG**: `!prerelease` → Stable, `prerelease` → Experimental
+
+## Platform Asset Selection
+
+Asset filenames are matched per platform, matching the Rust logic in `game_release/utils.rs`:
+
+| Variant | Windows | macOS | Linux |
+|---------|---------|-------|-------|
+| DDA | `windows-with-graphics-and-sounds` | `osx-with-graphics` or `osx-terminal-only` | `linux-with-graphics-and-sounds` |
+| BN | `windows-tiles` | `osx-tiles-arm` or `osx-tiles-x64` | `linux-tiles` |
+| TLG | `windows-tiles-sounds-x64-msvc` | `osx-tiles-universal` | `linux-tiles-sounds` |
+
+## Authentication
+
+The script uses the `GITHUB_TOKEN` environment variable for authenticated requests to avoid rate limiting. Without a token, you'll be limited to 60 requests per hour.
+
+```bash
+export GITHUB_TOKEN=your_token_here
+uv run setup-test-data
+```
+
+## Output
+
+The script downloads actual binary release assets and saves release metadata:
+
+```
+cat-launcher/src-tauri/src/infra/testing/data/assets/
+├── dda/
+│   ├── cdda-windows-with-graphics-and-sounds-x64-*.zip
+│   ├── cdda-linux-with-graphics-and-sounds-x64-*.tar.gz
+│   ├── cdda-osx-with-graphics-universal-*.dmg
+│   └── ...
+├── bn/
+│   ├── cbn-windows-tiles-x64-*.zip
+│   ├── cbn-linux-tiles-x64-*.tar.gz
+│   ├── cbn-osx-tiles-*.dmg
+│   └── ...
+└── tlg/
+    ├── tlg-windows-tiles-sounds-x64-msvc-*.zip
+    ├── tlg-linux-tiles-sounds-x64-*.tar.gz
+    ├── tlg-osx-tiles-universal-*.dmg
+    └── ...
+
+cat-launcher/src-tauri/src/infra/testing/data/metadata/
+├── DarkDaysAhead.json
+├── BrightNights.json
+└── TheLastGeneration.json
+```

--- a/scripts/setup-test-data/pyproject.toml
+++ b/scripts/setup-test-data/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "setup-test-data"
+version = "0.2.0"
+description = "Download release assets from game repositories for testing"
+readme = "README.md"
+authors = [
+    { name = "Abhishek Kumar", email = "abhi.kr.2100@gmail.com" }
+]
+requires-python = ">=3.13"
+dependencies = [
+    "httpx>=0.27.0",
+    "tenacity>=8.2.0",
+]
+
+[project.scripts]
+setup-test-data = "setup_test_data.cli:main"
+
+[build-system]
+requires = ["uv_build>=0.9.17,<0.10.0"]
+build-backend = "uv_build"

--- a/scripts/setup-test-data/src/setup_test_data/cli.py
+++ b/scripts/setup-test-data/src/setup_test_data/cli.py
@@ -1,0 +1,465 @@
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
+
+GITHUB_API = "https://api.github.com"
+
+REPOS: dict[str, str] = {
+    "dda": "CleverRaven/Cataclysm-DDA",
+    "bn": "cataclysmbnteam/Cataclysm-BN",
+    "tlg": "Cataclysm-TLG/Cataclysm-TLG",
+}
+
+EXPERIMENTAL_COUNT = 2
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent
+DEFAULT_OUTPUT_DIR = SCRIPT_DIR / "cat-launcher/src-tauri/src/infra/testing/data/assets"
+DEFAULT_METADATA_DIR = SCRIPT_DIR / "cat-launcher/src-tauri/src/infra/testing/data/metadata"
+RESOURCES_DIR = SCRIPT_DIR / "cat-launcher/src-tauri"
+
+
+class ReleaseType(Enum):
+    STABLE = "stable"
+    RELEASE_CANDIDATE = "release_candidate"
+    EXPERIMENTAL = "experimental"
+
+
+class OS(Enum):
+    WINDOWS = "windows"
+    LINUX = "linux"
+    MACOS = "macos"
+
+
+class Arch(Enum):
+    X64 = "x86_64"
+    ARM64 = "aarch64"
+
+
+@dataclass
+class Release:
+    id: int
+    tag_name: str
+    name: str
+    prerelease: bool
+    body: Optional[str]
+    published_at: str
+    assets: list[dict]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.id, str):
+            self.id = int(self.id)
+
+
+def is_retryable_exception(exception: Exception) -> bool:
+    if isinstance(exception, httpx.HTTPStatusError):
+        # Retry on 5xx errors or 429 Too Many Requests
+        if exception.response is not None:
+            return exception.response.status_code >= 500 or exception.response.status_code == 429
+        return False
+    if isinstance(exception, (httpx.TimeoutException, httpx.RequestError)):
+        # Transport errors (connection, dns, etc) are retryable
+        return True
+    return False
+
+
+def determine_release_type(
+    variant: str, tag_name: str, prerelease: bool
+) -> ReleaseType:
+    if variant == "dda":
+        if not prerelease:
+            return ReleaseType.STABLE
+        if "experimental" in tag_name:
+            return ReleaseType.EXPERIMENTAL
+        return ReleaseType.RELEASE_CANDIDATE
+    else:
+        if prerelease:
+            return ReleaseType.EXPERIMENTAL
+        return ReleaseType.STABLE
+
+
+def get_platform_asset_substrs(
+    variant: str, os_type: OS, arch: Arch
+) -> list[str]:
+    mapping: dict[tuple[str, OS, Arch], list[str]] = {
+        ("dda", OS.WINDOWS, Arch.X64): [
+            "windows-with-graphics-and-sounds"
+        ],
+        ("dda", OS.WINDOWS, Arch.ARM64): [
+            "windows-with-graphics-and-sounds"
+        ],
+        ("dda", OS.MACOS, Arch.X64): [
+            "osx-with-graphics",
+            "osx-terminal-only",
+        ],
+        ("dda", OS.MACOS, Arch.ARM64): [
+            "osx-with-graphics",
+            "osx-terminal-only",
+        ],
+        ("dda", OS.LINUX, Arch.X64): [
+            "linux-with-graphics-and-sounds",
+        ],
+        ("dda", OS.LINUX, Arch.ARM64): [
+            "linux-with-graphics-and-sounds",
+        ],
+        ("bn", OS.WINDOWS, Arch.X64): ["windows-tiles"],
+        ("bn", OS.WINDOWS, Arch.ARM64): ["windows-tiles"],
+        ("bn", OS.MACOS, Arch.X64): ["osx-tiles-x64"],
+        ("bn", OS.MACOS, Arch.ARM64): ["osx-tiles-arm"],
+        ("bn", OS.LINUX, Arch.X64): ["linux-tiles"],
+        ("bn", OS.LINUX, Arch.ARM64): ["linux-tiles"],
+        ("tlg", OS.WINDOWS, Arch.X64): [
+            "windows-tiles-sounds-x64-msvc",
+        ],
+        ("tlg", OS.WINDOWS, Arch.ARM64): [
+            "windows-tiles-sounds-x64-msvc",
+        ],
+        ("tlg", OS.MACOS, Arch.X64): ["osx-tiles-universal"],
+        ("tlg", OS.MACOS, Arch.ARM64): ["osx-tiles-universal"],
+        ("tlg", OS.LINUX, Arch.X64): ["linux-tiles-sounds"],
+        ("tlg", OS.LINUX, Arch.ARM64): ["linux-tiles-sounds"],
+    }
+    return mapping.get((variant, os_type, arch), [])
+
+
+def find_matching_asset(
+    assets: list[dict], substrings: list[str]
+) -> Optional[dict]:
+    for asset in assets:
+        name: str = asset.get("name", "")
+        for substr in substrings:
+            if substr in name:
+                return asset
+    return None
+
+
+def variant_id_pascal(variant: str) -> str:
+    return {"dda": "DarkDaysAhead", "bn": "BrightNights", "tlg": "TheLastGeneration"}[variant]
+
+
+def get_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+@retry(
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception(is_retryable_exception),
+    reraise=True,
+)
+def fetch_experimental_releases(client: httpx.Client, variant: str, count: int) -> list[Release]:
+    repo = REPOS[variant]
+    url = f"{GITHUB_API}/repos/{repo}/releases"
+    params = {"per_page": 100}
+    response = client.get(url, params=params)
+    response.raise_for_status()
+    data = response.json()
+
+    releases: list[Release] = []
+    for item in data:
+        tag_name = item["tag_name"]
+        prerelease = item["prerelease"]
+        if determine_release_type(variant, tag_name, prerelease) == ReleaseType.EXPERIMENTAL:
+            body = item.get("body")
+            releases.append(
+                Release(
+                    id=int(item["id"]),
+                    tag_name=tag_name,
+                    name=item["name"],
+                    prerelease=prerelease,
+                    body=body if body and body.strip() else None,
+                    published_at=item["published_at"],
+                    assets=item.get("assets", []),
+                )
+            )
+            if len(releases) >= count:
+                break
+    return releases
+
+
+def load_stable_releases(variant: str) -> list[Release]:
+    filepath = RESOURCES_DIR / "releases" / f"{variant_id_pascal(variant)}.json"
+    if not filepath.exists():
+        return []
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    releases: list[Release] = []
+    for item in data:
+        releases.append(
+            Release(
+                id=int(item["id"]),
+                tag_name=item["tag_name"],
+                name=item.get("name", item["tag_name"]),
+                prerelease=item["prerelease"],
+                body=item.get("body"),
+                published_at=item.get("published_at", item.get("created_at", "")),
+                assets=item.get("assets", []),
+            )
+        )
+    return releases
+
+
+@retry(
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception(is_retryable_exception),
+    reraise=True,
+)
+def download_asset(
+    client: httpx.Client, url: str, dest: Path, quiet: bool = False
+) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        if not quiet:
+            print(f"    Already exists, skipping: {dest.name}")
+        return
+
+    temp_dest = dest.with_suffix(".part")
+    try:
+        with client.stream("GET", url) as response:
+            response.raise_for_status()
+            with open(temp_dest, "wb") as f:
+                for chunk in response.iter_bytes(chunk_size=8192):
+                    f.write(chunk)
+                f.flush()
+                os.fsync(f.fileno())
+        os.replace(temp_dest, dest)
+    except Exception:
+        if temp_dest.exists():
+            os.unlink(temp_dest)
+        raise
+
+
+def download_asset_task(
+    client: httpx.Client, url: str, dest: Path, description: str, quiet: bool = False
+) -> tuple[str, Optional[Exception]]:
+    try:
+        download_asset(client, url, dest, quiet)
+        return (description, None)
+    except Exception as e:
+        return (description, e)
+
+
+def save_releases_metadata(
+    releases: list[Release], variant: str, metadata_dir: Path, quiet: bool = False
+) -> None:
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    filepath = metadata_dir / f"{variant_id_pascal(variant)}.json"
+    data: list[dict] = []
+    for r in releases:
+        assets_out: list[dict] = []
+        for a in r.assets:
+            assets_out.append(
+                {
+                    "id": int(a["id"]),
+                    "browser_download_url": a.get(
+                        "browser_download_url", ""
+                    ),
+                    "name": a.get("name", ""),
+                    "digest": a.get("digest"),
+                }
+            )
+        data.append(
+            {
+                "id": r.id,
+                "tag_name": r.tag_name,
+                "prerelease": r.prerelease,
+                "body": r.body,
+                "assets": assets_out,
+                "created_at": r.published_at,
+            }
+        )
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    if not quiet:
+        print(f"  Saved releases metadata: {filepath}")
+
+
+def get_download_tasks(
+    variant: str, releases: list[Release], output_dir: Path
+) -> list[tuple[str, Path, str]]:
+    tasks = []
+    for release in releases:
+        downloaded: set[str] = set()
+        for os_type in OS:
+            for arch in Arch:
+                substrings = get_platform_asset_substrs(variant, os_type, arch)
+                if not substrings:
+                    continue
+
+                asset = find_matching_asset(release.assets, substrings)
+                if not asset:
+                    continue
+
+                asset_name: str = asset.get("name", "")
+                cache_key = f"{os_type.value}/{asset_name}"
+                if cache_key in downloaded:
+                    continue
+                downloaded.add(cache_key)
+
+                download_url: str = asset.get("browser_download_url", "")
+                if not download_url:
+                    continue
+
+                dest = output_dir / variant / asset_name
+                description = f"{variant} {release.tag_name} {os_type.value}/{arch.value}: {asset_name}"
+                tasks.append((download_url, dest, description))
+    return tasks
+
+
+def process_variant(
+    client: httpx.Client,
+    variant: str,
+    experimental_count: int,
+    output_dir: Path,
+    quiet: bool,
+) -> tuple[list[Release], list[tuple[str, Path, str]], bool]:
+    if not quiet:
+        print(f"\nProcessing {variant} ({REPOS[variant]})...")
+
+    error_occurred = False
+    stable_releases = []
+    try:
+        stable_releases = load_stable_releases(variant)
+        if not quiet:
+            print(f"  Loaded {len(stable_releases)} stable/RC releases from local files")
+    except Exception as e:
+        print(f"Error loading stable releases for variant {variant}: {e}", file=sys.stderr)
+        error_occurred = True
+
+    experimental_releases = []
+    try:
+        experimental_releases = fetch_experimental_releases(
+            client, variant, experimental_count
+        )
+        if not quiet:
+            print(f"  Fetched {len(experimental_releases)} experimental releases from API")
+    except Exception as e:
+        print(f"Error fetching experimental releases for variant {variant}: {e}", file=sys.stderr)
+        error_occurred = True
+
+    selected = stable_releases + experimental_releases
+    tasks = get_download_tasks(variant, selected, output_dir)
+    return selected, tasks, error_occurred
+
+
+def execute_downloads(
+    client: httpx.Client,
+    tasks: list[tuple[str, Path, str]],
+    quiet: bool,
+) -> bool:
+    if not tasks:
+        return False
+
+    if not quiet:
+        print(f"\nDownloading {len(tasks)} assets in parallel...")
+
+    error_occurred = False
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [
+            executor.submit(download_asset_task, client, url, dest, desc, quiet)
+            for url, dest, desc in tasks
+        ]
+        for future in as_completed(futures):
+            desc, error = future.result()
+            if error:
+                print(f"Failed {desc}: {error}", file=sys.stderr)
+                error_occurred = True
+            elif not quiet:
+                print(f"Completed: {desc}")
+    return error_occurred
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Download release assets from game repositories for testing"
+    )
+    parser.add_argument(
+        "--variants",
+        nargs="+",
+        choices=list(REPOS.keys()),
+        default=list(REPOS.keys()),
+        help="Game variants to fetch releases for",
+    )
+    parser.add_argument(
+        "--experimental-count",
+        type=int,
+        default=EXPERIMENTAL_COUNT,
+        help="Number of experimental releases to select per variant",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Output directory for downloaded assets",
+    )
+    parser.add_argument(
+        "--metadata-dir",
+        type=Path,
+        default=DEFAULT_METADATA_DIR,
+        help="Output directory for releases metadata",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress output and only show errors",
+    )
+    parsed = parser.parse_args(args)
+
+    headers = get_headers()
+    global_error = False
+    with httpx.Client(headers=headers, timeout=None, follow_redirects=True) as client:
+        all_download_tasks = []
+        variant_releases: dict[str, list[Release]] = {}
+
+        for variant in parsed.variants:
+            releases, tasks, variant_error = process_variant(
+                client,
+                variant,
+                parsed.experimental_count,
+                parsed.output_dir,
+                parsed.quiet,
+            )
+            if variant_error:
+                global_error = True
+            if releases:
+                variant_releases[variant] = releases
+            all_download_tasks.extend(tasks)
+
+        if execute_downloads(client, all_download_tasks, parsed.quiet):
+            global_error = True
+
+        for variant, releases in variant_releases.items():
+            try:
+                save_releases_metadata(releases, variant, parsed.metadata_dir, parsed.quiet)
+            except Exception as e:
+                print(f"Error saving metadata for {variant}: {e}", file=sys.stderr)
+                global_error = True
+
+    if not parsed.quiet:
+        print("\nDone!")
+
+    if global_error:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-test-data/uv.lock
+++ b/scripts/setup-test-data/uv.lock
@@ -1,0 +1,94 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "setup-test-data"
+version = "0.2.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "tenacity", specifier = ">=8.2.0" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]


### PR DESCRIPTION
…release assets

Motivation:
- The old Python script only saved release metadata as JSON, but the launcher needs actual binary release assets for testing.
- The old script didn't reproduce the Rust logic for release type classification or platform asset selection.

Changes:
- Rename scripts/fetch_releases/ -> scripts/setup-test-data/
- Rewrite cli.py to download actual binary assets (.zip/.tar.gz/.dmg)
- Reproduce Rust's determine_release_type() for variant-specific stable/RC/experimental classification
- Reproduce Rust's get_platform_asset_substrs() for per-(variant, OS, arch) asset selection
- Download 5 stable + 3 RC + 2 experimental releases per variant
- Create releases/{variant_id}.json metadata for production fallback
- Update Taskfile.yml with new script path and add setup-tests dep
- Add python3 to nix development shell
- Ignore test assets directory

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduced a new `setup-test-data` CLI to download real release assets for DDA/BN/TLG and generate test metadata. Tests now auto-fetch assets via a Taskfile step.

- **New Features**
  - Hybrid selection: loads stable/RC from `cat-launcher/src-tauri/releases/*.json`; fetches `--experimental-count` experimental releases (default: 2) from GitHub.
  - Downloads Windows/macOS/Linux assets (.zip/.tar.gz/.dmg) using Rust-equivalent release-type and platform matching.
  - Saves assets to cat-launcher/src-tauri/src/infra/testing/data/assets and writes per-variant metadata to cat-launcher/src-tauri/src/infra/testing/data/metadata.

- **Refactors**
  - Renamed `scripts/fetch_releases` to `scripts/setup-test-data`; added Python package with `setup-test-data` console command (`uv run setup-test-data`).
  - Taskfile: added `setup-tests` (runs `setup-test-data --quiet`); `test` depends on it.
  - Updated `.gitignore` to ignore assets and metadata dirs; added `pyproject.toml` and `uv.lock`.

<sup>Written for commit 110e795414fc9b2e4b5f00a0d6c5fe355938c5b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

