### PR TITLE
chore(releases): update Bright Nights and Dark Days Ahead release info

### DIFF
--- a/cat-launcher/src-tauri/releases/BrightNights.json
+++ b/cat-launcher/src-tauri/releases/BrightNights.json
@@ -1,5 +1,37 @@
 [
   {
+    "id": 331902715,
+    "tag_name": "v0.12.0",
+    "prerelease": false,
+    "created_at": "2026-05-30T08:48:29Z",
+    "assets": [
+      {
+        "id": 433692343,
+        "name": "cbn-linux-tiles-x64-v0.12.0.tar.gz",
+        "digest": "sha256:8d9ac87b426e94f9544c8ef9f508216dbbcb537c2d4411592096bf8c57478e1a",
+        "browser_download_url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.12.0/cbn-linux-tiles-x64-v0.12.0.tar.gz"
+      },
+      {
+        "id": 433693059,
+        "name": "cbn-osx-tiles-arm-v0.12.0.dmg",
+        "digest": "sha256:72ab5e96ff17453283c5a969830ee4c8790f9dc37a2572bc6de09b85264df847",
+        "browser_download_url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.12.0/cbn-osx-tiles-arm-v0.12.0.dmg"
+      },
+      {
+        "id": 433695452,
+        "name": "cbn-osx-tiles-x64-v0.12.0.dmg",
+        "digest": "sha256:05a3bb26dad5c859ce0e9068496ac9481e78fde95fcafa9d3565f5dc8aaa7c2b",
+        "browser_download_url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.12.0/cbn-osx-tiles-x64-v0.12.0.dmg"
+      },
+      {
+        "id": 433710507,
+        "name": "cbn-windows-tiles-x64-msvc-v0.12.0.zip",
+        "digest": "sha256:e47a58915357af734f48a5c5ac8fb8ae5e7b8270bb672e85cc5920a7cb0ed001",
+        "browser_download_url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.12.0/cbn-windows-tiles-x64-msvc-v0.12.0.zip"
+      }
+    ]
+  },
+  {
     "id": 215342457,
     "tag_name": "v0.8.0",
     "name": "Cataclysm-BN v0.8.0",

--- a/cat-launcher/src-tauri/releases/DarkDaysAhead.json
+++ b/cat-launcher/src-tauri/releases/DarkDaysAhead.json
@@ -1,5 +1,31 @@
 [
   {
+    "id": 335441539,
+    "tag_name": "0.I",
+    "prerelease": false,
+    "created_at": "2026-06-06T15:41:42Z",
+    "assets": [
+      {
+        "id": 440304128,
+        "name": "cdda-linux-with-graphics-and-sounds-x64-2026-06-06-1535.tar.gz",
+        "digest": "sha256:d601b2475929d86efae1cd7612d9cda83837c5bf035e160f8ef161ec87fe071e",
+        "browser_download_url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.I/cdda-linux-with-graphics-and-sounds-x64-2026-06-06-1535.tar.gz"
+      },
+      {
+        "id": 440306255,
+        "name": "cdda-osx-with-graphics-universal-2026-06-06-1535.dmg",
+        "digest": "sha256:dc9f222e588c32eebe612b6bbde3bd52ff1f655d5a6c56dc113557131ba4f9a2",
+        "browser_download_url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.I/cdda-osx-with-graphics-universal-2026-06-06-1535.dmg"
+      },
+      {
+        "id": 440302664,
+        "name": "cdda-windows-with-graphics-and-sounds-x64-2026-06-06-1535.zip",
+        "digest": "sha256:cc69c15de637af5a95456fdb1df7a42090be93ee36f2341835ae8b499d747c73",
+        "browser_download_url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.I/cdda-windows-with-graphics-and-sounds-x64-2026-06-06-1535.zip"
+      }
+    ]
+  },
+  {
     "id": 187090088,
     "tag_name": "0.H-RELEASE",
     "prerelease": false,


### PR DESCRIPTION
- Add Bright Nights v0.12.0 release with Linux, macOS, Windows builds
- Add Dark Days Ahead 0.I release with Linux, macOS, Windows builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update launcher release metadata to include Bright Nights v0.12.0 and Dark Days Ahead 0.I with Linux, macOS, and Windows builds. This enables the launcher to show the latest downloads and verify them using the provided SHA-256 digests.

<sup>Written for commit 810b6ea7bf5153ace8087c299aaee60be2cceb18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

