### PR TITLE
fix: create app data directory before opening the database

### DIFF
--- a/cat-launcher/src-tauri/src/filesystem/paths.rs
+++ b/cat-launcher/src-tauri/src/filesystem/paths.rs
@@ -7,9 +7,14 @@ use crate::filesystem::utils::get_safe_filename;
 use crate::infra::utils::OS;
 use crate::variants::GameVariant;
 
-/// Returns the path to the application database file.
-pub fn get_db_path(data_dir: &Path) -> PathBuf {
-  data_dir.join("cat-launcher.db")
+/// Returns the path to the application database file, creating the data
+/// directory if it does not exist yet.
+pub async fn get_or_create_db_path(
+  data_dir: &Path,
+) -> Result<PathBuf, GetOrCreateDirectoryError> {
+  create_dir_all(data_dir).await?;
+
+  Ok(data_dir.join("cat-launcher.db"))
 }
 
 /// Returns the path to the application settings file.
@@ -432,4 +437,27 @@ pub async fn get_or_create_directory(
   create_dir_all(&dir_path).await?;
 
   Ok(dir_path)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::error::Error;
+
+  use tempfile::tempdir;
+
+  use super::get_or_create_db_path;
+
+  #[tokio::test]
+  async fn creates_the_data_directory_when_it_does_not_exist()
+  -> Result<(), Box<dyn Error + Send + Sync>> {
+    let temp_dir = tempdir()?;
+    let data_dir = temp_dir.path().join("com.munetmo.cat-launcher");
+
+    let db_path = get_or_create_db_path(&data_dir).await?;
+
+    assert!(data_dir.is_dir());
+    assert_eq!(db_path, data_dir.join("cat-launcher.db"));
+
+    Ok(())
+  }
 }

--- a/cat-launcher/src-tauri/src/utils.rs
+++ b/cat-launcher/src-tauri/src/utils.rs
@@ -7,8 +7,12 @@ use tauri::{App, Emitter, Listener, Manager, WindowEvent};
 use crate::active_release::repository::sqlite_active_release_repository::SqliteActiveReleaseRepository;
 use crate::constants::PARALLEL_REQUESTS;
 use crate::fetch_releases::repository::sqlite_releases_repository::SqliteReleasesRepository;
-use crate::filesystem::paths::{get_db_path, get_schema_file_path};
-use crate::filesystem::paths::GetSchemaFilePathError;
+use crate::filesystem::paths::{
+  get_or_create_db_path, get_schema_file_path,
+};
+use crate::filesystem::paths::{
+  GetOrCreateDirectoryError, GetSchemaFilePathError,
+};
 use crate::filesystem::utils::{copy_dir_all, CopyDirError};
 use crate::infra::autoupdate::update::run_updater;
 use crate::infra::download::Downloader;
@@ -68,6 +72,9 @@ pub enum RepositoryError {
   #[error("failed to get system directory: {0}")]
   SystemDir(#[from] tauri::Error),
 
+  #[error("failed to get database path: {0}")]
+  DbPath(#[from] GetOrCreateDirectoryError),
+
   #[error("failed to get schema file path: {0}")]
   SchemaFilePath(#[from] GetSchemaFilePathError),
 
@@ -77,7 +84,8 @@ pub enum RepositoryError {
 
 pub fn manage_repositories(app: &App) -> Result<(), RepositoryError> {
   let data_dir = app.path().app_local_data_dir()?;
-  let db_path = get_db_path(&data_dir);
+  let db_path =
+    tauri::async_runtime::block_on(get_or_create_db_path(&data_dir))?;
 
   let resources_dir = app.path().resource_dir()?;
   let schema_path = get_schema_file_path(&resources_dir)?;


### PR DESCRIPTION
First launch on a machine that has never run CatLauncher aborts before the window appears:

```
Failed to setup app: ... unable to open database file:
.../Application Support/com.munetmo.cat-launcher/cat-launcher.db
thread caused non-unwinding panic. aborting.
```

app_local_data_dir() only computes a path, and SQLite won't create a database in a directory that doesn't exist. get_db_path was the only accessor in filesystem::paths that returned a path without creating what it points into — so this replaces it with get_or_create_db_path, following the get_or_create_* convention its siblings already use. It's called via block_on, as manage_settings already does from the same hook.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create the app data directory before opening the SQLite database to prevent first-launch crashes on fresh machines. Previously `get_db_path` returned a path without creating its parent, causing SQLite to fail and the Tauri setup hook to abort; now `get_or_create_db_path` ensures the directory exists and `manage_repositories` calls it via `tauri::async_runtime::block_on`.

- Replace any `get_db_path` usage with async `get_or_create_db_path(&data_dir)`; in sync code, wrap with `tauri::async_runtime::block_on`.
- Handle the new `RepositoryError::DbPath` variant in exhaustive matches.
- No data migration; database remains `cat-launcher.db` in the app data directory, existing installs unaffected.

<sup>Written for commit de69539827ec30ebf926c0b54e9908929d64fc88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abhi-kr-2100/CatLauncher/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

